### PR TITLE
Storage: bind storage_type to each file that is saved

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -51,6 +51,7 @@ class Autoloader {
         'GUIPages' => 'constants/',
         'LogLevels' => 'constants/',
         'ReportFormats' => 'constants/',
+        'DBStorageType' => 'constants/',
         
         'Storage' => 'storage/',
         'Storage*' => 'storage/',

--- a/classes/constants/DBStorageType.class.php
+++ b/classes/constants/DBStorageType.class.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * Class containing issues that might be found when looking at a secondary index
+ */
+class DBStorageType extends Enum {
+    
+    const NOTFOUND           = 0;
+    const FILESYSTEM         = 1;
+    const FILESYSTEMCHUNKED  = 2;
+
+    private static $configClass = null;
+    
+    public static function getDatamap() {
+        return array(
+            'type' => 'int',
+            'size' => 'small',
+            'default' => self::NOTFOUND
+        );
+    }
+
+    public static function defaultValue() {
+        $type = Config::get('storage_type');
+        if(!$type)
+            throw new ConfigMissingParameterException('storage_type');
+        if( $type == 'filesystem' || $type == 'Filesystem' )
+            return self::FILESYSTEM;
+        if( $type == 'filesystemChunked' || $type == 'FilesystemChunked' )
+            return self::FILESYSTEMCHUNKED;
+        
+        // default
+        return self::FILESYSTEM;
+    }
+    
+    public static function defaultClassName() {
+        if( $configClass ) {
+            return $configClass;
+        }
+        $type = Config::get('storage_type');
+        if(!$type)
+            throw new ConfigMissingParameterException('storage_type');
+        
+        // Build storage underlying class name and check if it exists
+        $class = 'Storage'.ucfirst($type);
+        
+        if(!class_exists($class))
+            throw new ConfigBadParameterException('storage_type');
+
+        $configClass = $class;
+        return $configClass;
+    }
+    
+    public static function toClassName( $v ) {
+        if( $v == self::FILESYSTEM ) {
+            return "StorageFilesystem";
+        }
+        if( $v == self::FILESYSTEMCHUNKED ) {
+            return "StorageFilesystemChunked";
+        }
+        if( $v == self::NOTFOUND ) {
+            return self::defaultClassName();
+        }
+    }
+}

--- a/classes/constants/DBStorageType.class.php
+++ b/classes/constants/DBStorageType.class.php
@@ -64,8 +64,8 @@ class DBStorageType extends Enum {
     }
     
     public static function defaultClassName() {
-        if( $configClass ) {
-            return $configClass;
+        if( self::$configClass ) {
+            return self::$configClass;
         }
         $type = Config::get('storage_type');
         if(!$type)
@@ -77,8 +77,8 @@ class DBStorageType extends Enum {
         if(!class_exists($class))
             throw new ConfigBadParameterException('storage_type');
 
-        $configClass = $class;
-        return $configClass;
+        self::$configClass = $class;
+        return self::$configClass;
     }
     
     public static function toClassName( $v ) {

--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -52,7 +52,7 @@ class DBObject {
      * 
      * <field_def> associative array of field definition entries in :
      *   - type : int, uint, string, bool, enum, text, date, datetime, time
-     *   - size (for int types) : tiny, medium, big (defaults to medium)
+     *   - size (for int types) : small, medium, big (defaults to medium)
      *   - size (for string types) : string length
      *   - values (for enum types) : array of possible values
      *   - null : bool indicating if field can be null

--- a/classes/storage/Storage.class.php
+++ b/classes/storage/Storage.class.php
@@ -75,6 +75,27 @@ class Storage {
         // Cache name
         self::$class = $class;
     }
+
+    /**
+     * Get the storage class that was used with this file
+     * 
+     * @param File $file
+     * 
+     * @return String
+     */
+    public static function getStorageClass(File $file) {
+        return DBStorageType::toClassName( $file->storage_type );
+    }    
+
+    /**
+     * Get the storage class to use for new files
+     * 
+     * @return String
+     */
+    public static function getDefaultStorageClass() {
+        return DBStorageType::defaultClassName();
+    }    
+    
     
     /**
      * Delegates transfer storable check
@@ -86,7 +107,7 @@ class Storage {
     public static function canStore(Transfer $transfer) {
         self::setup();
         
-        return call_user_func(self::$class.'::canStore', $transfer);
+        return call_user_func(self::getDefaultStorageClass().'::canStore', $transfer);
     }
     
     /**
@@ -97,9 +118,9 @@ class Storage {
     public static function getUsage() {
         self::setup();
         
-        if(!method_exists(self::$class, 'getUsage')) return null;
+        if(!method_exists(self::getDefaultStorageClass(), 'getUsage')) return null;
         
-        return call_user_func(self::$class.'::getUsage');
+        return call_user_func(self::getDefaultStorageClass().'::getUsage');
     }
     
     /**
@@ -129,7 +150,7 @@ class Storage {
         }
         
         // Ask underlying class to read data
-        $data = call_user_func(self::$class.'::readChunk', $file, $offset, $length);
+        $data = call_user_func(self::getStorageClass($file).'::readChunk', $file, $offset, $length);
         
         // Update read offset
         self::$reading_offsets[$file->id] = $offset + $length;
@@ -156,7 +177,7 @@ class Storage {
             throw new StorageChunkTooLargeException(strlen($data), (int)Config::get('upload_chunk_size'));
         
         // Ask underlying class to write data
-        return call_user_func(self::$class.'::writeChunk', $file, $data, $offset);
+        return call_user_func(self::getStorageClass($file).'::writeChunk', $file, $data, $offset);
     }
     
     /**
@@ -167,9 +188,9 @@ class Storage {
     public static function completeFile(File $file) {
         self::setup();
         
-        if(!method_exists(self::$class, 'completeFile')) return;
+        if(!method_exists(self::getStorageClass($file), 'completeFile')) return;
         
-        return call_user_func(self::$class.'::completeFile', $file);
+        return call_user_func(self::getStorageClass($file).'::completeFile', $file);
     }
     
     /**
@@ -180,7 +201,7 @@ class Storage {
     public static function deleteFile(File $file) {
         self::setup();
         
-        call_user_func(self::$class.'::deleteFile', $file);
+        call_user_func(self::getStorageClass($file).'::deleteFile', $file);
     }
     
     /**
@@ -191,7 +212,7 @@ class Storage {
     public static function supportsDigest() {
         self::setup();
         
-        call_user_func(self::$class.'::supportsDigest');
+        call_user_func(self::getDefaultStorageClass().'::supportsDigest');
     }
     
     /**
@@ -204,7 +225,7 @@ class Storage {
     public static function getDigest(File $file) {
         self::setup();
         
-        call_user_func(self::$class.'::getDigest', $file);
+        call_user_func(self::getStorageClass($file).'::getDigest', $file);
     }
     
     /**
@@ -215,7 +236,7 @@ class Storage {
     public static function supportsWholeFile() {
         self::setup();
         
-        return call_user_func(self::$class.'::supportsWholeFile');
+        return call_user_func(self::getDefaultStorageClass().'::supportsWholeFile');
     }
     
     /**
@@ -231,7 +252,7 @@ class Storage {
     public static function storeWholeFile(File $file, $source_path) {
         self::setup();
         
-        call_user_func(self::$class.'::storeWholeFile', $file, $source_path);
+        call_user_func(self::getStorageClass($file).'::storeWholeFile', $file, $source_path);
     }
     
     /**
@@ -242,7 +263,7 @@ class Storage {
     public static function supportsLinking() {
         self::setup();
         
-        return call_user_func(self::$class.'::supportsLinking');
+        return call_user_func(self::getDefaultStorageClass().'::supportsLinking');
     }
     
     /**
@@ -254,6 +275,6 @@ class Storage {
     public static function storeAsLink(File $file, $source_path) {
         self::setup();
         
-        call_user_func(self::$class.'::storeAsLink', $file, $source_path);
+        call_user_func(self::getStorageClass($file).'::storeAsLink', $file, $source_path);
     }
 }

--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -46,7 +46,7 @@ class StorageFilesystemChunked extends StorageFilesystem {
     
     
     private static function getChunkFilename($file_path,$offset) {
-	return $file_path.'/'.str_pad($offset,24,'0',STR_PAD_LEFT));
+	return $file_path.'/'.str_pad($offset,24,'0',STR_PAD_LEFT);
     }
 
     /**


### PR DESCRIPTION
The addition of the new chunked storage type creates some issues when folks might want to migrate to using it while still serving old files that have already been transferred.

This PR will require a database upgrade to work;
```
php /opt/filesender/scripts/upgrade/database.php
```

Note that I have set the default storage for existing transfers to 'Filesystem'. If you have been using the chunked storage type then you will need to update the database with the below command to override the default setting, note use files as the table in postgresql and Files in MySQL.
```
update files set storage_type = 2 ;
```

Since each file saves the int value for the storage_type that was active when it was created you can more easily change the storage_type in the future while still serving existing files.
