### PR TITLE
For guests, get a link option does nothing

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -163,6 +163,9 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                                     $extraDivAttrs .= ' hidden="true" ';
                                 }
                             }
+                            if(Auth::isGuest() && $name == 'get_a_link' ) {
+                                $extraDivAttrs .= ' hidden="true" ';
+                            }
                             echo '<div class="fieldcontainer" data-option="'.$name.'" '. $extraDivAttrs .'>';
                             if($text) {
                                 echo '    <label for="'.$name.'">'.Lang::tr($name).'</label>';


### PR DESCRIPTION
Showing the option might give the user the feeling that it will have an impact. Not showing it at all for guests is less confusing.
