### PR TITLE
Allow encrypted_size to be null

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -71,6 +71,7 @@ class File extends DBObject
         ),
         'encrypted_size' => array(
             'type' => 'uint',
+            'null' => true,
             'size' => 'big'
         ),
         'upload_start' => array(


### PR DESCRIPTION
While upgrading our staging server, we found out that the migrations code doesn't handle the case where it has to add a NOT NULL column to a table which already contains data. This is no problem for MySQL because it will just fill `0` or `""` instead, but PostgreSQL will fail.

This pull request **does not** resolve the issue, but marks the new `encrypted_size` field to be nullable. I think that a nullable `encrypted_size` makes more sense in order to be able to mark files as not encrypted.