### PR TITLE
exceptions: allow some extra optional logging

### DIFF
--- a/classes/exceptions/Exceptions.class.php
+++ b/classes/exceptions/Exceptions.class.php
@@ -54,7 +54,7 @@ class LoggingException extends Exception {
      */
     public function __construct($msg_code, $log = null) {
         if( !$this->uid )
-             $this->uid = uniqid();
+            $this->uid = uniqid();
         
         // normalize arguments
         if(!$log) $log = $msg_code;
@@ -68,7 +68,7 @@ class LoggingException extends Exception {
                     $lines = array($lines);
                 
                 foreach ($lines as $line)
-                    $this->log( $category, $line );
+                $this->log( $category, $line );
             }
         }
         
@@ -97,10 +97,10 @@ class LoggingException extends Exception {
     function logArray($groupmsg,$arr)
     {
         foreach ($arr as $line) {
-           LoggingException::log($groupmsg,$line);
+            LoggingException::log($groupmsg,$line);
         }
     }
-     
+    
     /**
      * Uid getter
      * 
@@ -108,7 +108,7 @@ class LoggingException extends Exception {
      */
     public function getUid() {
         if( !$this->uid )
-             $this->uid = uniqid();
+            $this->uid = uniqid();
         return $this->uid;
     }
 }
@@ -195,6 +195,18 @@ class DetailedException extends LoggingException {
     public function getDetails() {
         return $this->details;
     }
+
+    /**
+     * return true if the needle (exception name) matches the config
+     * for additional verbose logging
+     */
+    public static function additionalLoggingDesired( $needle ) {
+        if( Utilities::configMatch( 'exception_additional_logging_regex',
+                                    $needle )) {
+            return true;
+        }
+        return false;
+    }
 }
 
 /**
@@ -225,8 +237,8 @@ class StorableException {
         if(is_array($exception)) {
             // Got array, extract data from specific keys
             foreach(array('message', 'uid', 'details') as $p)
-                if(array_key_exists($p, $exception))
-                    $this->$p = $exception[$p];
+            if(array_key_exists($p, $exception))
+                $this->$p = $exception[$p];
             
             return;
         }

--- a/classes/exceptions/RestExceptions.class.php
+++ b/classes/exceptions/RestExceptions.class.php
@@ -147,8 +147,27 @@ class RestSanityCheckFailedException extends RestException {
      * @param string $check name of the check
      * @param mixed $value value of the bad data
      * @param mixed $expected expected value
+     * @param file   the file   that caused to error (optional, log only)
+     * @param client the client that caused to error (optional, log only)
      */
-    public function __construct($check, $value, $expected) {
+    public function __construct($check, $value, $expected, $file = null, $client = null) {
+
+        // extra logging options for the admin
+        if( self::additionalLoggingDesired( 'RestSanityCheckFailedException' )) {
+            if( $file ) {
+                $this->log('EXCEPT-REST-CHUNK-SIZE','file size:' . $file->size );
+                $this->log('EXCEPT-REST-CHUNK-SIZE','file name:' . $file->name );
+                $this->log('EXCEPT-REST-CHUNK-SIZE','file uid:' . $file->uid );
+            }
+            if( $client ) {
+                if( $client['X-Filesender-Chunk-Offset'] ) 
+                    $this->log('EXCEPT-REST-CHUNK-SIZE','chunk offset:' . $client['X-Filesender-Chunk-Offset'] );
+                if( $client['X-Filesender-Chunk-Size'] ) 
+                    $this->log('EXCEPT-REST-CHUNK-SIZE','chunk size:' . $client['X-Filesender-Chunk-Size'] );
+                if( $_SERVER['HTTP_USER_AGENT'] )
+                    $this->log('EXCEPT-REST-CHUNK-SIZE','user agent:' . $_SERVER['HTTP_USER_AGENT'] );
+            }
+        }
         parent::__construct('rest_sanity_check_failed', 400, 'check "'.$check.'", "'.$expected.'" value was expected but got "'.$value.'" instead');
     }
 }

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -296,17 +296,23 @@ class RestEndpointFile extends RestEndpoint {
             // Check that the client sent file size the same as the loaded file if given
             if(!is_null($client['X-Filesender-File-Size']))
                 if($file->size != $client['X-Filesender-File-Size'])
-                    throw new RestSanityCheckFailedException('file_size', $file->size, $client['X-Filesender-File-Size']);
+                    throw new RestSanityCheckFailedException('file_size', $file->size,
+                                                             $client['X-Filesender-File-Size'],
+                                                             $file, $client );
             
             // Check that the offset from check data and the one in the url are the same if given
             if(!is_null($client['X-Filesender-Chunk-Offset']))
                 if($offset != $client['X-Filesender-Chunk-Offset'])
-                    throw new RestSanityCheckFailedException('chunk_offset', $offset, $client['X-Filesender-Chunk-Offset']);
+                    throw new RestSanityCheckFailedException('chunk_offset', $offset,
+                                                             $client['X-Filesender-Chunk-Offset'],
+                                                             $file, $client );
             
             // Check that the sent data size is the one givent by the client
             if(!is_null($client['X-Filesender-Chunk-Size']))
                 if($data_length != $client['X-Filesender-Chunk-Size'])
-                    throw new RestSanityCheckFailedException('chunk_size', $data_length, $client['X-Filesender-Chunk-Size']);
+                    throw new RestSanityCheckFailedException('chunk_size', $data_length,
+                                                             $client['X-Filesender-Chunk-Size'],
+                                                             $file, $client );
 
             // Check that data length does not exceed upload_chunk_size (can be smaller at the end of the file)
             $upload_chunk_size = Config::get('upload_chunk_size');
@@ -314,7 +320,9 @@ class RestEndpointFile extends RestEndpoint {
 
             if ($data_length > $upload_chunk_size) {
                 if (( $file->transfer->options['encryption'] && $data_length > $upload_crypted_chunk_size )) {
-                    throw new RestSanityCheckFailedException('chunk_size', $data_length, 'max ' . Config::get('upload_chunk_size'));
+                    throw new RestSanityCheckFailedException('chunk_size', $data_length,
+                                                             'max ' . Config::get('upload_chunk_size'),
+                                                             $file, $client );
                 }
             }
 

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -529,4 +529,27 @@ class Utilities {
         // Previous value matches
         return $token_to_check === self::$security_token['old']['value'];
     }
+
+
+    /**
+     * Read the config $configkey and if it is set then regex
+     * match it to see if needle matches and return the result. 
+     * This function handles empty configkey values and may cache results.
+     *
+     * So if you have a possible config key
+     *    mykey_regex => 'foo.*',
+     *
+     * you can see if you match in code with
+     * if( Utilities::configMatch( 'mykey_regex', 'bar' )) {
+     *    ...
+     * }
+     */
+    public static function configMatch( $configkey, $needle ) {
+        $cfg = Config::get( $configkey );
+        if( !strlen($cfg) )
+            return false;
+        if( preg_match('/' . $cfg . '/', $needle ))     
+            return true;  
+        return false;
+    }
 }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -153,6 +153,8 @@ title: Configuration directives
 * [auth_sp_fake_additional_attributes_values](#authspfakeadditionalattributesvalues)
 * [auditlog_lifetime](#auditloglifetime)
 * [report_format](#reportformat)
+* [exception_additional_logging_regex](#exceptionadditionalloggingregex)
+
 
 ## Webservices API
 
@@ -1418,6 +1420,19 @@ different options for different types.</span>
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ The same information is sent regardless of format.  Inline sends an email in plain text and HTML, with all information inline.  If PDF is chosen, the report is sent as PDF attachment.  Building a PDF is somewhat heavier on the server but won't matter unless you would have a heavily used server.  The library used is "dom pdf", included in the code.
+
+
+### exception_additional_logging_regex
+
+* __description:__ Exception names that additional logging is desired for
+* __mandatory:__ no
+* __type:__ string regex
+* __default:__ 
+* __available:__ since version 2.0
+* __comment:__ Sometimes a site might want to capture down extra logging for some exception types. This configuration is a regular expression to match the name of an exception against to see if you want this extra log info. This allows extra log info to be turned on and off fairly easily without having to edit code and possibly break something. Note that only some exceptions can give extra info.
+
+
+
 
 ---
 


### PR DESCRIPTION
Option to turn on additional logging for some exception types. This can be turned on/off with an optional config option to avoid the possibility of breaking a deployed system by editing the code directly.

This is an update to a previous PR but I'm allowing things to be turned on/off easily (default off) so that things can be turned on in the wild by admins who want to contribute feedback.
