### PR TITLE
Fix the random number generator and generate valid UUIDs

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -141,6 +141,46 @@ class Utilities {
         return preg_match('/' .  Config::get('valid_filename_regex') . '/u', $filename);
     }
 
+
+    /*
+     * Generate (pseudo) (super-)random hex string
+     * 
+     * @return string
+     */
+    public static function generateRandomHexString($nearly = false) {
+        // Random length
+        $len = random_int(16, 32);
+
+        // Random data
+        $rnd = '';
+        for($i=0; $i<$len; $i++) $rnd .= sprintf('%04d', random_int(0, 9999));
+        
+        // No need for an super-random, just hash
+        if($nearly) return hash('sha1', $rnd);
+        
+        // Need for an super-random
+        
+        // Get secret, generate it if not found
+        $sfile = FILESENDER_BASE.'/tmp/instance.secret';
+        if(file_exists($sfile)) {
+            $ctn = array_filter(array_map('trim', explode("\n", file_get_contents($sfile))), function($line) {
+                return substr($line, 0, 1) != '#';
+            });
+            
+            $secret = array_shift($ctn);
+        } else {
+            $secret = self::generateRandomHexString(true);
+            
+            if($fh = fopen($sfile, 'w')) {
+                fwrite($fh, '# Automatically generated'."\n");
+                fwrite($fh, $secret);
+                fclose($fh);
+            } else throw new CoreCannotWriteFileException($sfile);
+        }
+        // return hmac signature of random data with secret => super-random !
+        return hash_hmac('sha1', $rnd, $secret);
+    }
+    
     /**
      * Get instance uid
      * 

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -86,13 +86,13 @@ class Utilities {
         $bytes = bin2hex($bytes);
         $bytes{12} = '4';
         $parts = str_split($bytes, 4);
-        return implode('-', [
+        return implode('-', array(
                 $parts[0] . $parts[1],
                 $parts[2],
                 $parts[3],
                 $parts[4],
                 $parts[5] . $parts[6] . $parts[7]
-        ]);
+        ));
     }
 
     /**


### PR DESCRIPTION
In order to understand this commit, you need a bit of history.

During the PINE security audit in 2015, a vulnurability was found in the way FileSender generates random identifiers (2.6.13);
PINE found that `unid_id` and `mt_rand` by themselves weren't sufficient and recommended using HMAC for random number generation.
The new implementation thus used `mt_rand` to generate a random HMAC key the first time this was needed,
and all subsequent random numbers would consist of a random number from `mt_rand`, HMAC-ed with this stored random value.
This implementation was never security checked as far as I know.

In 2017, a new security audit was conducted by Radically Open Security.  They found the same code using `mt_rand`, and acknowledged the HMAC in the code (FIS-001), but recommended that these be replaced by newer PHP functions that weren't available during the previous audit.

This was then implemented (PR#54) by adding a polyfill for the newer PHP functions and replacing occurrences of `mt_rand` with `random_int`, which is not in the spirit of the recommendation in FIS-001.

This pull request seeks to remedy FIS-001 the way that was proposed, by replacing the logic for generating random identifiers, instead of simply replacing a function call.