### PR TITLE
give a little help to the admin if they set log_facilities in a way we dont expect

### DIFF
--- a/classes/exceptions/ConfigExceptions.class.php
+++ b/classes/exceptions/ConfigExceptions.class.php
@@ -76,10 +76,10 @@ class ConfigMissingParameterException extends DetailedException {
      * 
      * @param string $key name of the missing parameter
      */
-    public function __construct($key) {
+    public function __construct($key,$notetoadmin = '') {
         parent::__construct(
             'config_missing_parameter', // Message to give to the user
-            array('parameter' => $key) // Details to log
+            array('parameter' => $key, 'noteToAdmin' => $notetoadmin) // Details to log
         );
     }
 }

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -124,7 +124,8 @@ class Config {
         include_once($main_config_file);
         if ($virtualhost != null)
             $config['virtualhost'] = $virtualhost;
-        
+
+
         self::merge(self::$parameters, $config);
         
         // Load virtualhost config if used
@@ -211,6 +212,15 @@ class Config {
         
         if(!self::get('default_guest_days_valid'))
             self::$parameters['default_guest_days_valid'] = self::get('max_guest_days_valid');
+
+        // verify user settings
+        if( array_key_exists("log_facilities",$config)
+            && !is_array(array_shift(array_slice($config["log_facilities"],0,1))))
+        {
+            throw new ConfigMissingParameterException('log_facilities[]',
+            'Maybe you have set $config["log_facilities"] = array("type" => "file",...) instead of $config["log_facilities"] = array(array("type" => "file",...))' );
+        }
+
     }
             
     /**

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -113,8 +113,13 @@ class Logger {
             switch(strtolower($facility['type'])) {
                 case 'file' :
                     // Log to file needs at least a path
-                    if(!array_key_exists('path', $facility))
-                        throw new ConfigMissingParameterException('log_facilities['.$index.'][path]');
+                    if(!array_key_exists('path', $facility)) {
+                        // we can get here if the user has set $config['log_facilities'] to
+                        // just an array instead of an array of array.
+                        
+                        throw new ConfigMissingParameterException('log_facilities['.$index.'][path]',
+                           'Maybe you have set $config["log_facilities"] = array("type" => "file",...) instead of $config["log_facilities"] = array(array("type" => "file",...))' );
+                    }
                     
                     // If defined rotation rate must be valid
                     if(array_key_exists('rotate', $facility) && !in_array($facility['rotate'], array('hourly', 'daily', 'weekly', 'monthly', 'yearly')))

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -114,11 +114,7 @@ class Logger {
                 case 'file' :
                     // Log to file needs at least a path
                     if(!array_key_exists('path', $facility)) {
-                        // we can get here if the user has set $config['log_facilities'] to
-                        // just an array instead of an array of array.
-                        
-                        throw new ConfigMissingParameterException('log_facilities['.$index.'][path]',
-                           'Maybe you have set $config["log_facilities"] = array("type" => "file",...) instead of $config["log_facilities"] = array(array("type" => "file",...))' );
+                        throw new ConfigMissingParameterException('log_facilities['.$index.'][path]');
                     }
                     
                     // If defined rotation rate must be valid


### PR DESCRIPTION
This relates to the filed issue https://github.com/filesender/filesender/issues/107

It is informative to see how this happens. Default values are loaded and then the user's config.php is loaded and merged. So if the user has the following in the config.php
```
$config['log_facilities'] = 
        array(
            'type' => 'file',
            'path' => '/var/ram/logs/',
            'rotate' => 'hourly'
    ); 
```

The loaded config becomes the invalid mess;

```
(
    [0] => Array
        (
            [type] => file
            [path] => /opt/filesender/log/
            [rotate] => hourly
        )

    [type] => file
    [path] => /var/ram/logs/
    [rotate] => hourly
)
```

There is an attempt to work with these keys, casting them to an array before inspecting, which gets into trouble when the type=>file entry is encountered as it is itself cast to an array but doesn't include the path element into this subarray, so an exception is thrown.

So I now have some verification on the log_facilities that the user sets. I originally had that in the place it is used but moved it to the code that handles loading the config file. This now has a little noteToAdmin in the log to inform the user where they might start for a quick fix.
