### PR TITLE
fis012 disallow out of tree file names

### DIFF
--- a/classes/utils/Zipper.class.php
+++ b/classes/utils/Zipper.class.php
@@ -106,6 +106,8 @@ class Zipper {
 
             // Set up metadata and send the local header.
             $name = preg_replace('/^\\/+/', '', $file->name); // Strip leading slashes from filename.
+            $name = preg_replace('/\\.\\.\\//', '', $name);   // strip ../
+            $name = preg_replace('/\\/\\.\\./', '', $name);   // strip /..
             
             //timestamps
             $timestamp = $this->unixToDosTime(strtotime($transfer->created));


### PR DESCRIPTION
most extractors catch these out of tree write attempts, but we should do some filtering to help stop them from happening.