### PR TITLE
Make options label toggle checkboxes unless when user is a guest

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -717,7 +717,7 @@ $(function() {
         filesender.ui.nodes.expires.datepicker('setDate', $(this).val());
     });
     
-    // Make options label toggle checkboxes
+    // Make options label toggle checkboxes when the user is connected
     form.find('.basic_options label, .advanced_options label').on('click', function() {
         if($('body:not([data-auth-type=guest])').length > 0) {        
             var checkbox = $(this).closest('.fieldcontainer').find(':checkbox');

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -719,9 +719,11 @@ $(function() {
     
     // Make options label toggle checkboxes
     form.find('.basic_options label, .advanced_options label').on('click', function() {
-        var checkbox = $(this).closest('.fieldcontainer').find(':checkbox');
-        checkbox.prop('checked', !checkbox.prop('checked'));
-        checkbox.change();
+        if($('body:not([data-auth-type=guest])').length > 0) {        
+            var checkbox = $(this).closest('.fieldcontainer').find(':checkbox');
+            checkbox.prop('checked', !checkbox.prop('checked'));
+            checkbox.change();
+        }
     }).css('cursor', 'pointer');
     
     // Bind advanced options display toggle


### PR DESCRIPTION
Even if the options' checkboxes are disabled on the upload page when a guest access this page, he can interact with the options when clicking the associated label.

This pull request checks if the user is connected.