### PR TITLE
zip: fencepost error

### DIFF
--- a/classes/utils/Zipper.class.php
+++ b/classes/utils/Zipper.class.php
@@ -210,7 +210,7 @@ class Zipper {
         $bytesSent = 0;
         $chunkSize = Config::get('download_chunk_size');
         
-        for ($offset=0 ; $offset <= $file->size; $offset+=$chunkSize){
+        for ($offset=0 ; $offset < $file->size; $offset+=$chunkSize){
             $data = $file->readChunk($offset);
             echo $data;
             hash_update($hashContext, $data);


### PR DESCRIPTION
offset shouldn't need to be equal to size. A 2 byte file has offsets 0 and 1, reading at offset=2 is invalid.

This silently worked before because StorageFilesystem::readChunk() ignores the return value of seek() and returns null when no data is read.