### PR TITLE
Add an option to hide checkboxes in the guest upload page

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -108,6 +108,7 @@ title: Configuration directives
 * [default_guest_days_valid](#defaultguestdaysvalid)
 * [max_guest_days_valid](#maxguestdaysvalid)
 * [max_guest_recipients](#maxguestrecipients)
+* [guest_upload_page_hide_unchangable_options](#guest_upload_page_hide_unchangable_options)
 
 ## Authentication
 
@@ -986,6 +987,16 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __mandatory:__ no
 * __type:__ int
 * __default:__ 50
+* __available:__ since version 2.0
+* __1.x name:__
+* __comment:__
+
+### guest_upload_page_hide_unchangable_options
+
+* __description:__ when true checkboxes that the guest can not interact with are hidden
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -200,7 +200,9 @@ $default = array(
             'default' => ''
         ),
     ),
-    
+
+    'guest_upload_page_hide_unchangable_options' => false,
+
     'guest_options' => array(
         'email_upload_started' => array(
             'available' => true,

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -157,8 +157,13 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                             
                             $checked = $default ? 'checked="checked"' : '';
                             $disabled = $disable ? 'disabled="disabled"' : '';
-                            
-                            echo '<div class="fieldcontainer" data-option="'.$name.'">';
+                            $extraDivAttrs = '';
+                            if(Auth::isGuest() && $disable) {
+                                if( Config::get('guest_upload_page_hide_unchangable_options')) {
+                                    $extraDivAttrs .= ' hidden="true" ';
+                                }
+                            }
+                            echo '<div class="fieldcontainer" data-option="'.$name.'" '. $extraDivAttrs .'>';
                             if($text) {
                                 echo '    <label for="'.$name.'">'.Lang::tr($name).'</label>';
                                 echo '    <input id="'.$name.'" name="'.$name.'" type="text" value="'.htmlspecialchars($default).'" '.$disabled.'>';


### PR DESCRIPTION
There are only a few options that a guest can actually change on my fairly stock config. It might make for a simpler one time upload of the guest has less uninteractive clutter to have to scan over for a simple first time upload.