### PR TITLE
upload: if fwrite() returns short, tell user 

### DIFF
--- a/classes/exceptions/Exceptions.class.php
+++ b/classes/exceptions/Exceptions.class.php
@@ -207,6 +207,16 @@ class DetailedException extends LoggingException {
         }
         return false;
     }
+
+    /**
+     */
+    public function additionalLogFile( $msg, $file ) {
+            if( $file ) {
+                $this->log($msg,'file size:' . $file->size );
+                $this->log($msg,'file name:' . $file->name );
+                $this->log($msg,'file uid:'  . $file->uid );
+            }
+    }
 }
 
 /**

--- a/classes/exceptions/StorageFilesystemExceptions.class.php
+++ b/classes/exceptions/StorageFilesystemExceptions.class.php
@@ -128,7 +128,16 @@ class StorageFilesystemCannotWriteException extends StorageFilesystemException {
      * @param string $path
      * @param File $file
      */
-    public function __construct($path, $file = null) {
+    public function __construct($path, $file = null, $data = null, $offset = 0, $written = 0 ) {
+        if( self::additionalLoggingDesired( 'StorageFilesystemCannotWriteException' )) {
+            $msg = 'StorageFilesystemCannotWriteException';
+            $this->additionalLogFile( $msg, $file );
+            if( $data ) {
+                $this->log($msg,'data size:' . strlen($data));
+            }
+            $this->log($msg,'offset:  ' . $offset );
+            $this->log($msg,'written: ' . $written );
+        }
         parent::__construct('cannot_write', $path, $file);
     }
 }

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -349,7 +349,7 @@ class StorageFilesystem {
                 $offset = ftell($fh);
                 
                 // Try to write chunk
-                $written = fwrite($fh, $data);
+                $written = fwrite($fh, $data, $chunk_size);
                 
                 fflush($fh); // Flush file buffer before releasing lock
                 
@@ -358,7 +358,12 @@ class StorageFilesystem {
             
             // Close writer
             fclose($fh);
-            
+
+            if( $chunk_size != $written ) {
+                Logger::info('writeChunk() Can not write to : '.$chunkFile);
+                throw new StorageFilesystemCannotWriteException('writeChunk( '.$file_path, $file, $data, $offset, $written );
+            }
+
             return array(
                 'offset' => $offset,
                 'written' => $written

--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -170,9 +170,13 @@ class StorageFilesystemChunked extends StorageFilesystem {
             if ($encrypt)
                 $data = self::encrypt($data,self::genKey($file));
 
-            $written = fwrite($fh, $data);
-
+            $written = fwrite($fh, $data, $chunk_size);
             fclose($fh);
+
+            if( $chunk_size != $written ) {
+                Logger::info('writeChunk() Can not write to : '.$chunkFile);
+                throw new StorageFilesystemCannotWriteException('writeChunk( '.$file_path, $file, $data, $offset, $written );
+            }
 
             return array(
                 'offset' => $offset,


### PR DESCRIPTION
It is fine syscall wise for fwrite() to return less than the provided number of bytes. This lesser number was being sent back to the client but never checked. So I could have done
```
  fwrite($fh, $data, $chunk_size-1);
```
and return 1 byte less than the user gave us. The client did doesn't catch these short writes and say anything. So if the server didn't write all the data the client (and user) doesn't get any error. 

No with the brute force method of throwing on short writes the client will see if each of their bytes is not saved. From there the client code might like to retry the request. Though if the server has failed to write the bytes given then it might not help to rerun from the client side. It might be more useful to have a new utilities::fwriteWithTries() that can maybe retry to fwrite up to $n times.

Anyway, if fwrite() does a legal short write this patch will let the user know rather than ignore the issue.
