### PR TITLE
Allow CGI parameter separator to be configured

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -162,10 +162,11 @@ class AuthSPSaml {
             $target = Config::get('site_url').'index.php?s='.$landing_page;
         }
         
-        $url = self::$config['simplesamlphp_url'].'module.php/core/as_login.php?';
-        $url .= 'AuthId='.self::$config['authentication_source'];
-        $url .= '&ReturnTo='.urlencode($target);
-        
+        $url = Utilities::http_build_query(array(
+            'AuthId' => self::$config['authentication_source'],
+            'ReturnTo' => $target,
+        ), self::$config['simplesamlphp_url'].'module.php/core/as_login.php?' );
+
         return $url;
     }
     

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -258,7 +258,9 @@ class Recipient extends DBObject {
         }
         
         if($property == 'download_link') {
-            return Config::get('site_url').'?s=download&token='.$this->token;
+            return Utilities::http_build_query(
+                array( 's'     => 'download',
+                       'token' => $this->token ));
         }
         
         if($property == 'downloads') {

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -208,11 +208,11 @@ class TranslatableEmail extends DBObject {
             case 'Recipient': // Recipient context is it's transfer
                 $context = $to->transfer;
                 break;
-            
+                
             case 'Guest' : // Guest is a context by itself
                 $context = $to;
                 break;
-            
+                
             case 'User' : // If recipient is user try to find Transfer, File or Guest in variables
                 foreach($vars as $v) {
                     if(!is_object($v)) continue;
@@ -327,7 +327,10 @@ class TranslatableEmail extends DBObject {
         if($property == 'context') return call_user_func($this->context_type.'::fromId', $this->context_id);
         
         if($property == 'link') {
-            return Config::get('site_url').'?s=translate_email&token='.$this->token;
+            return Utilities::http_build_query(
+                array( 's'     => 'translate_email',
+                       'token' => $this->token ));
+            
         }
         
         throw new PropertyAccessException($this, $property);

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -434,9 +434,15 @@ class Utilities {
             }
         }
         $ret = $path;
-        $ret .= http_build_query( $q, '',
-                                  config::get('filesender_arg_separator_output'),
-                                  PHP_QUERY_RFC3986 );
+        if( phpversion() < 5.4 ) {
+            // CIFIXME remove this branch when CI php is upgraded.
+            $ret .= http_build_query( $q, '',
+                                      config::get('filesender_arg_separator_output'));
+        } else {
+            $ret .= http_build_query( $q, '',
+                                      config::get('filesender_arg_separator_output'),
+                                      PHP_QUERY_RFC3986 );
+        }        
         return $ret;
     }
     

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -402,6 +402,43 @@ class Utilities {
     public static function sanitizeOutput($output) {
         return htmlentities($output, ENT_QUOTES, 'UTF-8');
     }
+
+    public static function startsWith($haystack, $needle)
+    {
+         $length = strlen($needle);
+         return (substr($haystack, 0, $length) === $needle);
+    }
+
+    /**
+     * This is a wrapper around the PHP http_build_query with some
+     * smarts. $path is optional and if not given will be the site itself.
+     * If path is given and is ^http then it is taken as the site url prefix.
+     * On the other hand if path is relative then it is converted to absolute
+     * by this call.
+     *
+     * CGI parameters are given in $q which can be an array like;
+     * array( 'foo' => 'bar', 'baz' => 7 )
+     *
+     * @param array q the CGI parameters
+     * @param string path either nothing (default), a relative prefox, or absolute url
+     *
+     * @return string full URL using path and query params using the user's specified
+     *                path separator (; can be useful here).
+     */
+    public static function http_build_query( $q, $path = null ) {
+        if( $path == null ) {
+            $path = Config::get('site_url') . '?';
+        } else {
+            if( !Utilities::startsWith($path, 'http' )) {
+                $path = Config::get('site_url') . $path;
+            }
+        }
+        $ret = $path;
+        $ret .= http_build_query( $q, '',
+                                  config::get('filesender_arg_separator_output'),
+                                  PHP_QUERY_RFC3986 );
+        return $ret;
+    }
     
     /**
      * Check if HTTPS is in use

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -23,6 +23,7 @@ title: Configuration directives
 * [site_logouturl](#sitelogouturl)
 * [about_url](#abouturl)
 * [help_url](#helpurl)
+* [filesender_arg_separator_output](#filesenderargseparatoroutput)
 
 ## Backend storage
 
@@ -277,6 +278,19 @@ title: Configuration directives
 * __available:__ since version 1.0
 * __1.x name:__ helpURL
 * __comment:__ when configured with a mailto: address that points to e.g. support@yourdomain.dom the email bounce handler will use this address to send unprocessable email bounces to. <span style="background-color:orange">include link to email bounce handling config directives/help</span>
+
+
+### filesender_arg_separator_output
+
+* __description:__ separator to use for CGI parameters.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ &
+* __available:__ since version 2.0
+* __comment:__ You might like to set this to ";" and edit your site php.ini to include the setting arg_separator.input = ";&"
+
+
+
 
 ---
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -134,6 +134,8 @@ $default = array(
     'autocomplete' => false, 
     'autocomplete_min_characters' => 3,
 
+    'filesender_arg_separator_output' => '&', 
+
     'user_page' => false,
     //'user_page' => array(
     //    'lang' => 'write',

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -22,16 +22,16 @@
     if(empty($transfer->options['encryption'])) {
         $fileIds = array();
         foreach($transfer->files as $file) {
-            $downloadLinks[$file->id] = GUI::path('download.php?' . http_build_query(array(
+            $downloadLinks[$file->id] = Utilities::http_build_query(array(
                 'token' => $token,
                 'files_ids' => $file->id,
-            )));
+            ), 'download.php?' );
             $fileIds[] = $file->id;
         }
-        $archiveDownloadLink = GUI::path('download.php?' . http_build_query(array(
+        $archiveDownloadLink = Utilities::http_build_query(array(
             'token' => $token,
             'files_ids' => implode(',', $fileIds),
-        )));
+        ), 'download.php?' );
     }
 
     $isEncrypted = isset($transfer->options['encryption']) && $transfer->options['encryption'];


### PR DESCRIPTION
This allows the separator for CGI parameters to be set to something other than "&". Note that you will have to ensure your php.ini allows your setting too. By setting the separator to ";" you can avoid conflicts with some email clients escaping the "&" too much for example. This issue was reported in https://github.com/filesender/filesender/issues/98.

This PR targets some specific locations and I have checked over some of the emails and links on the site to see the ";" appear if configured to do so.
