### PR TITLE
fis011: you need to be authenticated in order to delete files

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -612,22 +612,10 @@ class RestEndpointTransfer extends RestEndpoint {
         
         $transfer = Transfer::fromId($id);
         
-        // Check access rights depending on config
-        if($security == 'key') {
-            try {
-                if(!array_key_exists('key', $_GET)) throw new Exception();
-                if(!$_GET['key']) throw new Exception();
-                if(!File::fromUid($_GET['key'])->transfer->is($transfer)) throw new Exception();
-                if(!in_array($transfer->status, array(TransferStatuses::CREATED, TransferStatuses::STARTED, TransferStatuses::UPLOADING))) throw new Exception();
-            } catch(Exception $e) {
-                throw new RestAuthenticationRequiredException();
-            }
-        }else{
-            $user = Auth::user();
+        $user = Auth::user();
             
-            if(!$transfer->isOwner($user) && !Auth::isAdmin())
-                throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
-        }
+        if(!$transfer->isOwner($user) && !Auth::isAdmin())
+            throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
         
         // Delete the transfer (not recoverable)
         $transfer->delete();


### PR DESCRIPTION
Deleting files is so final and quick that there is not much gain to allowing folks to do it after their saml session has expired. This also mitigates hack attempts from folks who might have found out a file uid and sweep through trying to clean out things 6 months after the session was setup. 