### PR TITLE
My Transfers page is now paginated

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -312,6 +312,7 @@ class AuditLog extends DBObject {
         foreach(self::all('target_type=\'Recipient\' AND target_id IN :ids', array(':ids' => array_map(function($recipient) {
             return $recipient->id;
         }, $transfer->recipients))) as $log) $logs[] = $log;
+         
         
         // Sort by event date
         usort($logs, function($a, $b) {

--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -225,24 +225,29 @@ class DBObject {
             $group = null;
             
             if(is_array($criteria)) {
+                if(array_key_exists('query',  $criteria)) $query  = $criteria['query'];
                 if(array_key_exists('where',  $criteria)) $where  = $criteria['where'];
                 if(array_key_exists('order',  $criteria)) $order  = $criteria['order'];
                 if(array_key_exists('group',  $criteria)) $group  = $criteria['group'];
                 if(array_key_exists('count',  $criteria)) $count  = (int)$criteria['count'];
+                if(array_key_exists('limit',  $criteria)) $count  = (int)$criteria['limit'];
                 if(array_key_exists('offset', $criteria)) $offset = (int)$criteria['offset'];
             }else $where = $criteria;
-                
-            if($where) $query .= ' WHERE '.$where;
-            if($group) $query .= ' GROUP BY '.$group;
-            if($order) $query .= ' ORDER BY '.$order;
+            
+            if($where)  $query .= ' WHERE '    . $where;
+            if($group)  $query .= ' GROUP BY ' . $group;
+            if($order)  $query .= ' ORDER BY ' . $order;
+            if($count)  $query .= ' LIMIT '    . $count;
+            if($offset) $query .= ' OFFSET '   . $offset;
         }
         
         // Look for primary key(s) name(s)
         $pk = array();
-        foreach(static::getDataMap() as $k => $d)
-            if(array_key_exists('primary', $d) && $d['primary'])
+        foreach(static::getDataMap() as $k => $d) {
+            if(array_key_exists('primary', $d) && $d['primary']) {
                 $pk[] = $k;
-        
+            }
+        }
         // Prepare query depending on contents
         if(preg_match('`\s+[^\s]+\s+IN\s+:[^\s]+\b`i', $query)) {
             $statement = DBI::prepareInQuery($query, array_filter($placeholders, 'is_array'));
@@ -256,12 +261,6 @@ class DBObject {
         // Fetch records, register them with id build from primary key(s) value(s)
         $records = $statement->fetchAll();
         $objects = array();
-        $page = null;
-        
-        if($count) {
-            $page = (object)array('total_count' => count($records), 'entries' => array());
-            $records = array_slice($records, $offset, $count);
-        }
         
         foreach($records as $r) {
             $id = array();
@@ -282,11 +281,7 @@ class DBObject {
             });
         }
         
-        if(!$page) return $objects;
-        
-        $page->entries = $objects;
-        
-        return $page;
+        return $objects;
     }
     
     /**
@@ -358,11 +353,11 @@ class DBObject {
                     case 'uint':
                         $value = (int)$value;
                         break;
-                    
+                        
                     case 'float':
                         $value = (float)$value;
                         break;
-                    
+                        
                     case 'datetime':
                     case 'date':
                         if(!$value && array_key_exists('null', $dfn) && $dfn['null']) {
@@ -373,11 +368,11 @@ class DBObject {
                             $value = (int)strtotime($value); // UNIX timestamp
                         }
                         break;
-                    
+                        
                     case 'time':
                         $value = (int)(strtotime($value) % (24 * 3600)); // Offset since 0h00
                         break;
-                    
+                        
                     case 'bool':
                         $value = (bool)$value;
                         break;
@@ -461,15 +456,15 @@ class DBObject {
                     case 'datetime':
                         $value = date('Y-m-d H:i:s', $value); // UNIX timestamp
                         break;
-                    
+                        
                     case 'date':
                         $value = date('Y-m-d', $value); // UNIX timestamp
                         break;
-                    
+                        
                     case 'time':
                         $value = date('H:i:s', $value); // Offset since 0h00
                         break;
-                    
+                        
                     case 'bool':
                         $value = $value ? '1' : '0';
                         break;
@@ -507,9 +502,13 @@ class DBObject {
         $table = static::getDBTable();
         
         // Remove autoinc keys
-        foreach(static::$dataMap as $field_name => $dfn)
-            if(array_key_exists('autoinc', $dfn) && $dfn['autoinc'])
-                if(array_key_exists($field_name, $data)) unset($data[$field_name]);
+        foreach(static::$dataMap as $field_name => $dfn) {
+            if(array_key_exists('autoinc', $dfn) && $dfn['autoinc']) {
+                if(array_key_exists($field_name, $data)) {
+                    unset($data[$field_name]);
+                }
+            }
+        }
         
         // Insert data
         $values = array();
@@ -519,10 +518,11 @@ class DBObject {
         
         // Get primary key(s) back
         $pks = array();
-        foreach(static::$dataMap as $field_name => $dfn)
-            if(array_key_exists('autoinc', $dfn) && $dfn['autoinc'])
+        foreach(static::$dataMap as $field_name => $dfn) {
+            if(array_key_exists('autoinc', $dfn) && $dfn['autoinc']) {
                 $pks[$field_name] = DBI::lastInsertId($table.'_'.$field_name.'_seq');
-        
+            }
+        }
         return $pks;
     }
     

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -190,10 +190,15 @@ class Transfer extends DBObject {
      * 
      * @return array of Transfer
      */
-    public static function fromUser($user, $closed = false) {
+    public static function fromUser($user, $closed = false, $limit = null, $offset = null ) {
         if($user instanceof User) $user = $user->id;
-        
-        return self::all($closed ? self::FROM_USER_CLOSED : self::FROM_USER, array(':user_id' => $user));
+
+        return self::all(array('where' => $closed ? self::FROM_USER_CLOSED : self::FROM_USER
+                               ,'limit' => $limit
+                               ,'offset' => $offset
+                               )
+                         , array(':user_id' => $user)
+                         );
     }
     
     /**

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -289,6 +289,8 @@ $lang['extend_expiry_date'] = 'Extend expiry date by {days} days';
 $lang['confirm_extend_expiry'] = 'Do you really want to extend the expiry date by {days} days ?';
 $lang['transfer_extended'] = 'Expiry date extended until {expires}';
 $lang['transfer_extended_reminded'] = 'Expiry date extended until {expires}, a reminder was sent to recipients';
+$lang['pager_more'] = 'More...';
+$lang['pager_has_no_more'] = 'No more records.';
 
 /**
  * Reports

--- a/templates/admin_transfers_section.php
+++ b/templates/admin_transfers_section.php
@@ -14,8 +14,9 @@ $transfers_page = function($status) {
         
     $offset = array_key_exists($status.'_tpo', $_REQUEST) ? (int)$_REQUEST[$status.'_tpo'] : 0;
     $offset = max(0, $offset);
-    
-    $page = Transfer::all(array('where' => $selector, 'count' => $page_size, 'offset' => $offset));
+
+    $total_count = 100;
+    $entries = Transfer::all(array('where' => $selector, 'count' => $page_size, 'offset' => $offset));
     
     $navigation = '<div class="transfers_list_page_navigation">'."\n";
     
@@ -26,7 +27,7 @@ $transfers_page = function($status) {
     }
     
     $p = 1;
-    for($o=0; $o<$page->total_count; $o+=$page_size) {
+    for($o=0; $o<$total_count; $o+=$page_size) {
         if($o >= $offset && $o < $offset + $page_size) {
             $navigation .= '<span>'.$p.'</span>'."\n";
         } else {
@@ -36,25 +37,25 @@ $transfers_page = function($status) {
         $p++;
     }
     
-    if($offset + $page_size < $page->total_count) {
+    if($offset + $page_size < $total_count) {
         $no = $offset + $page_size;
-        $lo = $page->total_count - ($page->total_count % $page_size);
+        $lo = $total_count - ($total_count % $page_size);
         $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$no.'#'.$status.'_transfers">&gt;</a>'."\n";
         $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$lo.'#'.$status.'_transfers">&gt;&gt;</a>'."\n";
     }
     
     $navigation .= '</div>'."\n";
     
-    if($page->total_count > $page_size)
+    if($total_count > $page_size)
         echo $navigation;
     
     Template::display('transfers_table', array(
         'status' => $status,
         'mode' => 'admin',
-        'transfers' => $page->entries
+        'transfers' => $entries
     ));
     
-    if($page->total_count > $page_size)
+    if($total_count > $page_size)
         echo $navigation;
 };
 

--- a/templates/admin_transfers_section.php
+++ b/templates/admin_transfers_section.php
@@ -15,6 +15,9 @@ $transfers_page = function($status) {
     $offset = array_key_exists($status.'_tpo', $_REQUEST) ? (int)$_REQUEST[$status.'_tpo'] : 0;
     $offset = max(0, $offset);
 
+    // FIXME: move the code away from wanting to know the total.
+    //       if the user has 1000 tuples do we really want to show 1000/15 direct page links
+    //       or should we instead allow queries on timeframe etc.
     $total_count = 100;
     $entries = Transfer::all(array('where' => $selector, 'count' => $page_size, 'offset' => $offset));
     

--- a/templates/transfers_page.php
+++ b/templates/transfers_page.php
@@ -1,17 +1,38 @@
+<?php
+
+    $openoffset   = $_GET['openoffset'];
+    $openlimit    = $_GET['openlimit'];
+    $closedoffset = $_GET['closedoffset'];
+    $closedlimit  = $_GET['closedlimit'];
+
+    if(!isset($openoffset))   $openoffset   = 0;
+    if(!isset($openlimit))    $openlimit    = 10;
+    if(!isset($closedoffset)) $closedoffset = 0;
+    if(!isset($closedlimit))  $closedlimit  = 5;
+
+
+?>
 <div class="box">
-    <?php if(Config::get('auditlog_lifetime') > 0) { ?><h2>{tr:available_transfers}</h2><?php } ?>
+    <?php if(0&&Config::get('auditlog_lifetime') > 0) { ?><h2>{tr:available_transfers}</h2><?php } ?>
     <?php Template::display('transfers_table', array(
         'status' => 'available',
         'mode' => 'user',
-        'transfers' => Transfer::fromUser(Auth::user())
+        'transfers' => Transfer::fromUser(Auth::user(), false, $openlimit+1, $openoffset ),
+        'limit' => $openlimit,
+        'offset' => $openoffset,
+        'pagerprefix' => 'open',
+        'header' => '{tr:available_transfers}'
     )) ?>
     
     <?php if(Config::get('auditlog_lifetime') > 0) { ?>
-    <h2>{tr:closed_transfers}</h2>
     <?php Template::display('transfers_table', array(
         'status' => 'closed',
         'mode' => 'user',
-        'transfers' => Transfer::fromUser(Auth::user(), true)
+        'transfers' => Transfer::fromUser(Auth::user(), true, $closedlimit+1, $closedoffset ),
+        'limit' => $closedlimit,
+        'offset' => $closedoffset,
+        'pagerprefix' => 'closed',
+        'header' => '{tr:closed_transfers}'
     )) ?>
     <?php } ?>
 

--- a/templates/transfers_page.php
+++ b/templates/transfers_page.php
@@ -13,7 +13,6 @@
 
 ?>
 <div class="box">
-    <?php if(0&&Config::get('auditlog_lifetime') > 0) { ?><h2>{tr:available_transfers}</h2><?php } ?>
     <?php Template::display('transfers_table', array(
         'status' => 'available',
         'mode' => 'user',

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -24,6 +24,8 @@
         $base = '?s=' . $_GET['s'];
         $cgioffset = $pagerprefix . 'offset';
         $cgilimit  = $pagerprefix . 'limit';
+        $nextPage  = $offset+$limit;
+        $nextLink  = "$base&$cgioffset=$nextPage&$cgilimit=$limit";
         
         if( $havePrev ) {
            $prevPage = max(0,$offset-$limit);
@@ -34,8 +36,7 @@
         }
 
         if( $haveNext ) {
-           $nextPage = $offset+$limit;
-           echo "<td class='pagenext'><a href='$base&$cgioffset=$nextPage&$cgilimit=$limit'>&gt;</a></td>";
+           echo "<td class='pagenext'><a href='$nextLink'>&gt;</a></td>";
         } else {
            echo "<td class='pagenext'>&nbsp;</td>";
         }
@@ -306,7 +307,22 @@
             <td colspan="7">{tr:no_transfers}</td>
         </tr>
         <?php } ?>
+
+        <tr class="pager_bottom_nav">
+            <td colspan="8" class="nextColumn">
+                <?php if($haveNext) { ?>
+                    <?php echo "<a href='$nextLink'>"; ?>
+                    {tr:pager_more}
+                    </a>
+                <?php } else { ?>
+                    {tr:pager_has_no_more}
+                <?php } ?>
+            </td>
+        </tr>
+
     </tbody>
 </table>
+
+
 
 <script type="text/javascript" src="{path:js/transfers_table.js}"></script>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -2,10 +2,51 @@
     if(!isset($status)) $status = 'available';
     if(!isset($mode)) $mode = 'user';
     if(!isset($transfers) || !is_array($transfers)) $transfers = array();
+    if(!isset($limit)) $limit = 100000;
+    if(!isset($offset)) $offset = 0;
+    if(!isset($pagerprefix)) $pagerprefix = '';
     $show_guest = isset($show_guest) ? (bool)$show_guest : false;
     $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
     $audit = (bool)Config::get('auditlog_lifetime') ? '1' : '';
+
+    if( count($transfers) > $limit ) {
+        $haveNext = 1;
+        $transfers = array_slice($transfers,0,$limit);
+    }
+    if( $offset > 0 ) {
+        $havePrev = 1;
+    }
+
+    $showPager = $havePrev || $haveNext;
+    
+    if( $havePrev || $haveNext ) {
+        echo '<table class="paginator" border="1"><tr>';
+        $base = '?s=' . $_GET['s'];
+        $cgioffset = $pagerprefix . 'offset';
+        $cgilimit  = $pagerprefix . 'limit';
+        
+        if( $havePrev ) {
+           $prevPage = max(0,$offset-$limit);
+           echo "<td class='pageprev0'><a href='$base&$cgioffset=0&$cgilimit=$limit'>&lt;&lt;</a></td>";
+           echo "<td class='pageprev'><a href='$base&$cgioffset=$prevPage&$cgilimit=$limit'>&lt;</a></td>";
+        } else {
+           echo "<td class='pageprev0'>&nbsp;&nbsp;</td><td class='pageprev'>&nbsp;</td>";
+        }
+
+        if( $haveNext ) {
+           $nextPage = $offset+$limit;
+           echo "<td class='pagenext'><a href='$base&$cgioffset=$nextPage&$cgilimit=$limit'>&gt;</a></td>";
+        } else {
+           echo "<td class='pagenext'>&nbsp;</td>";
+        }
+        echo "<td class='pageheader'>$header</td>";
+        echo '</tr></tbody></table>';
+    } else {
+        if( strlen($header) )
+            echo "<h2>$header</h2>";
+    }
 ?>
+
 <table class="transfers list" data-status="<?php echo $status ?>" data-mode="<?php echo $mode ?>" data-audit="<?php echo $audit ?>">
     <thead>
         <tr>
@@ -114,7 +155,7 @@
             <td class="downloads">
                 <?php $dc = count($transfer->downloads); echo $dc; if($dc) { ?> (<span class="clickable expand">{tr:see_all}</span>)<?php } ?>
             </td>
-            
+           
             <td class="expires" data-rel="expires">
                 <?php echo Utilities::formatDate($transfer->expires) ?>
             </td>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1252,4 +1252,23 @@ table.guests .guest .to .errors .details {
     display: none;
 }
 
-
+table.paginator .pageprev0 {
+    width: 2em;
+    text-align: center;
+}
+table.paginator .pageprev {
+    width: 1em;
+    text-align: center;
+}
+table.paginator .pagenext {
+    width: 1em;
+    text-align: center;
+}
+table.paginator .pageheader {
+    text-align: left;
+    font-size: 1.15em;
+    font-weight: bold;
+}
+table.paginator a {
+    text-decoration: none;
+}

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -337,6 +337,11 @@ table.list thead tr {
     font-weight: bold;
 }
 
+.pager_bottom_nav {
+    background-color: #eee;
+    text-align: right;
+}
+
 table.list th {
     text-align: center;
 }


### PR DESCRIPTION
DBObject::all() had some support for offset and limit (count) data though it was evaluated client side. Moving that to the db side allows for efficient evaluation with the minor cost that the client doesn't get to know the total number of matches any more.

The admin transfers page is the only client of the old code which has been updated to work with the db side queries. The number of pages is currently only a guess, though the speed of loading should more than make up for that temporary inconvenience.

I used the old fetch one more trick to allow the my transfers page to know if there are more records (a next page) or not. This is why transfers_page selects limit+1. The +1 is not shown to the user and only used to know if there is a next tuple or not.

With the seondary indexes already in place this should make the "My Transfers" page much more useful to medium to heavy system users.