### PR TITLE
FIS-004: Avoid leaking information when the user directly attacks the REST API.

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1083,4 +1083,33 @@ class Transfer extends DBObject {
         
         Logger::info('Mail#'.$translation_id.' sent to '.$recipient);
     }
+
+    /**
+     * uploading has completed. This is true for complete and closed 
+     * transfers and this method allows functions to check of an upload
+     * is still in progress or not.
+     */
+    public function isStatusAtleastUploaded() {
+        return $this->status == TransferStatuses::AVAILABLE ||
+               $this->status == TransferStatuses::CLOSED;
+    }
+    
+    /**
+     * closed transfer.
+     */
+    public function isStatusClosed() {
+        return $this->status == TransferStatuses::CLOSED;
+    }
+    
+    /**
+     * Call here when you want to deny state changes to already complete
+     * transfers. Note that states 'less than' UPLOADING are considered OK
+     * for this. We only want to deny changes to 'available' or closed transfers.
+     */
+    public function isStatusUploading() {
+        return $this->status == TransferStatuses::CREATED ||
+               $this->status == TransferStatuses::STARTED ||
+               $this->status == TransferStatuses::UPLOADING;
+    }
+
 }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -148,7 +148,7 @@ class RestEndpointTransfer extends RestEndpoint {
             $transfer = Transfer::fromId($id);
             try {
                 if(!File::fromUid($_GET['key'])->transfer->is($transfer)) throw new Exception();
-                if(!in_array($transfer->status, array(TransferStatuses::CREATED, TransferStatuses::STARTED, TransferStatuses::UPLOADING))) throw new Exception();
+                if(!$transfer->isStatusUploading()) throw new Exception();
             } catch(Exception $e) {
                 throw new RestAuthenticationRequiredException();
             }
@@ -387,8 +387,9 @@ class RestEndpointTransfer extends RestEndpoint {
                         !$guest->options[GuestOptions::CAN_ONLY_SEND_TO_ME]
                     )
                 )
-            )
+            ) {
                 throw new TransferNoRecipientsException();
+            }     
             
             // Check if not too much recipients
             $maxrecipients = Config::get('max_transfer_recipients');
@@ -560,6 +561,15 @@ class RestEndpointTransfer extends RestEndpoint {
                 if(!array_key_exists('key', $_GET)) throw new Exception();
                 if(!$_GET['key']) throw new Exception();
                 if(!File::fromUid($_GET['key'])->transfer->is($transfer)) throw new Exception();
+                if($transfer->isStatusClosed()) throw new Exception();
+                
+                if($data->complete && $transfer->isStatusUploading()) {
+                    // this block means we are ok
+                    // these are the options that we allow
+                } else {
+                    // bad attempt
+                    throw new Exception();
+                }
             } catch(Exception $e) {
                 throw new RestAuthenticationRequiredException();
             }


### PR DESCRIPTION
After a PUT some metadata is returned. If the put does nothing much then a nasty user could use that call to obtain other information about a transfer using the 'key'.