### PR TITLE
Add known installs list as markdown file to docs

### DIFF
--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -7,7 +7,7 @@ If you want to add your FileSender installation to this list, send an email to f
 
 | Country/Region|NREN/Org	| Service URL					| Known since|
 | --- | --- | --- |---|
-| Armenia	| ASNET-AM	| https://filesender.as.net.am/filesender/	| Feb 2016| 
+| Armenia	| ASNET-AM	| https://filesender.asnet.am/filesender/	| Feb 2016| 
 | Austria	| ACOnet	| https://filesender.aco.net/			| Nov 2012|
 | Austria	| Institute for Advanced Studies	| https://filesender.ihs.ac.at	| Jan 2014|
 | Belgium	| BELNET	| https://filesender.belnet.be/			| Mar 2010| 
@@ -60,7 +60,6 @@ If you want to add your FileSender installation to this list, send an email to f
 | Equador 	| CEDIA		| https://filesender.cedia.org.ec/filesender/	| Jun 2017| 
 | Latin-America	| ELCIRA	| https://filesender.redclara.net/filesender/	| Oct 2013|
 | USA		| Internet2	| https://filesender.internet2.edu/		| Jul 2012|
-| USA 		| Adelphi University | https://filesender.adelphi.edu/filesender/ | Dec 2013 |
 
 
 ## 

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -1,31 +1,71 @@
 # Known installs 
 
 ## 
-## Community installations higher education - Europe
+## HE&R Community installations - Europe & Middle-East
 
-| Country |NREN  | Service URL | Known since|
+| Country/Region|NREN/Org	| Service URL					| Known since|
 | --- | --- | --- |---|
-| Armenia	| ASNET-AM	| https://filesender.as.net.am/filesender/	| February 2016 | 
-| Austria	| ACOnet	| https://filesender.aco.net/			| November 2012 |
-| Belgium	| BELNET	| https://filesender.belnet.be/			| March 2010	| 
-| Czech Republic| CESNET	| https://filesender.cesnet.cz			| February 2012	| 
-| Denmark	| DeiC		| https://filesender.deic.dk			| March 2012	| 
-| Portugal	| FCCN		| https://filesender.fccn.pt			| January 2011	| 
-| Serbia	| AMRES | https://filesender.amres.ac.rs/ | July 2014 |
-| Slovenia	| ARNES | https://filesender.arnes.si/ | May 2011 | 
+| Armenia	| ASNET-AM	| https://filesender.as.net.am/filesender/	| Feb 2016| 
+| Austria	| ACOnet	| https://filesender.aco.net/			| Nov 2012|
+| Austria	| Institute for Advanced Studies	| https://filesender.ihs.ac.at	| Jan 2014|
+| Belgium	| BELNET	| https://filesender.belnet.be/			| Mar 2010| 
+| Catalonia	| i2CAT		| https://filesender.i2cat.net			| Apr 2011|
+| Croatia	| SRCE		| https://filesender.srce.hr/			| Oct 2010|
+| Cyprus	| CYNET		| https://filesender.ucy.ac.cy			| Nov 2012|
+| Czech Republic| CESNET	| https://filesender.cesnet.cz			| Feb 2012| 
+| Denmark	| DeiC		| https://filesender.deic.dk			| Mar 2012| 
+| Europe	| GEANT		| https://filesender.geant.org/			| Sep 2010|
+| Finland	| FUNET/CSC	| https://filesender.funet.fi/			| Sep 2012|
+| France	| RENATER	| https://filesender.renater.fr/		| Nov 2013|
+| Hungary	| NIIF		| https://filesender.niif.hu			| Feb 2012|
+| Ireland	| HEAnet	| https://filesender.heanet.ie			| 2009 |
+| Iran		| IPM/IRANET	| https://filesender.ipm.ir			| Aug 2016|
+| Israel	| IUCC/HUJI	| https://filesender.huji.ac.il			| Mar 2012|
+| Italy		| GARR		| https://filesender.garr.it/			| Apr 2012|
+| Lithuania	| LITNET	| https://filesender.vu.lt			| Feb 2012|
+| Lithuania	| Aleksandras Stulginskis University	| https://filesender.asu.lt	| Feb 2012|
+| Luxembourg	| RESTENA	| https://fs.restena.lu				| Feb 2011|
+| Moldova	| RENAM		| https://filesender.renam.md			| Aug 2016|
+| Netherlands	| SURFnet	| https://filesender.surf.nl/			| Jun 2010|
+| Netherlands	| Tilburg University			| https://send.uvt.nl/		| May 2012|
+| Norway	| UNINETT	| https://filesender.uninett.no/		| 2009|
+| Poland	| PIONIER	| https://files.pionier.net.pl/			| Apr 2013|
+| Portugal	| FCCN		| https://filesender.fccn.pt			| Jan 2011| 
+| Serbia	| AMRES		| https://filesender.amres.ac.rs/		| Jul 2014|
+| Slovenia	| ARNES		| https://filesender.arnes.si/ 			| May 2011| 
+| Spain		| RedIRIS	| https://filesender.rediris.es			| Mar 2017|
+| Spain/Sevilla	| Universidad Internacional de Andalucia| https://filesender.unia.es/	| May 2014|
+| Spain/Sevilla	| Universidad "Pablo de Olavide"	| https://filesender.upo.es/	| May 2014|
+| Switzerland	| SWITCH	| https://filesender.switch.ch			| Sep 2012|
+| UK/Kent	| GOETEC	| https://send.goetec.ac.uk			| Aug 2014|
 
 ## 
-## Community installations higher education - Asia - Pacific
-| Australia | AARNet | https://cloudstor.aarnet.edu.au/ | 2009 |
+## HE&R Community installations - Asia - Pacific
+| Country/Region|NREN  | Service URL | Known since|
+| --- | --- | --- |---|
+| Australia	| AARNet	| https://cloudstor.aarnet.edu.au/		| 2009 |
+| Japan / Okinawa| Okinawa Institute of Science and Technology	| https://filesender.oist.jp	| Sep 2013|
+| Korea		| KREONET	| https://filesender.kreonet.net		| Mar 2014|
+| Malaysia	| MYREN		| https://filesender.myren.net.my		| Oct 2017| 
+| Singapore	| SingAREN	| https://filesender.singaren.net.sg/filesender	| Jun 2016|
 
-| Serbia | AMRES | https://filesender.amres.ac.rs/ | July 2014 |
 ## 
-## Community installations higher education - Americas
+## HE&R Community installations - Americas
+| Country/Region|NREN  | Service URL | Known since|
+| --- | --- | --- |---|
+| Brazil	| RNP		| https://filesender.rnp.br			| Oct 2014|
+| Chili		| REUNA		| https://filesender.reuna.cl			| Sep 2013|
+| Equador 	| CEDIA		| https://filesender.cedia.org.ec/filesender/	| Jun 2017| 
+| Latin-America	| ELCIRA	| https://filesender.redclara.net/filesender/	| Oct 2013|
+| USA		| Internet2	| https://filesender.internet2.edu/		| Jul 2012|
 
-| Equador | CEDIA | https://filesender.cedia.org.ec/filesender/ | June 2017 | 
 
 ## 
-## Community installations higher education - Africa
+## HE&R Community installations - Africa
+| Country/Region|NREN  | Service URL | Known since|
+| --- | --- | --- |---|
+| Morocco	| MARWAN	| https://filesender.marwan.ma/filesender	| Feb 2015|
+| South Africa	| SANReN	| https://filesender.sanren.ac.za/filesender	| Apr 2014|
 
 
 

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -71,7 +71,8 @@
 
 
 ## Other
-| Country/Region|NREN  | Service URL | Known since|
+| Country/Region| Organisation | Service URL | Known since|
+| --- | --- | --- |---|
 | Netherlands	| Pleio - Dutch government | https://bestandendelen.pleio.nl/filesender | Oct 2013|
 | Philippines	| Government	| https://pakete.gov.ph 			| Jul 2013|
 

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -58,6 +58,7 @@
 | Equador 	| CEDIA		| https://filesender.cedia.org.ec/filesender/	| Jun 2017| 
 | Latin-America	| ELCIRA	| https://filesender.redclara.net/filesender/	| Oct 2013|
 | USA		| Internet2	| https://filesender.internet2.edu/		| Jul 2012|
+| USA 		| Adelphi University | https://filesender.adelphi.edu/filesender/ | Dec 2013 |
 
 
 ## 
@@ -70,6 +71,7 @@
 
 
 ## Other
-
-| USA | Adelphi University | https://filesender.adelphi.edu/filesender/ | Dec 2013 |
+| Country/Region|NREN  | Service URL | Known since|
+| Netherlands	| Pleio - Dutch government | https://bestandendelen.pleio.nl/filesender | Oct 2013|
+| Philippines	| Government	| https://pakete.gov.ph 			| Jul 2013|
 

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -1,4 +1,6 @@
-# Known installs 
+# Known FileSender installalations 
+
+If you want to add your FileSender installation to this list, send an email to filesender-dev@filesender.org or edit the file from [the FileSender Github repository](https://github.com/filesender/filesender/tree/master/docs) and create a pull request.
 
 ## 
 ## HE&R Community installations - Europe & Middle-East

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -5,15 +5,11 @@
 
 | Country |NREN  | Service URL | Known since|
 | --- | --- | --- |---|
-
-
 | Armenia	| ASNET-AM	| https://filesender.as.net.am/filesender/	| February 2016 | 
 | Austria	| ACOnet	| https://filesender.aco.net/			| November 2012 |
 | Belgium	| BELNET	| https://filesender.belnet.be/			| March 2010	| 
 | Czech Republic| CESNET	| https://filesender.cesnet.cz			| February 2012	| 
 | Denmark	| DeiC		| https://filesender.deic.dk			| March 2012	| 
-
-| | | | | 
 | Portugal	| FCCN		| https://filesender.fccn.pt			| January 2011	| 
 | Serbia	| AMRES | https://filesender.amres.ac.rs/ | July 2014 |
 | Slovenia	| ARNES | https://filesender.arnes.si/ | May 2011 | 

--- a/docs/known-installs.md
+++ b/docs/known-installs.md
@@ -1,0 +1,39 @@
+# Known installs 
+
+## 
+## Community installations higher education - Europe
+
+| Country |NREN  | Service URL | Known since|
+| --- | --- | --- |---|
+
+
+| Armenia	| ASNET-AM	| https://filesender.as.net.am/filesender/	| February 2016 | 
+| Austria	| ACOnet	| https://filesender.aco.net/			| November 2012 |
+| Belgium	| BELNET	| https://filesender.belnet.be/			| March 2010	| 
+| Czech Republic| CESNET	| https://filesender.cesnet.cz			| February 2012	| 
+| Denmark	| DeiC		| https://filesender.deic.dk			| March 2012	| 
+
+| | | | | 
+| Portugal	| FCCN		| https://filesender.fccn.pt			| January 2011	| 
+| Serbia	| AMRES | https://filesender.amres.ac.rs/ | July 2014 |
+| Slovenia	| ARNES | https://filesender.arnes.si/ | May 2011 | 
+
+## 
+## Community installations higher education - Asia - Pacific
+| Australia | AARNet | https://cloudstor.aarnet.edu.au/ | 2009 |
+
+| Serbia | AMRES | https://filesender.amres.ac.rs/ | July 2014 |
+## 
+## Community installations higher education - Americas
+
+| Equador | CEDIA | https://filesender.cedia.org.ec/filesender/ | June 2017 | 
+
+## 
+## Community installations higher education - Africa
+
+
+
+## Other
+
+| USA | Adelphi University | https://filesender.adelphi.edu/filesender/ | Dec 2013 |
+


### PR DESCRIPTION
Copied known installs over from the old Assembla wiki page, removed those which were offline. All remaining URLs checked. 