### PR TITLE
fis013 option to filter links in messages

### DIFF
--- a/classes/exceptions/GuestExceptions.class.php
+++ b/classes/exceptions/GuestExceptions.class.php
@@ -51,6 +51,20 @@ class GuestNotFoundException extends DetailedException {
 }
 
 /**
+ * We filter out URLs in the personal message
+ */
+class GuestMessageBodyCanNotIncludeURLsException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param Transfer $transfer
+     */
+    public function __construct() {
+        parent::__construct('message_can_not_contain_urls');
+    }
+}
+
+/**
  * Bad status exception
  */
 class GuestBadStatusException extends DetailedException {

--- a/classes/exceptions/MailExceptions.php
+++ b/classes/exceptions/MailExceptions.php
@@ -80,3 +80,4 @@ class MailAttachmentNoContentException extends DetailedException {
         );
     }
 }
+

--- a/classes/exceptions/TransferExceptions.class.php
+++ b/classes/exceptions/TransferExceptions.class.php
@@ -224,6 +224,20 @@ class TransferFilesIncompleteException extends TransferException {
 }
 
 /**
+ * We filter out URLs in the personal message
+ */
+class TransferMessageBodyCanNotIncludeURLsException extends TransferException {
+    /**
+     * Constructor
+     * 
+     * @param Transfer $transfer
+     */
+    public function __construct($transfer) {
+        parent::__construct($transfer, 'message_can_not_contain_urls');
+    }
+}
+
+/**
  * Expired
  */
 class TransferExpiredException extends TransferException {
@@ -278,3 +292,4 @@ class TransferExpiryExtensionCountExceededException extends TransferException {
         parent::__construct($transfer, 'expiry_extension_count_exceeded');
     }
 }
+

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -163,7 +163,12 @@ class RestEndpointGuest extends RestEndpoint {
         
         // Set provided metadata
         if($data->subject) $guest->subject = $data->subject;
-        if($data->message) $guest->message = $data->message;
+        if($data->message) {
+            $guest->message = $data->message;
+            if(!Utilities::isValidMessage($guest->message)) {
+                throw new GuestMessageBodyCanNotIncludeURLsException();
+            }
+        }
         
         // Allow any options for remote applications, check against allowed options otherwise
         $allowed_options = array_keys(Auth::isRemoteApplication() ? Guest::allOptions() : Guest::availableOptions());

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -435,7 +435,12 @@ class RestEndpointTransfer extends RestEndpoint {
             
             // Set additionnal data
             if($data->subject) $transfer->subject = $data->subject;
-            if($data->message) $transfer->message = $data->message;
+            if($data->message) {
+                $transfer->message = $data->message;
+                if(!Utilities::isValidMessage($transfer->message)) {
+                   throw new TransferMessageBodyCanNotIncludeURLsException();
+                }
+            }
             if(Config::get('transfer_recipients_lang_selector_enabled') && $data->lang) $transfer->lang = $data->lang;
             
             // Guest owner decides about guest options

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -85,7 +85,20 @@ class Utilities {
         
         return substr($rnd, 0, 8).'-'.substr($rnd, 8, 4).'-'.substr($rnd, 12, 4).'-'.substr($rnd, 16, 4).'-'.substr($rnd, 20, 12);
     }
+
+    /**
+     * Validates a personal message
+     *
+     */
+    public static function isValidMessage($msg) {
+        $r = Config::get('message_can_not_contain_urls_regex');
+        if($r.length && preg_match('/' . $r . '/', $msg )) {
+            return false;
+        }
+        return true;
+    }
     
+
     /**
      * Validates unique ID format
      * 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -119,6 +119,8 @@ $default = array(
     'report_format' => ReportFormats::INLINE,
 
     'valid_filename_regex' => '^[\\p{L}\\p{N}_\\.,;:!@#$%^&*)(\\]\\[_-]+$',
+    'message_can_not_contain_urls_regex' => '',
+//    'message_can_not_contain_urls_regex' => '(ftp:|http[s]*:|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})',
 
     'guest_limit_per_user' => 50,
     'guest_reminder_limit' => 50,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -255,6 +255,7 @@ $lang['guest_deleted'] = 'Guest deleted';
 $lang['guest_reminded'] = 'Guest reminded';
 $lang['confirm_delete_guest'] = 'Do you really want to delete this guest (the recipient won\'t be able to upload files anymore) ?';
 $lang['confirm_remind_guest'] = 'Do you really want to send a reminder to this guest ?';
+$lang['message_can_not_contain_urls'] = 'Message can not contain things that look like URLs';
 
 
 /**

--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -40,6 +40,7 @@
                     <div class="fieldcontainer">
                         <label for="message">{tr:message} ({tr:optional}) : </label>
 
+                        <label class="invalid" id="message_can_not_contain_urls" style="display:none;">{tr:message_can_not_contain_urls}</label>
                         <textarea name="message" rows="4"></textarea>
                     </div>
                 </td>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -108,7 +108,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                     
                     <div class="fieldcontainer" data-related-to="message">
                         <label for="message">{tr:message} ({tr:optional}) : </label>
-                        
+                        <label class="invalid" id="message_can_not_contain_urls" style="display:none;">{tr:message_can_not_contain_urls}</label>                        
                         <textarea name="message" rows="4"></textarea>
                     </div>
                         <?php if(Config::get('encryption_enabled')) { ?>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -292,6 +292,11 @@ input.invalid, textarea.invalid {
     border: 1px solid #f00;
 }
 
+label.invalid {
+    color: #f00;
+}
+
+
 .buttons {
     display: table;
     border-collapse: separate;

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -100,7 +100,8 @@ window.filesender.config = {
         enabled: <?php echo Config::get('autocomplete') ? 'true' : 'false' ?>,
         min_characters: <?php echo (is_int($amc) && $amc) ? $amc : 3 ?>
     },
-    
+    message_can_not_contain_urls_regex: '<?php $v = Config::get('message_can_not_contain_urls_regex'); $v = str_replace('\\', '\\\\', $v); echo $v; ?>',
+
     auditlog_lifetime: <?php $lt = Config::get('auditlog_lifetime'); echo is_null($lt) ? 'null' : $lt ?>,
     
     logon_url: '<?php echo AuthSP::logonURL() ?>',

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -255,6 +255,7 @@ $(function() {
         expires: send_voucher.find('input[name="expires"]'),
         options: {guest: {}, transfer: {}},
         sendbutton: send_voucher.find('.send'),
+        message_can_not_contain_urls: send_voucher.find('textarea[name="message_can_not_contain_urls"]'),
     };
     send_voucher.find('.guest_options input').each(function() {
         var i = $(this);
@@ -305,6 +306,12 @@ $(function() {
         
         filesender.ui.recipients.addFromInput($(this));
     });
+
+    // validate message as it is typed
+    window.filesender.ui.handleFlagInvalidOnRegexMatch(
+        filesender.ui.nodes.message,
+        $('#message_can_not_contain_urls'),
+        filesender.config.message_can_not_contain_urls_regex );
     
     // Bind picker
     filesender.ui.nodes.expires.datepicker({

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -508,6 +508,32 @@ window.filesender.ui = {
             bar.attr({title: lang.tr('user_quota')});
         });
     },
+
+    /**
+     * add a handler to show the error message invalidlabelobj when the text
+     * in inputtextareaobj matches the regular expression rexstr
+     * 
+     * @param inputtextareaobj input to attach check on
+     */
+    handleFlagInvalidOnRegexMatch: function(inputtextareaobj,invalidlabelobj,rexstr) {
+
+        if( rexstr.length ) {
+            banned = new RegExp(rexstr, 'g');
+        
+            inputtextareaobj.on('keyup', function(e) {
+                var v = $(this).val();
+                if (v.match(banned)) {
+                    $(this).addClass('invalid');
+                    invalidlabelobj.show();
+                }else{
+                    $(this).removeClass('invalid');
+                    invalidlabelobj.hide();
+                }
+            });
+        }
+    
+    },
+    
 };
 
 $(function() {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -684,6 +684,12 @@ $(function() {
         var files = filesender.ui.nodes.files.input[0].files;
         if(files && files.length) filesender.ui.files.add(files);
     }
+
+    // validate message as it is typed
+    window.filesender.ui.handleFlagInvalidOnRegexMatch(
+        filesender.ui.nodes.message,
+        $('#message_can_not_contain_urls'),
+        filesender.config.message_can_not_contain_urls_regex );
     
     // Setup date picker
     $.datepicker.setDefaults({


### PR DESCRIPTION
I have left the default setting to not filter links as I think using links is a _huge_ advantage to researchers. 

I guess since the default is now to get a link to the transfer then the 'message' in file sender will get less direct use. Offering the link to the transfer puts the security issue on the messaging systems that people are using to communicate these links to each other. But it doesn't mean that the 'message' option in FileSender should make users not want to use it by being a bunch more restrictive than email. 