### PR TITLE
FIS-005: Stop unauthorized file overwrite after transfer is complete.

### DIFF
--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -163,8 +163,7 @@ class RestEndpointFile extends RestEndpoint {
         $data = $this->request->input;
 
         // File's Transfer must be uploading or just started, fail otherwise
-        if(
-            $file->transfer->status != TransferStatuses::STARTED &&
+        if( $file->transfer->status != TransferStatuses::STARTED &&
             $file->transfer->status != TransferStatuses::UPLOADING
         ) {
             throw new RestCannotAddDataToCompleteTransferException('File', $file->id);
@@ -342,6 +341,7 @@ class RestEndpointFile extends RestEndpoint {
         
         }else if(is_null($mode) && $data && $data->complete) {
             // Client signals that the file's body has been fully uploaded, flag the file as complete
+            
             $file->complete();
             
             return true;

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -161,6 +161,15 @@ class RestEndpointFile extends RestEndpoint {
         
         // Get chunk data
         $data = $this->request->input;
+
+        // File's Transfer must be uploading or just started, fail otherwise
+        if(
+            $file->transfer->status != TransferStatuses::STARTED &&
+            $file->transfer->status != TransferStatuses::UPLOADING
+        ) {
+            throw new RestCannotAddDataToCompleteTransferException('File', $file->id);
+        }
+
         
         if($mode == 'whole') {
             // Process uploaded file, split into chunks and push to storage
@@ -333,7 +342,6 @@ class RestEndpointFile extends RestEndpoint {
         
         }else if(is_null($mode) && $data && $data->complete) {
             // Client signals that the file's body has been fully uploaded, flag the file as complete
-            
             $file->complete();
             
             return true;


### PR DESCRIPTION
It PUT was already protected from this, but POST needed the additional check on session status.

A command like the following used to allow override if sizes matched.
```
curl -X POST -k -v 'https://127.0.0.1/filesender/rest.php/file/149/whole?key=e9001...e2bc8' -F "file=@/tmp/new1"
...
{"id":149,"transfer_id":158,"uid":"e9001...e2bc8","name":"df2","size":30,"sha1":null}
```

Now it results in an error ```"message":"cannot_add_data_to_complete_transfer"```