### PR TITLE
improve file extension testing for bad cases

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -68,6 +68,7 @@ $default = array(
     'mac_unzip_name' => 'The Unarchiver',
     'mac_unzip_link' => 'http://unarchiver.c3.cx/unarchiver',
     'ban_extension' => 'exe,bat',
+    'extension_whitelist_regex' => '^[a-zA-Z0-9]*$', // a valid file extension must match this regex
     
     'max_transfer_size' => 107374182400,
     'max_transfer_recipients' => 50,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -39,6 +39,7 @@ require_once('../includes/init.php');
 header('Content-Type: text/javascript; charset=UTF-8');
 
 $banned = Config::get('ban_extension');
+$extension_whitelist_regex = Config::get('extension_whitelist_regex');
 
 $amc = Config::get('autocomplete_min_characters');
 
@@ -61,6 +62,7 @@ window.filesender.config = {
     max_transfer_files: <?php echo Config::get('max_transfer_files') ?>,
     
     ban_extension: <?php echo is_string($banned) ? "'".$banned."'" : 'null' ?>,
+    extension_whitelist_regex: <?php echo is_string($extension_whitelist_regex) ? "'".$extension_whitelist_regex."'" : 'null' ?>,
     
     max_transfer_recipients: <?php echo Config::get('max_transfer_recipients') ?>,
     max_guest_recipients: <?php echo Config::get('max_guest_recipients') ?>,

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -182,7 +182,21 @@ window.filesender.transfer = function() {
                 return false;
             }
         }
-        
+
+        if (typeof filesender.config.extension_whitelist_regex == 'string') {
+            var extension_whitelist = filesender.config.extension_whitelist_regex;
+            regex = new RegExp(extension_whitelist);
+            var extension = file.name.split('.').pop();
+            if (!extension.match(regex)) {
+                errorhandler({ message: 'banned_extension_includes_bad_characters',
+			       details: { extension: extension,
+					  filename: file.name,
+					  banned: filesender.config.extension_whitelist_regex}});
+                
+                return false;
+            }
+        }
+	
         if (this.size + file.size > filesender.config.max_transfer_size) {
             errorhandler({message: 'transfer_maximum_size_exceeded', details: {size: file.size, max: filesender.config.max_transfer_size}});
             return false;


### PR DESCRIPTION
Using a whitelist is better than trying to work out all the exploits that might come along. For example, nasties like the following as the file extension.

```
\"install_keystroke_monitor();" 
```

Most extensions are just normal characters