### PR TITLE
Make FileSender compatible with PHP 5.3, for backwards compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-- 5.4
+- 5.3
 addons:
   sauce_connect:
     username: "$SAUCE_USERNAME"

--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -167,17 +167,6 @@ class DBObject {
     }
     
     /**
-     * Default creator
-     * 
-     * Creates empty object
-     * 
-     * @return object instance
-     */
-    public static function create() {
-        return new static();
-    }
-    
-    /**
      * Object comparison
      * 
      * @param object $other other object or id

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -278,7 +278,7 @@ class StorageFilesystem {
      * @throws StorageFilesystemFileNotFoundException
      * @throws StorageFilesystemCannotReadException
      */
-    public function readChunk(File $file, $offset, $length) {
+    public static function readChunk(File $file, $offset, $length) {
         $chunk_size = (int)Config::get('download_chunk_size');
         
         $file_path = self::buildPath($file).$file->uid;
@@ -316,7 +316,7 @@ class StorageFilesystem {
      * @throws StorageFilesystemOutOfSpaceException
      * @throws StorageFilesystemCannotWriteException
      */
-    public function writeChunk(File $file, $data, $offset = null) {
+    public static function writeChunk(File $file, $data, $offset = null) {
         $chunk_size = strlen($data);
         
         $path = self::buildPath($file);
@@ -387,7 +387,7 @@ class StorageFilesystem {
      * 
      * @throws StorageFilesystemCannotDeleteException
      */
-    public function deleteFile(File $file) {
+    public static function deleteFile(File $file) {
         $file_path = self::buildPath($file).$file->uid;
         
         if(!file_exists($file_path)) return;

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -236,7 +236,7 @@ class GUI {
      * 
      * @return string
      */
-    public function currentPage($page = null) {
+    public static function currentPage($page = null) {
         if(!is_null($page)) self::$current_page = $page;
         
         // Already cached ?

--- a/classes/utils/Mail.class.php
+++ b/classes/utils/Mail.class.php
@@ -561,7 +561,7 @@ class Mail {
         }
 
         $other_recipients = '';
-        foreach(['To', 'Cc', 'Bcc'] as $recipient_type)
+        foreach(array('To', 'Cc', 'Bcc') as $recipient_type)
         {
             foreach($this->rcpt[$recipient_type] as $recipient)
             {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "sauce/sausage": "^0.17.0",
+        "sauce/sausage": "0.14.0",
+        "appium/php-client": "@dev",
         "phpunit/phpunit": "4.8.27",
         "phpunit/phpunit-selenium": "2.0.2",
         "phpunit/phpunit-mock-objects": "2.3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "686d65b2987f0c47b4f4c86ed57ee8e5",
-    "content-hash": "3a68269c19a2f861bc8e5e829d9630fd",
+    "hash": "3a652fae6c411b1ffbe83d4ce09bdc9b",
+    "content-hash": "80881c1c47c3f5a9876c93f4d721caea",
     "packages": [
         {
             "name": "appium/php-client",
-            "version": "v0.1.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appium/php-client.git",
-                "reference": "5c2223b1fa480e3408783dd770d0b99631820b9f"
+                "reference": "06c68c20d389bfd50a512393b1fe750cc5044b2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appium/php-client/zipball/5c2223b1fa480e3408783dd770d0b99631820b9f",
-                "reference": "5c2223b1fa480e3408783dd770d0b99631820b9f",
+                "url": "https://api.github.com/repos/appium/php-client/zipball/06c68c20d389bfd50a512393b1fe750cc5044b2f",
+                "reference": "06c68c20d389bfd50a512393b1fe750cc5044b2f",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "phpunit",
                 "selenium"
             ],
-            "time": "2014-09-22 16:34:46"
+            "time": "2016-11-09 01:09:43"
         },
         {
             "name": "brianium/habitat",
@@ -98,29 +98,28 @@
         },
         {
             "name": "brianium/paratest",
-            "version": "0.14.0",
+            "version": "0.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brianium/paratest.git",
-                "reference": "dddcfa8510da7aae9616ba1738ebf630d9e84aa4"
+                "reference": "0d4459f470f7b3ef2619fc9f1fc8720d7287ee40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brianium/paratest/zipball/dddcfa8510da7aae9616ba1738ebf630d9e84aa4",
-                "reference": "dddcfa8510da7aae9616ba1738ebf630d9e84aa4",
+                "url": "https://api.github.com/repos/brianium/paratest/zipball/0d4459f470f7b3ef2619fc9f1fc8720d7287ee40",
+                "reference": "0d4459f470f7b3ef2619fc9f1fc8720d7287ee40",
                 "shasum": ""
             },
             "require": {
                 "brianium/habitat": "1.0.0",
-                "composer/semver": "~1.2",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-simplexml": "*",
-                "php": ">=5.5.11",
+                "php": ">=5.3.0",
                 "phpunit/php-timer": ">=1.0.4",
                 "phpunit/phpunit": ">=3.7.8",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/process": "~2.3|~3.0"
+                "symfony/console": "~2.3",
+                "symfony/process": "~2.3"
             },
             "bin": [
                 "bin/paratest"
@@ -153,69 +152,7 @@
                 "phpunit",
                 "testing"
             ],
-            "time": "2016-08-12 20:14:13"
-        },
-        {
-            "name": "composer/semver",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "reference": "c7cb9a2095a074d131b65a8a0cd294479d785573",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "time": "2016-08-30 16:08:34"
+            "time": "2015-12-02 19:51:57"
         },
         {
             "name": "doctrine/instantiator",
@@ -272,177 +209,38 @@
             "time": "2015-06-14 21:17:01"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
-                "reference": "ea74994a3dc7f8d2f65a06009348f2d63c81e61f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "time": "2016-09-16 13:37:59"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "time": "2015-12-27 11:43:31"
-        },
-        {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.2.0",
-                "webmozart/assert": "^1.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "phpunit/phpunit": "~4.0"
             },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
+                "psr-0": {
+                    "phpDocumentor": [
                         "src/"
                     ]
                 }
@@ -454,23 +252,23 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
+                    "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2015-02-03 12:10:50"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "version": "v1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -478,10 +276,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -519,7 +318,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -585,16 +384,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -628,7 +427,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -717,16 +516,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -762,7 +561,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
@@ -958,27 +757,23 @@
         },
         {
             "name": "sauce/sausage",
-            "version": "0.17.0",
+            "version": "0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jlipps/sausage.git",
-                "reference": "ce7fea6a8de0090459cf23719aec907452600aa6"
+                "reference": "15a36175a6a8a61b0982ea1561770cf0b537250e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jlipps/sausage/zipball/ce7fea6a8de0090459cf23719aec907452600aa6",
-                "reference": "ce7fea6a8de0090459cf23719aec907452600aa6",
+                "url": "https://api.github.com/repos/jlipps/sausage/zipball/15a36175a6a8a61b0982ea1561770cf0b537250e",
+                "reference": "15a36175a6a8a61b0982ea1561770cf0b537250e",
                 "shasum": ""
             },
             "require": {
-                "appium/php-client": ">=0.1.0",
-                "brianium/paratest": ">=0.12.1",
-                "php": ">=5.4.0",
-                "phpunit/phpunit-selenium": ">=1.4.1",
+                "brianium/paratest": ">=0.6.1",
+                "php": ">=5.3.0",
+                "phpunit/phpunit-selenium": ">=1.3.3",
                 "sauce/sausage-installer": ">=0.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=4.5.1"
             },
             "suggest": {
                 "sauce/connect": ">=3.1"
@@ -1010,12 +805,11 @@
                 "Sauce",
                 "SauceLabs",
                 "api",
-                "appium",
                 "phpunit",
                 "selenium",
                 "testing"
             ],
-            "time": "2015-04-28 03:02:03"
+            "time": "2014-04-11 18:00:28"
         },
         {
             "name": "sauce/sausage-installer",
@@ -1056,68 +850,23 @@
             "time": "2012-09-28 18:41:38"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2016-02-13 06:45:14"
-        },
-        {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -1162,7 +911,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -1385,52 +1134,6 @@
             "time": "2015-10-12 03:26:01"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
-                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2016-01-28 13:25:10"
-        },
-        {
             "name": "sebastian/recursion-context",
             "version": "1.0.2",
             "source": {
@@ -1484,48 +1187,6 @@
             "time": "2015-11-11 19:50:13"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28 20:34:47"
-        },
-        {
             "name": "sebastian/version",
             "version": "1.0.6",
             "source": {
@@ -1562,26 +1223,27 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.4",
+            "version": "v2.6.13",
+            "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563"
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/8ea494c34f0f772c3954b5fbe00bffc5a435e563",
-                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0e5e18ae09d3f5c06367759be940e9ed3f568359",
+                "reference": "0e5e18ae09d3f5c06367759be940e9ed3f568359",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=5.3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/process": "~2.1"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -1591,16 +1253,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
+                "psr-0": {
                     "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1618,97 +1277,39 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-19 06:48:39"
+            "time": "2015-07-26 09:08:40"
         },
         {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "name": "symfony/process",
+            "version": "v2.6.13",
+            "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/process/zipball/57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
+                "reference": "57f1e88bb5dafa449b83f9f265b11d52d517b3e9",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "suggest": {
-                "ext-mbstring": "For best performance"
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2016-05-18 14:26:46"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v3.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "e64e93041c80e77197ace5ab9385dedb5a143697"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e64e93041c80e77197ace5ab9385dedb5a143697",
-                "reference": "e64e93041c80e77197ace5ab9385dedb5a143697",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
+                "psr-0": {
                     "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1726,38 +1327,39 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-08-16 14:58:24"
+            "time": "2015-06-30 16:10:16"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.4",
+            "version": "v2.6.13",
+            "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
+                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
-                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
+                "reference": "c044d1744b8e91aaaa0d9bac683ab87ec7cbf359",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
+                "psr-0": {
                     "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1775,63 +1377,15 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-02 02:12:52"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3|^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2015-07-26 08:59:42"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "appium/php-client": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/travis/config.travis.mysql.php
+++ b/travis/config.travis.mysql.php
@@ -307,4 +307,4 @@ $config['sauce_username'] = getenv('sauce_username'); // String, Sauce Labs user
 $config['sauce_access_key'] = getenv('sauce_access_key');     // String, Sauce Labs access key
 
 $config['ban_extension'] = 'exe,bat';
-$config['user_page'] = [];
+$config['user_page'] = array();

--- a/travis/config.travis.pgsql.php
+++ b/travis/config.travis.pgsql.php
@@ -312,5 +312,5 @@ $config['sauce_username'] = getenv('sauce_username'); // String, Sauce Labs user
 $config['sauce_access_key'] = getenv('sauce_access_key');     // String, Sauce Labs access key
 
 $config['ban_extension'] = 'exe,bat';
-$config['user_page'] = [];
+$config['user_page'] = array();
 

--- a/unittests/selenium_tests/SeleniumTest.php
+++ b/unittests/selenium_tests/SeleniumTest.php
@@ -110,7 +110,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     protected function getKeyBindings()
     {
-        $key_bindings = [];
+        $key_bindings = array();
         
         $refl = new ReflectionClass('PHPUnit_Extensions_Selenium2TestCase_Keys');
         foreach ($refl->getConstants() as $constant_key=>$constant_value)
@@ -161,14 +161,14 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     protected function setUserPage()
     {
-        $this->changeConfigValue('user_page', '[\'lang\'=>true,\'auth_secret\'=>true,\'id\'=>true,\'created\'=>true]');
+        $this->changeConfigValue('user_page', 'array(\'lang\'=>true,\'auth_secret\'=>true,\'id\'=>true,\'created\'=>true)');
         $this->refresh();
         sleep(2);
     }
 
     protected function unsetUserPage()
     {
-        $this->changeConfigValue('user_page', '[]');
+        $this->changeConfigValue('user_page', 'array()');
         $this->refresh();
         sleep(2);
     }
@@ -256,7 +256,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     public function downloadZip($token, $data_ids)
     {
-        stream_context_set_default(["ssl"=>["allow_self_signed"=>true]]);
+        stream_context_set_default(array("ssl"=>array("allow_self_signed"=>true)));
 
         //https://file_sender.app/filesender/download.php?token=36c2120e-44b1-c06e-8c32-27e3c4285ee6&files_ids=
         $zip_location = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'testzip-' . $token . '.zip';
@@ -292,10 +292,10 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     private function IndividualDownloadsTest($token, $file_datas_to_check)
     {
-        stream_context_set_default(["ssl"=>["allow_self_signed"=>true]]);
+        stream_context_set_default(array("ssl"=>array("allow_self_signed"=>true)));
 
         $elements = $this->elements($this->using('css selector')->value('.files.box .file'));
-        $data_ids = [];
+        $data_ids = array();
 
         foreach($elements as $element)
         {
@@ -317,10 +317,10 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     private function IndividualEncryptedDownloadsTest($token, $file_datas_to_check)
     {
-        stream_context_set_default(["ssl"=>["allow_self_signed"=>true]]);
+        stream_context_set_default(array("ssl"=>array("allow_self_signed"=>true)));
         // the download class is for encrypted direct downloads
         $elements = $this->elements($this->using('css selector')->value('.files.box .file.download'));
-        $data_ids = [];
+        $data_ids = array();
 
         foreach($elements as $element)
         {

--- a/unittests/selenium_tests/tests/ConfigurationOptionsTest.php
+++ b/unittests/selenium_tests/tests/ConfigurationOptionsTest.php
@@ -41,7 +41,7 @@ class ConfigurationOptionsTest extends SeleniumTest {
         }
 
 
-        $recipients = ['usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test'];
+        $recipients = array('usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test');
         $subject = 'testSubject_' . rand(0, 100);
         $content = 'testContent_' . rand(0, 100);
 
@@ -78,7 +78,7 @@ class ConfigurationOptionsTest extends SeleniumTest {
         $this->checkCheckbox('enable_recipient_email_download_complete', true);
 
 
-        $recipients = ['usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test'];
+        $recipients = array('usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test');
         $subject = 'testSubject_' . rand(0, 100);
         $content = 'testContent_' . rand(0, 100);
 
@@ -123,7 +123,7 @@ class ConfigurationOptionsTest extends SeleniumTest {
         }
 
 
-        $recipients = ['usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test'];
+        $recipients = array('usera@filetestertest.test', 'userb@filetestertest.test', 'userc@filetestertest.test');
         $subject = 'testSubject_' . rand(0, 100);
         $content = 'testContent_' . rand(0, 100);
 
@@ -172,7 +172,7 @@ class ConfigurationOptionsTest extends SeleniumTest {
         $test2_file_data = file_get_contents($test2_file);
         $this->sendKeys($this->byCssSelector(".file_selector input[name=\"files\"]"), $test2_file);
 
-        return [$test1_file_data, $test2_file_data];
+        return array($test1_file_data, $test2_file_data);
     }
 
     private function checkCheckbox($name, $checked = true) {
@@ -225,7 +225,7 @@ class ConfigurationOptionsTest extends SeleniumTest {
 
     private function yieldRecipientMails($recipient_id) {
 
-        $folder_names = [];
+        $folder_names = array();
         $folder_name = getcwd() . '\\testmails\\' . $recipient_id . '\\';
         //print_r($folder_name); exit;
         $dir = new DirectoryIterator($folder_name);

--- a/unittests/selenium_tests/tests/EncryptionTest.php
+++ b/unittests/selenium_tests/tests/EncryptionTest.php
@@ -47,7 +47,7 @@ class EncryptionTest extends SeleniumTest {
         
         // check db for encryption
         $statement = DBI::prepare('SELECT * FROM files where \'a\'=:a ORDER BY id DESC LIMIT 1');
-        $statement->execute(['a' => 'a']);
+        $statement->execute(array('a' => 'a'));
         $data = $statement->fetch();
         
         $encrypted_succes = false;
@@ -65,7 +65,7 @@ class EncryptionTest extends SeleniumTest {
         $test1_file_data = file_get_contents($test1_file);
         $this->sendKeys($this->byCssSelector(".file_selector input[name=\"files\"]"), $test1_file);
 
-        return [$test1_file_data];
+        return array($test1_file_data);
     }
     
     /**

--- a/unittests/selenium_tests/tests/EncryptionTest.php
+++ b/unittests/selenium_tests/tests/EncryptionTest.php
@@ -31,8 +31,9 @@ class EncryptionTest extends SeleniumTest {
         $this->byCssSelector('.start.ui-button')->click();
 
         // wait for the dialog
-        $this->waitUntil(function(){
-            $elements = $this->elements($this->using('css selector')->value('.ui-dialog-title'));
+        $test = $this;
+        $this->waitUntil(function() use ($test){
+            $elements = $test->elements($test->using('css selector')->value('.ui-dialog-title'));
             $count = count($elements);
             if($count > 0)
             {

--- a/unittests/selenium_tests/tests/MaxFilesTest.php
+++ b/unittests/selenium_tests/tests/MaxFilesTest.php
@@ -28,7 +28,7 @@ class MaxFilesTest extends SeleniumTest
 
         ${"temp"} = $this->execute(array(  'script' => "var file_upload_container = document.getElementsByClassName('file_selector')[0];file_upload_container.style.display='block';", 'args'   => array() ));
 
-        $test_files_created = [];
+        $test_files_created = array();
         for($i = 0; $i < $number_of_files; $i++)
         {
             $test_file = sys_get_temp_dir().DIRECTORY_SEPARATOR.'no'.($i+1).'.txt';

--- a/unittests/selenium_tests/tests/TransferExpiredTest.php
+++ b/unittests/selenium_tests/tests/TransferExpiredTest.php
@@ -32,9 +32,9 @@ class TransferExpiredTest extends SeleniumTest
 
         $this->byCssSelector('.start.ui-button')->click();
 
-
-        $this->waitUntil(function(){
-            $elements = $this->elements($this->using('css selector')->value('.ui-dialog-content.ui-widget-content.success'));
+        $test = $this;
+        $this->waitUntil(function() use ($test){
+            $elements = $test->elements($test->using('css selector')->value('.ui-dialog-content.ui-widget-content.success'));
             $count = count($elements);
             if($count > 0)
             {

--- a/unittests/selenium_tests/tests/TransferExpiredTest.php
+++ b/unittests/selenium_tests/tests/TransferExpiredTest.php
@@ -45,6 +45,6 @@ class TransferExpiredTest extends SeleniumTest
 
         $url = trim($this->byCssSelector('.ui-dialog-content.ui-widget-content.success textarea')->value());
 
-        $this->checkDownloadUrl($url, [$test1_file_data, $test2_file_data]);
+        $this->checkDownloadUrl($url, array($test1_file_data, $test2_file_data));
     }
 }

--- a/unittests/tests/common/CommonPHPUnitConfigs.php
+++ b/unittests/tests/common/CommonPHPUnitConfigs.php
@@ -37,7 +37,7 @@
 
 date_default_timezone_set("Europe/Paris");
 
-require_once dirname(dirname(dirname(dirname(__FILE__)))) . implode(DIRECTORY_SEPARATOR, ['', 'includes', 'init.php']);
+require_once dirname(dirname(dirname(dirname(__FILE__)))) . implode(DIRECTORY_SEPARATOR, array('', 'includes', 'init.php'));
 
 require_once(dirname(__FILE__).'/../../../classes/autoload.php');
 

--- a/unittests/tests/dbs/DBsTest.php
+++ b/unittests/tests/dbs/DBsTest.php
@@ -57,7 +57,7 @@ class DBsTest extends CommonUnitTestCase {
     public function testConnexion() {
         try {
             $statement = DBI::prepare('SELECT 1;');
-            $statement->execute([]);
+            $statement->execute(array());
             $data = $statement->fetch();
             $this->assertTrue(isset($data['?column?']) ? $data['?column?'] == 1 : $data[1] == 1);
 


### PR DESCRIPTION
The [] notation is prettier, but Red Hat 6 still uses PHP 5.3 which doesn't support it.
Since FileSender supports all alive versions of Debian and Red Hat, we must limit ourselves to syntaxes supported by old PHP versions.