### PR TITLE
activate by default email_guest_created

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -219,7 +219,7 @@ $default = array(
             'default' => false
         ),
         'email_guest_created' => array(
-            'available' => false,
+            'available' => true,
             'advanced' => true,
             'default' => true
         ),


### PR DESCRIPTION
Actually, no email is sent with the guest voucher after its creation, which is odd due to email_guest_created paramater values.