### PR TITLE
Reports: allow IP address to be hidden

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -24,6 +24,7 @@ title: Configuration directives
 * [about_url](#abouturl)
 * [help_url](#helpurl)
 * [filesender_arg_separator_output](#filesenderargseparatoroutput)
+* [reports_show_ip_addr](#reportsshowipaddr)
 
 ## Backend storage
 
@@ -293,6 +294,16 @@ title: Configuration directives
 * __default:__ &
 * __available:__ since version 2.0
 * __comment:__ You might like to set this to ";" and edit your site php.ini to include the setting arg_separator.input = ";&"
+
+
+### reports_show_ip_addr
+
+* __description:__ Show the IP addresses used in reports
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ true
+* __available:__ since version 2.0
+* __comment:__ If you want to hide IP addresses from reports set it to false
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -114,7 +114,9 @@ $default = array(
     
     'report_bounces' => 'asap',
     'report_bounces_asap_then_daily_range' => 15 * 60,
-    
+
+    'reports_show_ip_addr' => true,
+
     'statlog_lifetime' => 0,
     'statlog_log_user_organization' => false,
     'auditlog_lifetime' => 31,

--- a/templates/report_html.php
+++ b/templates/report_html.php
@@ -31,8 +31,10 @@ foreach($report->logs as $entry) {
     );
     
     echo '<td>'.$action.'</td>';
-    
-    echo '<td>'.$entry->ip.'</td>';
+
+    if( Config::get('reports_show_ip_addr')) {
+        echo '<td>'.$entry->ip.'</td>';
+    }
     
     echo '</tr>';
 }

--- a/templates/report_pdf.php
+++ b/templates/report_pdf.php
@@ -74,7 +74,9 @@ foreach($report->logs as $entry) {
     
     echo '<td>'.$action.'</td>';
     
-    echo '<td>'.$entry->ip.'</td>';
+    if( Config::get('reports_show_ip_addr')) {
+        echo '<td>'.$entry->ip.'</td>';
+    }
     
     echo '</tr>';
 }

--- a/templates/report_plain.php
+++ b/templates/report_plain.php
@@ -27,8 +27,12 @@ foreach($report->logs as $entry) {
         ),
         $entry->target
     );
-    
-    $lines[] = array('date' => $date, 'action' => $action, 'ip' => $entry->ip);
+
+    $nextline = array('date' => $date, 'action' => $action );
+    if( Config::get('reports_show_ip_addr')) {
+        $nextline += array('ip' => $entry->ip);
+    }
+    $lines[] = $nextline;
 }
 
 // Find longest date to compute first column width


### PR DESCRIPTION
Some sites might not like to report the IP address in their reports and with this patch that can be turned off without having to alter the reports templates to do it.