### PR TITLE
Do not require session to signal upload complete

### DIFF
--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -78,7 +78,10 @@ class RestEndpointFile extends RestEndpoint {
         
         if(!$_GET['key']) // No key, need token
             return true;
-        
+
+        if(($method == 'put') && preg_match('`^[0-9]+$`', $path)) // No need if key and signal upload complete
+            return false;
+
         if(($method == 'post') && preg_match('`^[0-9]+/whole$`', $path)) // No need if key and whole file upload
             return false;
         


### PR DESCRIPTION
When a user uploads a large file and the security token expires during upload,
FileSender has code in place to allow the upload to continue.
However, when the whole file has been uploaded, the browser must signal upload complete.
Now, FileSender suddenly does check the session and aborts the upload, thus defeating the purpose of allowing the upload to continue.

This commit will allow for the signaling of upload complete without checking the security token, in addition to the already existing code to allow for uploading chunks without checking the security token.  Thus allowing a user to complete a upload when the security token expires.