### PR TITLE
see how well php 5.6 works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+dist: precise
+sudo: required
 language: php
 php:
-- 5.6
+- 5.3
 addons:
   sauce_connect:
     username: "$SAUCE_USERNAME"
@@ -33,9 +35,9 @@ before_script:
 - sudo sed -i "s/error_reporting = E_ALL/error_reporting = E_ALL \& ~E_DEPRECATED
   \& ~E_STRICT/" ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sudo sed -i "s/host    all             all             127.0.0.1\/32            trust/host    all             all             127.0.0.1\/32            md5/"
-  /etc/postgresql/9.3/main/pg_hba.conf
+  /etc/postgresql/9.1/main/pg_hba.conf
 - sudo sed -i "s/host    all             all             ::1\/128                 trust/host    all             all             ::1\/128                 md5/"
-  /etc/postgresql/9.3/main/pg_hba.conf
+  /etc/postgresql/9.1/main/pg_hba.conf
 - sudo sed -i "s/NameVirtualHost \*:80/# NameVirtualHost \*:80/" /etc/apache2/ports.conf
 - sudo sed -i "s/Listen 80/# Listen 80/" /etc/apache2/ports.conf
 - "~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ before_script:
 - sudo sed -i "s/error_reporting = E_ALL/error_reporting = E_ALL \& ~E_DEPRECATED
   \& ~E_STRICT/" ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - sudo sed -i "s/host    all             all             127.0.0.1\/32            trust/host    all             all             127.0.0.1\/32            md5/"
-  /etc/postgresql/9.1/main/pg_hba.conf
+  /etc/postgresql/9.3/main/pg_hba.conf
 - sudo sed -i "s/host    all             all             ::1\/128                 trust/host    all             all             ::1\/128                 md5/"
-  /etc/postgresql/9.1/main/pg_hba.conf
+  /etc/postgresql/9.3/main/pg_hba.conf
 - sudo sed -i "s/NameVirtualHost \*:80/# NameVirtualHost \*:80/" /etc/apache2/ports.conf
 - sudo sed -i "s/Listen 80/# Listen 80/" /etc/apache2/ports.conf
 - "~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-- 5.3
+- 5.6
 addons:
   sauce_connect:
     username: "$SAUCE_USERNAME"


### PR DESCRIPTION
not a bad test, the CI worked fine before, so if anything breaks now it will be due to the distro and php 5.3 to php 5.6 update. 

So the main thing for this PR to evolve to do is getting the CI going again. Hopefully without resorting to forcing the use of an outdated distro in order to use 5.3 again. Keeping the CI modernish is likely better for all. A followup might be useful after a survey to see if everybody is using a later php version. Best to test in the CI using the same version that most folks want to use.