### PR TITLE
avoid hitting index size limit on mysql

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -48,7 +48,7 @@ class User extends DBObject {
     protected static $dataMap = array(
         'id' => array(
             'type' => 'string',
-            'size' => 255,
+            'size' => 190,
             'primary' => true
         ),
         'additional_attributes' => array(


### PR DESCRIPTION
If the user is on a mysql type database and has character encodings that take 4 bytes per character then using varchar(255) will fail to create an index. The simple fix is to only allow email addresses up to 190 bytes long.