### PR TITLE
sysadmin: Help the sysadmin with missing SAML attributes

### DIFF
--- a/classes/auth/AuthSPFake.class.php
+++ b/classes/auth/AuthSPFake.class.php
@@ -84,9 +84,13 @@ class AuthSPFake {
             }
             
             // Check attributes
-            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid',$attributes);
+            if(!$attributes['uid'])
+                throw new AuthSPMissingAttributeException(
+                    'uid',$attributes,'uid','uid');
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
+            if(!$attributes['email'])
+                throw new AuthSPMissingAttributeException(
+                     'email',$attributes,'email','email');
             
             if(!is_array($attributes['email'])) $attributes['email'] = array($attributes['email']);
             

--- a/classes/auth/AuthSPFake.class.php
+++ b/classes/auth/AuthSPFake.class.php
@@ -84,9 +84,9 @@ class AuthSPFake {
             }
             
             // Check attributes
-            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid');
+            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid',$attributes);
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email');
+            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
             
             if(!is_array($attributes['email'])) $attributes['email'] = array($attributes['email']);
             

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -108,9 +108,12 @@ class AuthSPSaml {
             if(!$attributes['uid'])
                 throw new AuthSPMissingAttributeException(
                     'uid', $raw_attributes,
-                    self::$config['uid_attribute']);
+                    'uid_attribute',self::$config['uid_attribute']);
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
+            if(!$attributes['email'])
+                throw new AuthSPMissingAttributeException(
+                    'email',$raw_attributes,
+                    'email_attribute',self::$config['email_attribute']);
             
             foreach($attributes['email'] as $email) {
                 if(!Utilities::validateEmail($email)) throw new AuthSPBadAttributeException('email');

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -105,9 +105,12 @@ class AuthSPSaml {
             if(is_array($attributes['uid'])) $attributes['uid'] = array_shift($attributes['uid']);
             if(is_array($attributes['name'])) $attributes['name'] = array_shift($attributes['name']);
             
-            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid');
+            if(!$attributes['uid'])
+                throw new AuthSPMissingAttributeException(
+                    'uid', $raw_attributes,
+                    self::$config['uid_attribute']);
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email');
+            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
             
             foreach($attributes['email'] as $email) {
                 if(!Utilities::validateEmail($email)) throw new AuthSPBadAttributeException('email');

--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -99,9 +99,9 @@ class AuthSPShibboleth {
             if(is_array($attributes['uid'])) $attributes['uid'] = array_shift($attributes['uid']);
             if(is_array($attributes['name'])) $attributes['name'] = array_shift($attributes['name']);
             
-            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid');
+            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid',$attributes);
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email');
+            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
             
             foreach($attributes['email'] as $email) {
                 if(!Utilities::validateEmail($email)) throw new AuthSPBadAttributeException('email');

--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -99,9 +99,13 @@ class AuthSPShibboleth {
             if(is_array($attributes['uid'])) $attributes['uid'] = array_shift($attributes['uid']);
             if(is_array($attributes['name'])) $attributes['name'] = array_shift($attributes['name']);
             
-            if(!$attributes['uid']) throw new AuthSPMissingAttributeException('uid',$attributes);
+            if(!$attributes['uid'])
+                throw new AuthSPMissingAttributeException(
+                    'uid',$attributes,'uid_attribute',self::$config['uid_attribute']);
             
-            if(!$attributes['email']) throw new AuthSPMissingAttributeException('email',$attributes);
+            if(!$attributes['email'])
+                throw new AuthSPMissingAttributeException(
+                     'email',$attributes,'email_attribute',self::$config['email_attribute']);
             
             foreach($attributes['email'] as $email) {
                 if(!Utilities::validateEmail($email)) throw new AuthSPBadAttributeException('email');

--- a/classes/exceptions/AuthSPExceptions.class.php
+++ b/classes/exceptions/AuthSPExceptions.class.php
@@ -70,16 +70,27 @@ class AuthSPAuthenticationNotFoundException extends DetailedException {
 class AuthSPMissingAttributeException extends DetailedException {
     /**
      * Constructor
-     * 
+     *
+     * The $attributes array is used to furnish the server only log
+     * file with the current data to allow the system admin to see
+     * possible key mismatches.
+     *
      * @param string $name name of the attribute
+     * @param array  $attributes array of key-value where a key of $name should have been found
      */
-    public function __construct($name) {
+    public function __construct($name,$attributes,$attrname='not given') {
         $info = array('attribute' => $name);
         
         $lid = 'auth_sp_attribute_'.$name.'_hint';
         $hint = (string)Lang::tr($lid);
         if($hint != '{'.$lid.'}') $info['hint'] = $hint;
-        
+
+        // Give the system admin some information to help them fix things
+        $internalLog = DetailedException::convertArrayToLogArray($attributes,'    ');
+        $this->log( 'attributes', (string)Lang::tr('serverlog_auth_sp_attribute_not_found'));
+        $this->log( 'attributes', Lang::tr('serverlog_wanted_key_in_array')->r('key',$attrname));
+        $this->logArray( 'attributes', $internalLog );
+
         parent::__construct('auth_sp_missing_attribute', null, $info);
     }
 }

--- a/classes/exceptions/AuthSPExceptions.class.php
+++ b/classes/exceptions/AuthSPExceptions.class.php
@@ -78,7 +78,7 @@ class AuthSPMissingAttributeException extends DetailedException {
      * @param string $name name of the attribute
      * @param array  $attributes array of key-value where a key of $name should have been found
      */
-    public function __construct($name,$attributes,$attrname='not given') {
+    public function __construct($name,$attributes,$attrkey,$attrname='') {
         $info = array('attribute' => $name);
         
         $lid = 'auth_sp_attribute_'.$name.'_hint';
@@ -88,6 +88,7 @@ class AuthSPMissingAttributeException extends DetailedException {
         // Give the system admin some information to help them fix things
         $internalLog = DetailedException::convertArrayToLogArray($attributes,'    ');
         $this->log( 'attributes', (string)Lang::tr('serverlog_auth_sp_attribute_not_found'));
+        $this->log( 'attributes', Lang::tr('serverlog_config_directive')->r('key',$attrkey));
         $this->log( 'attributes', Lang::tr('serverlog_wanted_key_in_array')->r('key',$attrname));
         $this->logArray( 'attributes', $internalLog );
 

--- a/classes/exceptions/Exceptions.class.php
+++ b/classes/exceptions/Exceptions.class.php
@@ -53,7 +53,8 @@ class LoggingException extends Exception {
      * @param mixed $log lines to log by categories
      */
     public function __construct($msg_code, $log = null) {
-        $this->uid = uniqid();
+        if( !$this->uid )
+             $this->uid = uniqid();
         
         // normalize arguments
         if(!$log) $log = $msg_code;
@@ -61,27 +62,53 @@ class LoggingException extends Exception {
             $log = array('exception' => $log);
         
         // Log info
-        if ($log) 
+        if ($log) {
             foreach ($log as $category => $lines) {
                 if (!is_array($lines)) 
                     $lines = array($lines);
                 
-                foreach ($lines as $line) 
-                    Logger::error(
-                        '['.get_class($this).' '.
-                        $category.' uid:'.$this->uid.'] '.$line
-                    ); //insert get_class($this) before $category (concatenate them)
+                foreach ($lines as $line)
+                    $this->log( $category, $line );
             }
+        }
         
         parent::__construct($msg_code);
     }
-    
+
+    /**
+     * Log an exception line with the detail message groupmsg.
+     * You can use groupmsg to cluster data from a single array into
+     * a block in the log so folks know where the dump starts and ends.
+     *
+     * @param string $groupmsg something about the line
+     * @param string $line     the line to log
+     */
+    function log($groupmsg,$line)
+    {
+        Logger::error(
+            '['.get_class($this).' '.
+            $groupmsg.' uid:'.$this->getUid().'] '.$line
+        );
+    }
+
+    /**
+     * Log the whole array as a series of lines with log($groupmsg,$line)
+     */
+    function logArray($groupmsg,$arr)
+    {
+        foreach ($arr as $line) {
+           LoggingException::log($groupmsg,$line);
+        }
+    }
+     
     /**
      * Uid getter
      * 
      * @return string the exception uid
      */
     public function getUid() {
+        if( !$this->uid )
+             $this->uid = uniqid();
         return $this->uid;
     }
 }
@@ -123,9 +150,24 @@ class DetailedException extends LoggingException {
             'trace' => explode("\n", $this->getTraceAsString()),
             'details' => array(),
         );
-        
-        // Cast to string(s)
-        foreach ($internal_details as $key => $detail) {
+
+        $log['details'] = $this->convertArrayToLogArray($internal_details);
+        parent::__construct($msg_code, $log);
+    }
+
+    /**
+     * Convert the array $arr to a logable array which is suitable
+     * to be passed to LoggingException::__construct()
+     *
+     * @param array arr the array to convert to something that can be logged
+     * @param string prefix optional prefix for each key so you can indent in the log
+     *
+     * @return array the same data as $arr but in a log friendly format
+     */
+    public static function convertArrayToLogArray($arr,$prefix='')
+    {
+        $ret = array();
+        foreach ($arr as $key => $detail) {
             $key = is_int($key) ? '' : $key.' = ';
             
             if (is_scalar($detail)) {
@@ -135,14 +177,14 @@ class DetailedException extends LoggingException {
                     $detail = '"'.$detail.'"';
                 }
                 
-                $log['details'][] = $key.$detail;
+                $ret[] = $prefix.$key.$detail;
             } else {
                 foreach (explode("\n", print_r($detail, true)) as $line) {
-                    $log['details'][] = $key.$line;
+                    $ret[] = $prefix.$key.$line;
                 }
             }
         }
-        parent::__construct($msg_code, $log);
+        return $ret;
     }
     
     /**

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -426,6 +426,8 @@ $lang['auth_sp_missing_delegation_class'] = 'SP authentification delegation clas
 $lang['auth_sp_authentication_not_found'] = 'SP authentification class not found';
 $lang['auth_sp_missing_attribute'] = 'SP authentification attribute not found';
 $lang['auth_sp_bad_attribute'] = 'SP authentification bad attribute';
+$lang['serverlog_auth_sp_attribute_not_found'] = 'These are the attributes that are available at auth time. Perhaps double check that the spelling of the attribute name is correct. Maybe the configuration is looking for the wrong attribute?';
+$lang['serverlog_wanted_key_in_array'] = 'Wanted an attribute with key \'{key}\'';
 
 // Bad exceptions
 $lang['bad_email'] = 'Invalid email format';

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -426,7 +426,8 @@ $lang['auth_sp_missing_delegation_class'] = 'SP authentification delegation clas
 $lang['auth_sp_authentication_not_found'] = 'SP authentification class not found';
 $lang['auth_sp_missing_attribute'] = 'SP authentification attribute not found';
 $lang['auth_sp_bad_attribute'] = 'SP authentification bad attribute';
-$lang['serverlog_auth_sp_attribute_not_found'] = 'These are the attributes that are available at auth time. Perhaps double check that the spelling of the attribute name is correct. Maybe the configuration is looking for the wrong attribute?';
+$lang['serverlog_auth_sp_attribute_not_found'] = 'There has been trouble finding a SP auth attribute. These are the attributes that are available at auth time. Perhaps double check that the spelling of the attribute name is correct. Maybe the configuration is looking for the wrong attribute?';
+$lang['serverlog_config_directive'] = 'Related configuration directive \'{key}\'';
 $lang['serverlog_wanted_key_in_array'] = 'Wanted an attribute with key \'{key}\'';
 
 // Bad exceptions


### PR DESCRIPTION
When a key is mistyped or the sysadmin is expecting different keys in the auth session than are there then things can be hard to debug. For example, using a local user/password in simplesaml one might select the wrong uid attribute but have no idea what the right choice is. With this serverlogging then the sysadmin gets some more clues that can be found with the finding out details hex string from the browser.
