### PR TITLE
Define method in failsafe logging facility

### DIFF
--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -76,7 +76,7 @@ class Logger {
     private static function setup() {
         if(!is_null(self::$facilities)) return;
 
-        self::$facilities = array(array('type' => 'error_log')); // Failsafe facility so we have at least one if no valid ones defined in config
+        self::$facilities = array(array('type' => 'error_log', 'method' => 'logErrorLog')); // Failsafe facility so we have at least one if no valid ones defined in config
         
         // Get facilities from config, cast to single type
         $facilities = Config::get('log_facilities');


### PR DESCRIPTION
The logger has a failsafe to be able to log when no logging is configured yet. However, this fails on [classes/utils/Logger.class.php#L306](https://github.com/filesender/filesender/blob/27b7026/classes/utils/Logger.class.php#L306), where it required a `method` to be defined. The method being missing causes a fatal error, which causes PHPUnit to fail while trying to show an error message about missing configuration.