### PR TITLE
sort guest transfer table newest first

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -221,7 +221,7 @@ class Transfer extends DBObject {
         
         // Sort by date
         uasort($transfers, function($a, $b) {
-            return $a->created - $b->created;
+            return $b->created - $a->created;
         });
         
         return $transfers;


### PR DESCRIPTION
The "My Transfers" page is sorted with the newest activity at the top. This will sort the guest transfers in the same way so the newest is at the top.
