### PR TITLE
Import some of the docs from assembla

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -1,7 +1,7 @@
 <ul>
 	<li><a href="{{site.baseurl}}/">FileSender Documentation</a>
 	<ul>
-		<li><a href="{{site.baseurl}}/roadmap/">Roadmap</a>
+		<li><a href="{{site.baseurl}}/roadmap">Roadmap</a>
 	</ul>
 	<li><a href="{{site.baseurl}}/v2.0/">Documentation v2.0-beta</a>
 	<ul>

--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -1,7 +1,9 @@
 <ul>
 	<li><a href="{{site.baseurl}}/">FileSender Documentation</a>
 	<ul>
-		<li><a href="{{site.baseurl}}/roadmap">Roadmap</a>
+  	        <li><a href="{{site.baseurl}}/roadmap">Roadmap</a>
+	        <li><a href="{{site.baseurl}}/mailinglist">Mailing List</a>
+                <li><a href="{{site.baseurl}}/socialmedia">Social (Blog, Twitter)</a>
 	</ul>
 	<li><a href="{{site.baseurl}}/v2.0/">Documentation v2.0-beta</a>
 	<ul>

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,5 +1,25 @@
 # Acknowledgements
 
+## Acknowledgements for v2.0
+
+The FileSender project wishes to acknowledge the following people and
+organisations for their contributions to the FileSender 2.0 release.
+
+### Funding
+
+Sustained funding, staff and other resources for the FileSender
+project are provided by the National Research and Educational Networks
+(NRENs) AARNet (Australia), BELNET (Belgium), HEAnet (Ireland),
+SURFnet (The Netherlands) and UNINETT (Norway).
+
+### Core development team (incomplete)
+
+* Ben Martin: code lead, software architect
+* Guido Aben, AARNet: 2nd project lead, field testing, finances coordination
+* Jan Meijer, UNINETT: project lead, field testing, documentation
+
+
+
 ## Acknowledgements for v1-6
 
 The FileSender project wishes to acknowledge the following people and
@@ -11,8 +31,6 @@ Sustained funding, staff and other resources for the FileSender
 project are provided by the National Research and Educational Networks
 (NRENs) AARNet (Australia), BELNET (Belgium), HEAnet (Ireland),
 SURFnet (The Netherlands) and UNINETT (Norway).
-
- 
 
 For the 1.6 release FileSender received targeted financial
 contributions from ARNES (Slovenia), CSC/FUNET (Finland).
@@ -43,7 +61,6 @@ contributions from ARNES (Slovenia), CSC/FUNET (Finland).
 * Thijs Kinkhorst, Tilburg University, the Netherlands, for his solid patches
 * The User Experience group (in particular Dharani Perera-Schulz), eSolutions, Monash University, Australia, for conducting a Usability and interaction design review
 * UNINETT Feide RnD for supplying Feide Open IdP as a public service
-* 
 * Pine Security, the Netherlands was contracted for the code security reviews
 * Nakamura Motonori, NII, Japan for suggesting to include the download status of a file in MyFiles, triggering the Myfiles update in version 1.6
 * Emiel Florijn, the Netherlands, for spotting and reporting a security issue
@@ -75,3 +92,111 @@ FileSender core team.
 
 Despite our best efforts we might have forgotten someone. Please drop
 us a line on filesender-dev@filesender.org if you spot any omissions.
+
+
+
+## Acknowledgements for v1-5
+
+
+The FileSender project wishes to acknowledge the following people and
+organisations for their contributions to the FileSender 1.5 release.
+
+### Funding
+
+Sustained funding, staff and other resources for the FileSender
+project are provided by the National Research and Educational Networks
+(NRENs) AARNet (Australia), HEAnet (Ireland), SURFnet (The
+Netherlands) and UNINETT (Norway).
+
+For the 1.5 release FileSender received targeted financial
+contributions from ARNES (Slovenia), Belnet (Belgium), CSC/FUNET
+(Finland), CESNET (Czech Republic), the Hebrew University of Jerusalem
+(Israel) and UNI-C (Denmark).
+
+### Core development team
+
+* Chris Richter, Ricoshae: code lead, software architect
+* Guido Aben, AARNet: 2nd project lead, field testing, finances coordination
+* Jan Meijer, UNINETT: project lead, field testing, documentation
+* Xander Jansen, SURFnet: release manager, bug analysis, coding, field testing, release testing lead,  documentation
+* Wendy Mason, Monash e-Research Centre: workflow testing lead, client-side workflow test automation, client-side release testing, documentation
+
+### Significant contributions
+
+* Alan Lo, Victorian Partnership for Advanced Computing (VPAC), Australia, for advice on selection & use of Selenium for automated testing
+* Bartlomiej Balcerek, Wroclaw Centre for Networking and Supercomputing, Poland, for conducting a security review of FileSender
+* David Jericho, AARnet, Australia for feedback, field testing and patches
+* Dick Visser, TERENA, the Netherlands, for his solid patches
+* Mario Vandaele, BELNET, Belgium for his feedback, field testing and patches
+* Maciej Kotowicz, Wroclaw Centre for Networking and Supercomputing, Poland, for conducting a security review of FileSender
+* Rogier Spoor, SURFnet, the Netherlands, for provisioning resources
+* Thijs Kinkhorst, Tilburg University, the Netherlands, for his solid patches
+* The User Experience group (in particular Dharani Perera-Schulz), eSolutions, Monash University, Australia, for conducting a Usability and interaction design review
+* UNINETT Feide RnD for supplying Feide Open IdP as a public service
+* Funka.nu, Sweden, was contracted for a usability review
+* Maarten Koopmans, Vrijheid.net, the Netherlands, was contracted for significant coding and architecture contributions
+* Pine Security, the Netherlands was contracted for the code security reviews
+
+### Translations
+
+Language files were contributed by: 
+
+* Andrej Bagon, ARNES, Slovenia: Slovenian
+* Claude Tompers, RESTENA, Luxemburg: French, German
+* Csillag Tamas, PPKE, Hungary: Hungarian
+* Fabio Spelta, UNIMIB, Italy: Italian
+* Lubos Kopecky, CESNET, Czech Republic: Czech
+* Marina Vermezovic, Amres, Serbia: Serbian
+* Nikola Garafolic, SRCE, Croatia: Croatian
+* Paco Sanchez, UNIA: Spanish
+* Riccardo Valzorio, CILEA, Italy: Italian
+* Víctor José Hernández Gómez, UPO, Spain: Spanish
+* Victoriano Giralt, University of Malaga, Spain: Spanish
+
+The Dutch, English and Norwegian language files were provided by the FileSender core team.
+
+
+### Did we miss someone?
+
+Despite our best efforts we might have forgotten someone.  Please drop us a line on filesender-dev@filesender.org if you spot any omissions.
+
+
+## Acknowledgements for v1-0
+
+### Acknowledgements 1.0 release
+
+The FileSender project wishes to acknowledge the following people and
+organisations for their contributions to the FileSender 1.0 release.
+
+The FileSender project is funded by a consortium of NRENs. For the 1.0
+release funding and staff resources were made available by AARNet,
+HEAnet, SURFnet and UNINETT
+
+### Core development team
+
+* Chris Richter (coding, architect)
+* Gijs Molenaar (coding, packaging, documentation)
+* Guido Aben (project coordination, field testing)
+* Jan Meijer (project coordination, field testing, documentation)
+* Xander Jansen (testing, bug fixing, coding, release manager, documentation)
+* Wendy Mason (testing, documentation)
+
+### Significant contributions:
+
+* Brian Boyle (project coordination and feedback)
+* Rogier Spoor (resource provisioning)
+* Markus Steinbacher (coding)
+* Paul Doyle (release process)
+* Hong Shuliang (testing framework)
+* Rene Scheffer of Stroomt (UI expert review)
+* Pine Security for the code security reviews
+* Jaap de Heer, Paul von Winckelmann of StreamTech in the Netherlands for fixing the security issues
+* Mario Vandaele of  BELNET in Belgium for his feedback, field testing and patches
+* Damir Danijel Zagar, Emir Imamagic and Nikola Garafolic of SRCE in Croatia for their feedback, field testing, patches and the usage stats code
+* João Pagaime of FCCN in Portugal for his feedback and field testing.
+* Hanne Moa of UNINETT in Norway for feedback and field testing
+* David Jericho of AARnet in Australia for feedback, field testing and patches
+* Paul Dekkers of SURFnet, the Netherlands, for his work on SRS with Exim
+
+Despite our efforts to include all contributors we might have
+forgotten someone. Please let us know of any oversight.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,77 @@
+# Acknowledgements
+
+## Acknowledgements for v1-6
+
+The FileSender project wishes to acknowledge the following people and
+organisations for their contributions to the FileSender 1.6 release.
+
+### Funding
+
+Sustained funding, staff and other resources for the FileSender
+project are provided by the National Research and Educational Networks
+(NRENs) AARNet (Australia), BELNET (Belgium), HEAnet (Ireland),
+SURFnet (The Netherlands) and UNINETT (Norway).
+
+ 
+
+For the 1.6 release FileSender received targeted financial
+contributions from ARNES (Slovenia), CSC/FUNET (Finland).
+
+### Core development team
+
+* Chris Richter, Ricoshae: code lead, software architect
+* Guido Aben, AARNet: 2nd project lead, field testing, finances coordination
+* Jan Meijer, UNINETT: project lead, field testing, documentation
+* Xander Jansen, SURFnet: release manager, bug analysis, coding, field testing, release testing lead,  documentation
+* Wendy Mason, Monash e-Research Centre: workflow testing lead, client-side workflow test automation, client-side release testing, documentation  
+
+### New TeraSender upload module
+
+* René Klomp and Edwin Schaap for their work on the FileSender
+* TeraByte Challenge as part of their master in system and network
+* engineering at Amsterdam University (UvA). This work resulted in a
+* research report documenting how to increase the upload speed of
+* FileSender and in the new TeraSender upload module in version 1.6.
+* See the blog articles for details.
+
+### Significant contributions
+
+* David Jericho, AARnet, Australia for feedback, field testing and patches
+* Dick Visser, TERENA, the Netherlands, for his solid patches
+* Jean-Philippe Evrard, BELNET, Belgium for the customisable footer
+* Rogier Spoor, SURFnet, the Netherlands, for provisioning resources
+* Thijs Kinkhorst, Tilburg University, the Netherlands, for his solid patches
+* The User Experience group (in particular Dharani Perera-Schulz), eSolutions, Monash University, Australia, for conducting a Usability and interaction design review
+* UNINETT Feide RnD for supplying Feide Open IdP as a public service
+* 
+* Pine Security, the Netherlands was contracted for the code security reviews
+* Nakamura Motonori, NII, Japan for suggesting to include the download status of a file in MyFiles, triggering the Myfiles update in version 1.6
+* Emiel Florijn, the Netherlands, for spotting and reporting a security issue
+
+
+### Translations
+
+Language files were contributed by: 
+
+* Andrej Bagon, ARNES, Slovenia: Slovenian
+* Claude Tompers, RESTENA, Luxemburg: French, German
+* Csillag Tamas, PPKE, Hungary: Hungarian
+* Fabio Spelta, UNIMIB, Italy: Italian
+* Lubos Kopecky, CESNET, Czech Republic: Czech
+* Marina Vermezovic, Amres, Serbia: Serbian
+* Nikola Garafolic, SRCE, Croatia: Croatian
+* Paco Sanchez, UNIA: Spanish
+* Riccardo Valzorio, CILEA, Italy: Italian
+* Tomi Salmi, CSC/Funet, Finland: Finnish
+* Víctor José Hernández Gómez, UPO, Spain: Spanish
+* Victoriano Giralt, University of Malaga, Spain: Spanish
+
+
+The Dutch, English and Norwegian language files were provided by the
+FileSender core team.
+
+
+### Did we miss someone?
+
+Despite our best efforts we might have forgotten someone. Please drop
+us a line on filesender-dev@filesender.org if you spot any omissions.

--- a/docs/mailinglist.md
+++ b/docs/mailinglist.md
@@ -1,0 +1,47 @@
+# Support and Mailing lists
+
+## FileSender uses three mailinglists and a ticketing system:
+
+* Announcements: filesender-announce@filesender.org
+* Support and development discussion: filesender-dev@filesender.org
+* Bugs: [GitHub Issue Tracker](https://github.com/filesender/filesender/issues)
+* Track: [Github commits](https://github.com/filesender/filesender/commits/master)
+
+## Announcements
+
+The FileSender project uses a mailinglist to announce new releases and important news:
+
+filesender-announce@filesender.org
+
+To subscribe send an email to sympa@filesender.org with 'subscribe
+filesender-announce' in the subject or the body of the mail.
+Alternatively you can go to the Sympa mailinglist server web interface
+and subscribe yourself there.
+
+[The mailinglist archive can be found
+here](https://postlister.uninett.no/sympa_filesender/arc/filesender-announce)
+
+## Support and development discussion
+
+The FileSender project uses one mailinglist to coordinate the
+development and provide support to the user community:
+
+     filesender-dev@filesender.org
+
+To subscribe send an email to sympa@filesender.org with 'subscribe
+filesender-dev' in the subject or the body of the mail. Alternatively
+you can go to the [Sympa mailinglist server web interface](https://postlister.uninett.no/sympa_filesender/info/filesender-dev) and subscribe
+yourself there.
+
+Non-subscribers can also send emails to the list - note that those
+emails are moderated by one of three list-owners, so it can take a
+little while before your email gets through.
+
+[The mailinglist archive can be found
+here](https://postlister.uninett.no/sympa_filesender/arc/filesender-dev)
+
+## Bugs
+
+Please inspect and report bugs on the [GitHub Issue
+Tracker](https://github.com/filesender/filesender/issues)
+

--- a/docs/socialmedia.md
+++ b/docs/socialmedia.md
@@ -1,0 +1,8 @@
+# Social Media
+
+Interested parties can monitor feature updates and coding directions
+by subscribing to the [Developer Mailing List](/mailinglist).
+Announcments will also appear on the
+[blog](http://blog.filesender.org) and our Twitter account,
+[@filesender](https://twitter.com/filesender).
+

--- a/docs/v2.0/release/index.md
+++ b/docs/v2.0/release/index.md
@@ -1,0 +1,74 @@
+# Release Process
+
+Here you can find how to make a new release for filesender. Details of
+past and planned filesender releases are listed in the release
+schedule.
+
+## Source packages
+
+* First make sure that you really want to make a release. No files should be changed from this point, except for files containing version numbers and changelog.
+* Make a tag in git.
+
+```
+$ git tag filesender-release-version-2.0beta1
+```
+
+* Edit the files containing version numbers and changelogs. Commit this to the branch.
+* Visit the [GitHub release page](https://github.com/filesender/filesender/releases)
+  and click on [Draft a new release](https://github.com/filesender/filesender/releases/new).
+* In the tag version selection enter your git tag that you created above.
+* The release title and description should follow the style of the last release on
+  the [release page](https://github.com/filesender/filesender/releases).
+* Do not worry about attaching files, github will take tar.gz snapshots from the repository for you.
+* Record the link to this new release. For example: https://github.com/filesender/filesender/releases/tag/filesender-2.0-beta1
+* Edit the Development Status section on the home page to reflect the current release number and release date.
+* Send the release announcement email as plain text (NO HTML!) using the following email template:
+
+```
+    To: filesender-announce@filesender.org
+    Cc: filesender-dev@filesender.org
+    Subject: New FileSender Released: version N.nn 
+
+    Hi,
+
+    A new FileSender release is now available for download.
+    Please see the releases page for full details and information
+    on how to obtain, install, and migrate to this release
+    
+    https://github.com/filesender/filesender/releases/
+
+    Cheers.
+```
+    
+
+## Debian package
+
+```
+FIXME: update for 2.0 epoch
+```
+
+Requirements: a debian system
+
+* Make sure you have all debian packaging tools installed $ sudo apt-get install devscripts
+* To sign the packages you need your the filesender-dev key in your gnupg configuration.
+* Do a clean export of the tag $ svn export http://subversion.assembla.com/svn/file_sender/filesender/tags/filesender-
+* inside the exported folder run $ dpkg-buildpackage
+* Debian packages will be in the parent
+* You can add the debian package to the stable repository by running $ reprepro -b /var/www/debian/ includedeb stable filesenderall.deb
+* You can also add the source to the source stable repo: $ reprepro -b /var/www/debian/ includedsc stable *.dsc
+
+## RPM package
+
+```
+FIXME: update for 2.0 epoch
+```
+
+* Make sure you have RPM installed: $ sudo apt-get install rpm
+* Create the required directory structure: mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS,TMP}
+* To sign the packages you need to put this in ~/.rpmmacros %signature gpg %gpg_name Filesender Development filesender-dev@filesender.org Also make sure the filesender-dev private key is in your gnupg configuration
+* Put the specs file from http://subversion.assembla.com/svn/file_sender/filesender/tags/filesender- in rpmbuild/SPECS
+* Put the source tarball, patches and extra files in rpmbuild/SOURCES. The required files are listed in the spec file and can be found in http://subversion.assembla.com/svn/file_sender/filesender/tags/filesender-
+* run rpmbuild -ba --sign rpmbuild/SPECS/*.spec
+* If everything went well the RPM's will be in rpmbuild/RPMS
+* to publish the RPM copy it to /var/www/rpm/stable
+* Update the yum repository database: $ cd /var/www/rpm/stable $ createrepo -o . .


### PR DESCRIPTION
Use of Assembla is being decommissioned. These are a few pages from the old wiki which seems useful to have on the new github based site. There may be more to import, and the releases instructions need some more freshing up love for sure.