### PR TITLE
Remove redundant filename check

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -169,12 +169,6 @@ window.filesender.transfer = function() {
             return false;
         }
 
-        
-        if (!/^[^\\\/:;\*\?\"<>|]+(\.[^\\\/:;\*\?\"<>|]+)*$/.test(file.name)) {
-            errorhandler({message: 'invalid_file_name', details: {filename: file.name}});
-            return false;
-        }
-        
         if (!file.size) {
             errorhandler({message: 'empty_file'});
             return false;


### PR DESCRIPTION
As part of the effort to remedy FIS-007 (PR#64), a filename check was introduced.
However, another filename check was already in place.  The new filename check is better,
because it uses the configuration setting to decide which filename is good and which isn't.

This commit removes the old filename check.