### PR TITLE
Prevent calling session_start() directly

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -109,6 +109,10 @@ class Auth {
                 self::$exception = $e;
                 throw $e;
             }
+
+            // If no session has been made at this point, we make one ourselves.
+            // Only types 'guest' and 'sp' are browsers.
+            if(in_array(self::$type, array('sp', 'guest'))) session_start();
             
             if(self::$attributes && array_key_exists('uid', self::$attributes)) {
                 $user_filter = Config::get('auth_user_filter');

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -205,10 +205,6 @@ class AuthSPSaml {
             require_once(self::$config['simplesamlphp_location'] . 'lib/_autoload.php');
             
             self::$simplesamlphp_auth_simple = new SimpleSAML_Auth_Simple(self::$config['authentication_source']);
-            
-            $session_data = isset($_SESSION) ? $_SESSION : array();
-            self::$simplesamlphp_auth_simple->isAuthenticated();
-            foreach($session_data as $k => $v) $_SESSION[$k] = $v;
         }
         
         return self::$simplesamlphp_auth_simple;

--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -45,8 +45,11 @@ class RestServer {
      */
     public static function process() {
         try {
-            @session_start();
-            
+            // Get authentication state (fills auth data in relevant classes)
+            // Will also start a session using the authentication handler.
+            // This prevents problems caused by duplicate sessions.
+            Auth::isAuthenticated();
+
             // If undergoing maintenance report it as an error
             if(Config::get('maintenance')) throw new RestException('undergoing_maintenance', 503);
             
@@ -117,9 +120,6 @@ class RestServer {
             
             $security_token = null;
             $security_token_matches = false;
-            
-            // Get authentication state (fills auth data in relevant classes)
-            Auth::isAuthenticated();
             
             if(Auth::isRemoteApplication()) {
                 // Remote applications must honor ACLs

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -154,7 +154,7 @@ class RestEndpointUser extends RestEndpoint {
         }
         
         if($property == 'remote_auth_config') {
-            $perm = array_key_exists('remote_auth_sync_request', $_SESSION) ? $_SESSION['remote_auth_sync_request'] : null;
+            $perm = isset($_SESSION) && array_key_exists('remote_auth_sync_request', $_SESSION) ? $_SESSION['remote_auth_sync_request'] : null;
             if(!$perm)
                 throw new RestAuthenticationRequiredException();
             
@@ -227,7 +227,7 @@ class RestEndpointUser extends RestEndpoint {
             $user->save();
             
             // Remove lang from session if there was one, we don't need it anymore as it was saved in user profile
-            if(array_key_exists('lang', $_SESSION))
+            if(isset($_SESSION) && array_key_exists('lang', $_SESSION))
                 unset($_SESSION['lang']);
         }
         

--- a/classes/utils/LegacyUploadProgress.class.php
+++ b/classes/utils/LegacyUploadProgress.class.php
@@ -72,6 +72,7 @@ class LegacyUploadProgress {
     public static function getTrackingData($key) {
         $session_key = self::getSessionKey($key);
         if(is_null($session_key)) return null;
+        if(!isset($_SESSION)) return null;
         if(!array_key_exists($session_key, $_SESSION)) return null;
         
         $data = $_SESSION[$session_key]['files'][0];

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -385,7 +385,7 @@ class Utilities {
             return self::$security_token['value'];
         
         // Fetch existing token
-        $token = array_key_exists('security_token', $_SESSION) ? $_SESSION['security_token'] : null;
+        $token = isset($_SESSION) && array_key_exists('security_token', $_SESSION) ? $_SESSION['security_token'] : null;
         
         // Old token style, cancel it
         if(!is_array($token)) $token = null;

--- a/includes/init/init_web.php
+++ b/includes/init/init_web.php
@@ -58,8 +58,6 @@ if(!session_id()) {
 // Ensure HTTPS if needed
 GUI::forceHTTPS();
 
-session_start();            // Start the session
-$_SESSION['valid'] = true;  // Set session as valid TODO do we we still need this ?
 // Handle magic quoting (TODO maybe deprecated now ?)
 if(get_magic_quotes_gpc()) {
     $_POST = array_map('stripslashes', $_POST);


### PR DESCRIPTION
FileSender uses a third party authentication handler (often SimpleSamlPhp). It has its own session handler. When combining it with another session system, such as by calling `session_start()`, the sessions conflict.

In FileSender, `session_start()` is called, seeminly for legacy reasons. This has no direct negative effects, because it doesn't actually use this session. However, it does trigger a log message in SimpleSamlPhp. [SimpleSamlPhp 1.14.9 has a bug where this log message causes the application to crash](https://github.com/simplesamlphp/simplesamlphp/issues/517#issuecomment-261258092).

This pull request will remove `session_start()` everywhere it was used. I have tested this on my test instance for multiple weeks, it has so far not caused issues.