### PR TITLE
fix cron not deleting transfers of the same day

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -104,7 +104,7 @@ class Guest extends DBObject {
      * Set selectors
      */
     const AVAILABLE = "status = 'available' ORDER BY created DESC";
-    const EXPIRED = "expires < :date ORDER BY expires ASC";
+    const EXPIRED = "expires <= :date ORDER BY expires ASC";
     const FROM_USER = "user_id = :user_id AND status = 'available' ORDER BY created DESC";
     
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -108,9 +108,9 @@ class Transfer extends DBObject {
     const UPLOADING = "status = 'uploading' ORDER BY created DESC";
     const AVAILABLE = "status = 'available' ORDER BY created DESC";
     const CLOSED = "status = 'closed' ORDER BY created DESC";
-    const EXPIRED = "expires < :date ORDER BY expires ASC";
+    const EXPIRED = "expires <= :date ORDER BY expires ASC";
     const FAILED = "created < :date AND (status = 'created' OR status = 'started' OR status = 'uploading') ORDER BY expires ASC";
-    const AUDITLOG_EXPIRED = "expires < :date ORDER BY expires ASC";
+    const AUDITLOG_EXPIRED = "expires <= :date ORDER BY expires ASC";
     const FROM_USER = "user_id = :user_id AND status='available' ORDER BY created DESC";
     const FROM_USER_CLOSED = "user_id = :user_id AND status='closed' ORDER BY created DESC";
     const FROM_GUEST = "guest_id = :guest_id AND status='available' ORDER BY created DESC";


### PR DESCRIPTION
We have users who can see transfers on "Currently available transfers" panel even if the transfer expired on the same day.
The cause is related to the EXPIRED request called by the cron which doesn't include the same day.