### PR TITLE
db: auditlog and statlog can be quite large

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -43,7 +43,7 @@ class AuditLog extends DBObject {
     protected static $dataMap = array(
         'id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
             'primary' => true,
             'autoinc' => true
         ),

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -43,7 +43,7 @@ class StatLog extends DBObject {
     protected static $dataMap = array(
         'id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
             'primary' => true,
             'autoinc' => true
         ),

--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -296,7 +296,10 @@ class DatabaseMysql {
      * @param array $problems problematic options
      */
     public static function updateTableColumnFormat($table, $column, $definition, $problems) {
-        $query = 'ALTER TABLE '.$table.' MODIFY '.$column.' '.self::columnDefinition($definition);
+        $localdef = $definition;
+        if(array_key_exists('primary', $localdef) && $localdef['primary'])
+            $localdef['primary'] = false;
+        $query = 'ALTER TABLE '.$table.' MODIFY '.$column.' '.self::columnDefinition($localdef);
         DBI::exec($query);
     }
     


### PR DESCRIPTION
This moves the id column of these two tables to be larger. It is a shame that the default meduim sized int in mysql is meduim which is 3 bytes (16million) instead of a 4 byte int which would be much harder to bump into the limits for.

It is overkill making these bigints which are 8 byte numbers on both db backends. If we store 9 million, million, million records in any auditlog then we are doing well.

I noticed that MariaDB doesn't like it if you alter column for an existing primary key and state primary key in the alter clause. I have removed that in the code so that migration can be done simply using the update.db script. In the future we should really ensure that we are not making the column a primary key in the db upgrade (ie, only remove the primary key clause in the alter column if it is already a primary key in the db). 