### PR TITLE
FIS-007 fix for XSS injection in file name on transfer page

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -725,7 +725,11 @@ class Transfer extends DBObject {
             
             if(count($matches)) return array_shift($matches);
         }
-        
+
+        if( !Utilities::isValidFileName( $name )) {
+            throw new TransferFileNameInvalidException( $name );
+        }
+
         // Create and save new recipient
         $file = File::create($this);
         $file->name = $name;

--- a/classes/exceptions/TransferExceptions.class.php
+++ b/classes/exceptions/TransferExceptions.class.php
@@ -68,6 +68,21 @@ class TransferBadStatusException extends DetailedException {
 }
 
 /**
+ * File name has bad characters
+ */
+class TransferFileNameInvalidException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param int $wanted
+     * @param int $max
+     */
+    public function __construct($name) {
+        parent::__construct('transfer_file_name_invalid', array('name' => $name));
+    }
+}
+
+/**
  * Missing too many recipients exception
  */
 class TransferTooManyRecipientsException extends DetailedException {

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -107,6 +107,18 @@ class Utilities {
     }
     
     /**
+     * Validates a filename
+     * 
+     * @param string $filename
+     * 
+     * @return bool
+     */
+    public static function isValidFileName($filename) {
+        return preg_match('/' .  Config::get('valid_filename_regex') . '/', $filename);
+    }
+
+
+    /*
      * Generate (pseudo) (super-)random hex string
      * 
      * @return string

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -117,7 +117,9 @@ $default = array(
     'storage_usage_warning' => 20,
     
     'report_format' => ReportFormats::INLINE,
-    
+
+    'valid_filename_regex' => '^[a-zA-Z0-9_\-\.,;:!@#$%^&*)(\]\[_-]+$',
+
     'user_page' => false,
     //'user_page' => array(
     //    'lang' => 'write',

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -550,6 +550,7 @@ $lang['transfer_user_quota_exceeded'] = 'User quota exceeded';
 $lang['transfer_expiry_extension_not_allowed'] = 'Transfer expiry date extension is not allowed';
 $lang['transfer_expiry_extension_count_exceeded'] = 'Transfer expiry date extension maximum reached';
 $lang['transfer_files_incomplete'] = 'Transfer\'s files are not done uploading';
+$lang['transfer_file_name_invalid'] = 'File name contains bad characters';
 
 // User related exceptions
 $lang['user_not_found'] = 'User not found';

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -237,8 +237,9 @@
                                 <?php if(isset($transfer->options['encryption']) && $transfer->options['encryption'] === true) { ?>
                                 <span class="fa fa-lg fa-download transfer-file transfer-download" title="{tr:download}" data-id="<?php echo $file->id ?>" 
                                         data-encrypted="<?php echo isset($transfer->options['encryption'])?$transfer->options['encryption']:'false'; ?>" 
-                                        data-mime="<?php echo $file->mime_type; ?>" 
-                                        data-name="<?php echo $file->name; ?>"></span>
+                                        data-mime="<?php echo Template::sanitizeOutput($file->mime_type); ?>" 
+                                        data-name="<?php echo Template::sanitizeOutput($file->name); ?>"></span>
+                                        
                                 <?php } else {?>
                             <a class="fa fa-lg fa-download" title="{tr:download}" href="download.php?files_ids=<?php echo $file->id ?>"></a>
                                 <?php } ?>


### PR DESCRIPTION
File names have no need to include things like the following

```
\"alert(1);
```

Most folks do the right thing, but they are not the ones we are concerned with here. Instead of trying to work out what to do with a blacklist of "you can't do a \" here" it is more secure to declare what characters are valid for a file name and reject the rest. Output is also sanitized just in case something got through before that is nasty.
