### PR TITLE
Update compatibility checking for crypto and WebWorkers

### DIFF
--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -90,9 +90,4 @@
     </div>
 </div>
 
-<script>
-    // check for compatability
-    window.filesender.crypto_app().init();
-</script>
-
 <script type="text/javascript" src="{path:js/download_page.js}"></script>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -268,9 +268,4 @@
     </tbody>
 </table>
 
-<script>
-    // check for compatability
-    window.filesender.crypto_app().init();
-</script>
-
 <script type="text/javascript" src="{path:js/transfers_table.js}"></script>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -133,10 +133,6 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                             <div class="fieldcontainer" id="encryption_description_disabled_container">
                                 {tr:file_encryption_description_disabled}
                             </div>
-                            <script>
-                                // check for compatability
-                                window.filesender.crypto_app().init();
-                            </script>
                         <?php } ?>
                     <?php } ?>
                     

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -11,32 +11,6 @@ window.filesender.crypto_app = function () {
         crypto_iv_len: window.filesender.config.crypto_iv_len,
         crypto_crypt_name: window.filesender.config.crypto_crypt_name,
         crypto_hash_name: window.filesender.config.crypto_hash_name,
-        init: function () {
-            $(function () {
-                window.crypto_support = true;
-                if (window.msCrypto) {
-                    window.crypto = window.msCrypto;
-                }
-                if (window.crypto && !window.crypto.subtle && window.crypto.webkitSubtle) {
-                    window.crypto.subtle = window.crypto.webkitSubtle;
-                }
-                if (typeof window.crypto === 'undefined') {
-                    window.crypto_support = false;
-                    // Disable the upload fields
-                    $("#encryption").attr("disabled", "disabled");
-                    $("#encryption_description_container_disabled").show();
-
-                    // Disable the transfer buttons
-                    $('#encryption_description_not_supported').show();
-                    $('.transfer-download').css({'color': 'rgba(173, 173, 173, 1)', 'cursor': 'default'});
-
-                    // Disable the download buttons
-                    $(".files.box .file[data-encrypted='1']").css({'height': '3.5em'});
-                    $(".files.box .file[data-encrypted='1'] .download").hide();
-                    $(".download_decryption_disabled").show();
-                }
-            });
-        },
         generateVector: function () {
             return crypto.getRandomValues(new Uint8Array(16));
         },
@@ -55,17 +29,8 @@ window.filesender.crypto_app = function () {
                 filesender.ui.log(e);
             };
         },
-        encryptBlob: function (value, password, callback, do_init) {
-
-            if(typeof do_init === 'undefined') { // optional parameter, default to true
-                do_init = true;
-            }
-
+        encryptBlob: function (value, password, callback) {
             var $this = this;
-
-            if(do_init) {
-                $this.init();
-            }
 
             this.generateKey(password, function (key, iv) {
                 crypto.subtle.encrypt({name: $this.crypto_crypt_name, iv: iv}, key, value).then(
@@ -94,8 +59,6 @@ window.filesender.crypto_app = function () {
         },
         decryptBlob: function (value, password, callbackDone, callbackProgress, callbackError) {
             var $this = this;
-
-            $this.init();
 
             var encryptedData = value; // array buffers array
             var blobArray = [];
@@ -131,8 +94,6 @@ window.filesender.crypto_app = function () {
         },
         decryptDownload: function (link, mime, name, progress) {
             var $this = this;
-
-            $this.init();
 
             var prompt = filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();

--- a/www/js/crypter/crypto_test.js
+++ b/www/js/crypter/crypto_test.js
@@ -1,0 +1,1 @@
+postMessage(typeof(crypto) !== 'undefined' && typeof(crypto.subtle) !== 'undefined');

--- a/www/js/filesender.js
+++ b/www/js/filesender.js
@@ -7,6 +7,8 @@ window.filesender.supports = {
     localStorage: false,
     workers: false,
     digest: false,
+    crypto: false,
+    workerCrypto: false,
 };
 
 window.filesender.supports.localStorage = typeof(localStorage) !== 'undefined';
@@ -14,3 +16,13 @@ window.filesender.supports.localStorage = typeof(localStorage) !== 'undefined';
 window.filesender.supports.workers = typeof(Worker) !== 'undefined';
 
 window.filesender.supports.reader = typeof(FileReader) !== 'undefined';
+
+window.filesender.supports.crypto = typeof(crypto) !== 'undefined' && typeof(crypto.subtle) !== 'undefined'
+
+if (window.filesender.supports.workers) {
+    w = new Worker('js/crypter/crypto_test.js');
+    w.onmessage = function(event) {
+        window.filesender.supports.workerCrypto = event.data;
+    }
+}
+

--- a/www/js/filesender.js
+++ b/www/js/filesender.js
@@ -6,7 +6,6 @@ if(!('filesender' in window)) window.filesender = {};
 window.filesender.supports = {
     localStorage: false,
     workers: false,
-    digest: false,
     crypto: false,
     workerCrypto: false,
 };

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -93,19 +93,8 @@ window.filesender.transfer = function() {
     
     this.canUseTerasender = function() {
         var enable = filesender.config.terasender_enabled && filesender.supports.workers;
-        if (!enable)
-                return false;
-
-        var ua = window.navigator.userAgent.toLowerCase();
-        var ie = (ua.indexOf('msie ')!=-1 || ua.indexOf('trident/')!=-1 || ua.indexOf('edge/')!=-1);
-        var ff = ua.toLowerCase().indexOf('firefox') != -1;
-        var mac = ua.indexOf('mac os x') != -1;
-
-        if ((ie && this.encryption)  	//IE doesnt expose crypto lib to workers.
-//           || (ff && mac)		//FF sometimes crashs the tab. My guess is the workers dont always end gracefully. //FIXED, worker.terminate is better than close().
-           ) return false;
-
-        return true;
+        enable &= !this.encryption || filesender.supports.workerCrypto;
+        return enable;
     };
 
     /**

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -375,7 +375,7 @@ $(function () {
     // File download buttons when the files are encrypted
     $('.transfer-download').on('click', function () {
         
-        if(!window.crypto_support){
+        if(!filesender.supports.crypto){
             return;
         }
         

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -537,4 +537,19 @@ $(function () {
     });
 
     filesender.ui.updateUserQuotaBar();
+
+    if (!filesender.supports.crypto) {
+        // Disable the upload fields
+        $("#encryption").attr("disabled", "disabled");
+        $("#encryption_description_container_disabled").show();
+
+        // Disable the transfer buttons
+        $('#encryption_description_not_supported').show();
+        $('.transfer-download').css({'color': 'rgba(173, 173, 173, 1)', 'cursor': 'default'});
+
+        // Disable the download buttons
+        $(".files.box .file[data-encrypted='1']").css({'height': '3.5em'});
+        $(".files.box .file[data-encrypted='1'] .download").hide();
+        $(".download_decryption_disabled").show();
+    }
 });


### PR DESCRIPTION
FileSender currently uses User Agent detection to find out whether TeraSender can be used in combination with crypto. This is not ideal, since webbrowsers get updated all the time and capabilities are improved each release.

This pull request removes User Agent detection, and instead detects capabilities by probing browser features. In addition, it fixes a bug that earlier was (incorrectly) attributed to webbrowsers not supporting crypto in WebWorkers, namely that WebWorkers do not have access to the DOM, making jQuery unavailable. Therefore, in this pull request, jQuery is removed from WebWorkers code, and moved to more appropriate locations.

If this pull request is accepted, #5 should not be relevant anymore.