### PR TITLE
Make the UI work for link/nolink guest setups

### DIFF
--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -65,9 +65,6 @@
                             $checked = $default ? 'checked="checked"' : '';
                             $extraDivAttrs = '';
                             $hidden = '';
-                            if( $name == 'get_a_link' ) {
-                                $extraDivAttrs .= ' hidden="true" ';
-                            }
                             if($transfer && in_array($name, array(TransferOptions::REDIRECT_URL_ON_COMPLETE))) {
                                 echo '<div class="fieldcontainer" data-option="'.$name.'" '. $extraDivAttrs .'>';
                                 echo '    <label for="'.$name.'">'.Lang::tr($name).'</label>';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -154,7 +154,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                             $default = $cfg['default'];
                             if(Auth::isSP() && !$text)
                                 $default = Auth::user()->defaultTransferOptionState($name);
-                            
+
                             $checked = $default ? 'checked="checked"' : '';
                             $disabled = $disable ? 'disabled="disabled"' : '';
                             $extraDivAttrs = '';
@@ -162,9 +162,6 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                                 if( Config::get('guest_upload_page_hide_unchangable_options')) {
                                     $extraDivAttrs .= ' hidden="true" ';
                                 }
-                            }
-                            if(Auth::isGuest() && $name == 'get_a_link' ) {
-                                $extraDivAttrs .= ' hidden="true" ';
                             }
                             echo '<div class="fieldcontainer" data-option="'.$name.'" '. $extraDivAttrs .'>';
                             if($text) {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -889,6 +889,8 @@ $(function() {
                 i.val(transfer_options[option]);
             }
         }
+        form.find('input[name="get_a_link"]').trigger('change');
+        
     } else if(failed) {
         var id = failed.id;
         if(filesender.config.chunk_upload_security == 'key') {


### PR DESCRIPTION
With a little love this works either way the checkbox is selected. It is important to get it right as the guest may well be blocked from changing the get_a_link option so it needs to work by default either way to be useful.