### PR TITLE
Fix regressions after merge CodeBrige

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-if (!defined('FILESENDER_BASE')) define('FILESENDER_BASE', dirname(dirname(__FILE__)));
+if (!defined('FILESENDER_BASE')) die('autoload.php was called without init.php.');
 
 /**
  * Autoloading helper

--- a/config/config-sample-meijer.php
+++ b/config/config-sample-meijer.php
@@ -144,7 +144,7 @@ $config['transfer_options'] = array(
 		),
 
 		// Never allow a recipient to receive an email once their download is complete
-		'email_enable_recipient_download_complete' => array(
+		'enable_recipient_email_download_complete' => array(
 			'available' => false,
 			'advanced' => false,
 			'default' => false

--- a/scripts/install/install.php
+++ b/scripts/install/install.php
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-include dirname(__FILE__).'/../../includes/init.php';
+require_once dirname(__FILE__).'/../../includes/init.php';
 
 Logger::setProcess(ProcessTypes::INSTALL);
 

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-include dirname(__FILE__).'/../../includes/init.php';
+require_once dirname(__FILE__).'/../../includes/init.php';
 
 Logger::setProcess(ProcessTypes::UPGRADE);
 

--- a/scripts/upgrade/upgrade.php
+++ b/scripts/upgrade/upgrade.php
@@ -82,7 +82,7 @@ if($config && preg_match('`class\s+config\s+\{`i', $config)) {
 
 // Init once old config has been taken care of
 
-include dirname(__FILE__).'/../../includes/init.php';
+require_once dirname(__FILE__).'/../../includes/init.php';
 
 Logger::setProcess(ProcessTypes::UPGRADE);
 

--- a/travis/config.travis.mysql.php
+++ b/travis/config.travis.mysql.php
@@ -144,7 +144,7 @@ $config['transfer_options'] = array(
 		),
 
 		// Never allow a recipient to receive an email once their download is complete
-		'email_enable_recipient_download_complete' => array(
+		'enable_recipient_email_download_complete' => array(
 			'available' => false,
 			'advanced' => false,
 			'default' => false

--- a/travis/config.travis.pgsql.php
+++ b/travis/config.travis.pgsql.php
@@ -144,7 +144,7 @@ $config['transfer_options'] = array(
 		),
 
 		// Never allow a recipient to receive an email once their download is complete
-		'email_enable_recipient_download_complete' => array(
+		'enable_recipient_email_download_complete' => array(
 			'available' => false,
 			'advanced' => false,
 			'default' => false

--- a/unittests/selenium_tests/SeleniumTest.php
+++ b/unittests/selenium_tests/SeleniumTest.php
@@ -194,7 +194,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
         $str=file_get_contents('config/config.php');
 
         //replace something in the file string
-        $str=preg_replace("/\\\$config\['".$type."'\] = (.*);/", "\$config['".$type."'] = $value;",$str, -1, $count);
+        $str=preg_replace("/\\\$config\['".$type."'\]\s*=\s*(.*);/", "\$config['".$type."'] = $value;",$str, -1, $count);
 
         if($count == 0)
         {

--- a/unittests/tests/common/CommonPHPUnitConfigs.php
+++ b/unittests/tests/common/CommonPHPUnitConfigs.php
@@ -37,6 +37,8 @@
 
 date_default_timezone_set("Europe/Paris");
 
+require_once dirname(dirname(dirname(dirname(__FILE__)))) . implode(DIRECTORY_SEPARATOR, ['', 'includes', 'init.php']);
+
 require_once(dirname(__FILE__).'/../../../classes/autoload.php');
 
 // Make sure we're not stopped by the authentication system


### PR DESCRIPTION
During the merging of the changes from CodeBridge, I seem to have missed some changes related to unittesting on Travis. More specific, during unittesting, `FILESENDER_BASE` was defined twice and Selenium was strict about whitespacing while patching config files for different tests. Additionally, one config option was misspelled in meijer's config file, which was used by CodeBridge.

Instead of backporting the stopgaps, I've opted to solve the problems at their roots. Thus, `FILESENDER_BASE` is now only defined in init. The define statement in the autoloader is replaced with a fatal error because it shouldn't be called. Selenium will now be more lenient with whitespace, and the misspelled config option has now been renamed to the correct one.