### PR TITLE
Make the disclaimer message more meaningful to the page

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -333,7 +333,10 @@ $lang['report_guest_event_transfer_sent'] = 'Download link sent to recipient(s)'
  * Download page specific
  */
 $lang['archive_download'] = 'Download as single (.zip) file';
-$lang['download_disclamer'] = 'You can download all files at once as a single compressed archive (.zip) file.  Click on the downloaded file to uncompress it and access individual files.';
+$lang['download_disclamer'] = '';
+$lang['download_disclamer_nocrypto_message'] = 'You can right click on the download button and "Copy Link Location" to download the file using another tool.';
+$lang['download_disclamer_crypto_message'] = 'Click on a file to download the data and decrypt it on your computer.';
+$lang['download_disclamer_archive'] = 'You can download all files at once as a single compressed archive (.zip) file.  Click on the downloaded file to uncompress it and access individual files.';
 $lang['download_file'] = 'Download file';
 $lang['mac_archive_message'] = 'This compressed archive (.zip file) will be too big for the standard uncompress utility of Apple OS X.<br />  You\'ll find a alternative uncompress software here: <a href="{cfg:mac_unzip_link}" target="_blank">{cfg:mac_unzip_name}</a>.';
 $lang['select_all_for_archive_download'] = 'Select all files to download them as an archive';

--- a/language/fr_FR/lang.php
+++ b/language/fr_FR/lang.php
@@ -318,7 +318,7 @@ $lang['report_guest_event_transfer_sent'] = 'Les liens de téléchargement ont �
  * Download page specific
  */
 $lang['archive_download'] = 'Télécharger l\'archive';
-$lang['download_disclamer'] = 'Voici vos fichiers. Vous pouvez les télécharger indépendamment les uns des autres ou rassemblés sous forme d\'archive ZIP.';
+$lang['download_disclamer_archive'] = 'Voici vos fichiers. Vous pouvez les télécharger indépendamment les uns des autres ou rassemblés sous forme d\'archive ZIP.';
 $lang['download_file'] = 'Télécharger';
 $lang['mac_archive_message'] = 'Si vous utilisez OSX vous pourrez trouver un utilitaire permettant d\'ouvrir l\'archive en suivant le lien suivant : <a href="{cfg:mac_unzip_link}" target="_blank">{cfg:mac_unzip_name}</a>.';
 $lang['select_all_for_archive_download'] = 'Sélectionner tous les fichiers';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -33,11 +33,27 @@
             'files_ids' => implode(',', $fileIds),
         )));
     }
-    
+
+    $isEncrypted = isset($transfer->options['encryption']) && $transfer->options['encryption'];
+    $canDownloadArchive = count($transfer->files) > 1;
+    if($isEncrypted) {
+        // It is not possible to download archives of the encrypted files. 
+        // since there is no unzip -> decrypt -> zip process in the current filesender 
+        $canDownloadArchive = false;
+    }
     ?>
     
     <div class="disclamer">
         {tr:download_disclamer}
+        <?php if(!$isEncrypted) { ?>
+            {tr:download_disclamer_nocrypto_message}
+        <?php } ?>
+        <?php if($isEncrypted) { ?>
+            {tr:download_disclamer_crypto_message}
+        <?php } ?>
+        <?php if($canDownloadArchive) { ?>
+            {tr:download_disclamer_archive}
+        <?php } ?>
     </div>
     
     <div class="general box" data-transfer-size="<?php echo $transfer->size ?>">
@@ -50,19 +66,19 @@
         <div class="size">{tr:size} : <?php echo Utilities::sanitizeOutput(Utilities::formatBytes($transfer->size)) ?></div>
         
         <?php if($transfer->subject) { ?>
-        <div class="subject">{tr:subject} : <?php echo Utilities::sanitizeOutput($transfer->subject) ?></div>
+            <div class="subject">{tr:subject} : <?php echo Utilities::sanitizeOutput($transfer->subject) ?></div>
         <?php } ?>
         
         <?php if($transfer->message) { ?>
-        <div class="message">
-            {tr:message} :
-            <p>
-                <?php echo Utilities::sanitizeOutput($transfer->message) ?>
-            </p>
-        </div>
+            <div class="message">
+                {tr:message} :
+                <p>
+                    <?php echo Utilities::sanitizeOutput($transfer->message) ?>
+                </p>
+            </div>
         <?php } ?>
     </div>
-    <div class="files box" data-count="<?php echo (isset($transfer->options['encryption']) && $transfer->options['encryption'])?'1':count($transfer->files) ?>">
+    <div class="files box" data-count="<?php echo ($isEncrypted)?'1':count($transfer->files) ?>">
         <div class="select_all">
             <span class="fa fa-lg fa-mail-reply fa-rotate-270"></span>
             <span class="select clickable">
@@ -87,9 +103,8 @@
             <span class="downloadprogress"></span>
         </div>
     <?php } ?>
-    <?php if(!isset($transfer->options['encryption']) || $transfer->options['encryption'] === false) { ?>
-    <?php // It is not possible to download archives of the encrypted files since there is no unzip -> decrypt -> zip process in the current filesender ?>
-        <div class="archive">
+        <?php if($canDownloadArchive) { ?>
+            <div class="archive">
             <div class="archive_message">{tr:archive_message}</div>
             
             <div class="mac_archive_message">


### PR DESCRIPTION
The archive message is only shown if there is >1 file. Some css was hiding it anyway in those cases.
A message about encryption is shown when that option is effective.
And the right click + copy link message is now shown at the top of page to give the user a hint that it should work.
