### PR TITLE
make strings 190 chars for possible sec indexing in mysql

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -53,20 +53,20 @@ class AuditLog extends DBObject {
         ),
         'target_type' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'target_id' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'author_type' => array(
             'type' => 'string',
-            'size' => 255,
+            'size' => 190,
             'null' => true
         ),
         'author_id' => array(
             'type' => 'string',
-            'size' => 255,
+            'size' => 190,
             'null' => true
         ),
         'ip' => array(

--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -59,11 +59,11 @@ class File extends DBObject
         ),
         'name' => array(
             'type' => 'string',
-            'size' => 255,
+            'size' => 190,
         ),
         'mime_type' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'size' => array(
             'type' => 'uint',

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -49,7 +49,7 @@ class Guest extends DBObject {
         ),
         'user_id' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'user_email' => array(
             'type' => 'string',
@@ -62,7 +62,7 @@ class Guest extends DBObject {
         ),
         'email' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'transfer_count' => array(
             'type' => 'uint',
@@ -70,7 +70,7 @@ class Guest extends DBObject {
         ),
         'subject' => array(
             'type' => 'string',
-            'size' => 255,
+            'size' => 190,
             'null' => true
         ),
         'message' => array(

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -55,7 +55,7 @@ class Recipient extends DBObject {
         ),
         'email' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'token' => array(
             'type' => 'string',

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -53,7 +53,7 @@ class StatLog extends DBObject {
         ),
         'target_type' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'size' => array(
             'type' => 'int',

--- a/classes/data/TrackingEvent.class.php
+++ b/classes/data/TrackingEvent.class.php
@@ -54,11 +54,11 @@ class TrackingEvent extends DBObject
         ),
         'target_type' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'target_id' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'details' => array(
             'type' => 'text'

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -51,11 +51,11 @@ class TranslatableEmail extends DBObject {
         ),
         'context_type' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'context_id' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'token' => array(
             'type' => 'string',
@@ -63,7 +63,7 @@ class TranslatableEmail extends DBObject {
         ),
         'translation_id' => array(
             'type' => 'string',
-            'size' => 255
+            'size' => 190
         ),
         'variables' => array(
             'type' => 'text',

--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -321,7 +321,7 @@ class DatabaseMysql {
                 break;
             
             case 'string':
-                $size = array_key_exists('size', $definition) ? $definition['size'] : '255';
+                $size = array_key_exists('size', $definition) ? $definition['size'] : '190';
                 $mysql = 'VARCHAR('.$size.')';
                 break;
             


### PR DESCRIPTION
Sometimes folks use four byte character encodings in mysql. it seems there are combinations out there that only allow 190(x4) bytes to be indexed as primary or secondary indexes. So if it doesn't matter if a string is 190 or 255 chars long, maybe we should make it 190 so that we can add a secondary index to the column later if desired without having to think about column truncation at that time.

I still have to run over these changes to reason able if they truncate something that will feel it.
