### PR TITLE
send a confirmation email to guest after upload

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -179,12 +179,14 @@ class Guest extends DBObject {
         if(is_object($this->options)) $this->options = (array)$this->options;
         
         // Legacy option format conversion, will be transformed to object by json conversion
-        if(is_array($this->transfer_options)) $this->transfer_options = array_merge(
-            array_fill_keys(array_keys(Transfer::allOptions()), false),
-            array_fill_keys($this->transfer_options, true)
-        );
-        
-        if(is_object($this->transfer_options)) $this->transfer_options = (array)$this->transfer_options;
+        if(is_array($this->transfer_options)) {
+            $this->transfer_options = array_merge(
+                array_fill_keys(array_keys(Transfer::allOptions()), false),
+                array_fill_keys($this->transfer_options, true)
+            );
+        }
+        if(is_object($this->transfer_options))
+            $this->transfer_options = (array)$this->transfer_options;
     }
     
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -658,7 +658,10 @@ class Transfer extends DBObject {
             
             return $auth_url;
         }
-        
+        if($property == 'download_link') {
+            $recipients = array_values($this->recipients);
+            return $recipients[0]->download_link;
+        }
         throw new PropertyAccessException($this, $property);
     }
     
@@ -868,6 +871,9 @@ class Transfer extends DBObject {
             // Send notification if required
             if($this->getOption(TransferOptions::EMAIL_UPLOAD_COMPLETE))
                 TranslatableEmail::quickSend('guest_upload_complete', $guest->owner, $guest);
+
+            // Let the guest know the upload is complete too
+            TranslatableEmail::quickSend('guest_upload_complete_confirmation_to_guest', $guest, $this);
             
             // Remove guest rights if valid for one upload only
             if($guest->getOption(GuestOptions::VALID_ONLY_ONE_TIME))

--- a/language/en_AU/guest_upload_complete_confirmation_to_guest.mail.php
+++ b/language/en_AU/guest_upload_complete_confirmation_to_guest.mail.php
@@ -1,0 +1,57 @@
+subject: You have uploaded files to FileSender as a Guest
+
+{alternative:plain}
+
+Dear Sir or Madam,
+
+You have uploaded files to your guest voucher :
+
+Guest: {guest.email}
+Voucher link: {cfg:site_url}?s=upload&vid={guest.token}
+Download link: {recipient.download_link}
+
+The voucher is available until {date:guest.expires} after which time it will be automatically deleted.
+
+Best regards,
+{cfg:site_name}
+
+{alternative:html}
+
+<p>
+     Dear Sir or Madam,
+</p>
+
+<p>
+  You have uploaded files to your guest voucher :
+</p>
+
+<table rules="rows">
+    <thead>
+        <tr>
+            <th colspan="2">Voucher details</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Guest</td>
+            <td><a href="mailto:{guest.email}">{guest.email}</a></td>
+        </tr>
+        <tr>
+            <td>Voucher link</td>
+            <td><a href="{cfg:site_url}?s=upload&vid={guest.token}">{cfg:site_url}?s=upload&vid={guest.token}</a></td>
+        </tr>
+        <tr>
+            <td>Download link</td>
+            <td><a href="{transfer.download_link}">{transfer.download_link}</a></td>
+        </tr>
+        <tr>
+            <td>Valid until</td>
+            <td>{date:guest.expires}</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>
+    Best regards,<br />
+    {cfg:site_name}
+</p>

--- a/language/fr_FR/guest_upload_complete_confirmation_to_guest.mail.php
+++ b/language/fr_FR/guest_upload_complete_confirmation_to_guest.mail.php
@@ -1,0 +1,55 @@
+subject: Vous avez téléchargé des fichiers vers FileSender en tant qu'invité
+
+{alternative:plain}
+
+Madame, Monsieur,
+
+Vous avez téléchargé des fichiers dans votre bon de visite
+
+invité: {guest.email}
+Lien Voucher: {cfg:site_url}?s=upload&vid={guest.token}
+Lien de téléchargement: {recipient.download_link}
+
+Cordialement,
+{cfg:site_name}
+
+{alternative:html}
+
+<p>
+    Madame, Monsieur,
+</p>
+
+<p>
+    Vous avez téléchargé des fichiers dans votre bon de visite.
+</p>
+
+<table rules="rows">
+    <thead>
+        <tr>
+            <th colspan="2">Voucher details</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Invité</td>
+            <td><a href="mailto:{guest.email}">{guest.email}</a></td>
+        </tr>
+        <tr>
+            <td>Lien Voucher</td>
+            <td><a href="{cfg:site_url}?s=upload&vid={guest.token}">{cfg:site_url}?s=upload&vid={guest.token}</a></td>
+        </tr>
+        <tr>
+            <td>Lien de téléchargement</td>
+            <td><a href="{transfer.download_link}">{transfer.download_link}</a></td>
+        </tr>
+        <tr>
+            <td>Valable jusque</td>
+            <td>{date:guest.expires}</td>
+        </tr>
+    </tbody>
+</table>
+
+<p>
+    Cordialement,<br />
+    {cfg:site_name}
+</p>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -145,7 +145,6 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                         
                     </div>
                 </td>
-                
                 <td class="box">
                     <?php
                         $displayoption = function($name, $cfg, $disable = false) {


### PR DESCRIPTION
When the guest performs an upload, a dialog box is presented offering the download link. If the user does not record this link right at the time then there is no way they can get it again later. Emailing the link to the user allows them access to it at a later time if they want to resend it to somebody.