### PR TITLE
loosen the security to allow more freedom again

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -114,7 +114,7 @@ class Utilities {
      * @return bool
      */
     public static function isValidFileName($filename) {
-        return preg_match('/' .  Config::get('valid_filename_regex') . '/', $filename);
+        return preg_match('/' .  Config::get('valid_filename_regex') . '/u', $filename);
     }
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -118,7 +118,7 @@ $default = array(
     
     'report_format' => ReportFormats::INLINE,
 
-    'valid_filename_regex' => '^[a-zA-Z0-9_\-\.,;:!@#$%^&*)(\]\[_-]+$',
+    'valid_filename_regex' => '^[\p{L}\p{N}_\-\.,;:!@#$%^&*)(\]\[_-]+$',
 
     'user_page' => false,
     //'user_page' => array(


### PR DESCRIPTION
This lets some common chars back into filenames 

```
php > echo preg_match( '/^[\p{L}\p{N}_]*$/u', 'ÆØÅÜÉéafdsfdDFSDFDS543534' ) == 1 ? 'ok' : 'bad';
ok
```