### PR TITLE
NO MERGE Various crypto improvements

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -746,11 +746,20 @@ class Transfer extends DBObject {
 
         // padding on the last chunk of the file
         // may not be a full chunk so need to calculate
-        $lastChunkPadding = 16 - $lastChunkSize % 16;
-        if ($lastChunkPadding == 0)
-            $lastChunkPadding = 16;
-            
-        return $file->size + ($chunksMinusOne * $echunkdiff) + $lastChunkPadding + 16;
+        switch(Config::get('crypto_crypt_name')) {
+            case 'AES-CBC': {
+                $lastChunkPadding = 16 - $lastChunkSize % 16;
+                if ($lastChunkPadding == 0)
+                    $lastChunkPadding = 16;
+                break;
+            }
+            case 'AES-GCM': {
+                $lastChunkPadding = 16;
+                break;
+            }
+            default: throw new ConfigBadParameterException('crypto_crypt_name');
+        }
+        return $file->size + ($chunksMinusOne * $echunkdiff) + $lastChunkPadding + Config::get('crypto_iv_len');
     }
 
     /**

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -284,9 +284,19 @@ class RestEndpointFile extends RestEndpoint {
                 // Calculate the correct length
                 $chunkLength = strlen($data);
                 // The encryption adds padding and a checksum
-                $paddedLength = 16 - $client['X-Filesender-Chunk-Size'] % 16;
-                if ($paddedLength == 0) {
-                    $paddedLength = 16;
+                switch(Config::get('crypto_crypt_name')) {
+                    case 'AES-CBC': {
+                        $paddedLength = 16 - $client['X-Filesender-Chunk-Size'] % 16;
+                        if ($paddedLength == 0) {
+                            $paddedLength = 16;
+                        }
+                        break;
+                    }
+                    case 'AES-GCM': {
+                        $paddedLength = 16;
+                        break;
+                    }
+                    default: throw new ConfigBadParameterException('crypto_crypt_name');
                 }
                 // The initialization vector
                 $ivLength = Config::get('crypto_iv_len');

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -289,7 +289,7 @@ class RestEndpointFile extends RestEndpoint {
                     $paddedLength = 16;
                 }
                 // The initialization vector
-                $ivLength = 16;
+                $ivLength = Config::get('crypto_iv_len');
                 // Content length
                 $data_length = ($chunkLength - $paddedLength - $ivLength);
             } else {

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -381,7 +381,7 @@ class StorageFilesystem {
 
         if($file->transfer->options['encryption']){
             if($size != $file->encrypted_size)
-                throw new FileIntegrityCheckFailedException($file, 'Expected size was '.$file->size.' but size on disk is '.$size);
+                throw new FileIntegrityCheckFailedException($file, 'Expected size was '.$file->encrypted_size.' but size on disk is '.$size);
         }else{
             if($size != $file->size)
                 throw new FileIntegrityCheckFailedException($file, 'Expected size was '.$file->size.' but size on disk is '.$size);

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -87,10 +87,10 @@ $default = array(
     'download_chunk_size' => 5 * 1024 * 1024,
     
     'encryption_enabled' => true,
-    'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
-    'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config
-    'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used
-    'crypto_hash_name' => "SHA-256", // The hash used to convert password to hashencryption_enabled
+    'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 32 + 16, // 32 for IV, 16 checksum for AES-GCM/AES-CBC
+    'crypto_iv_len' => 32,
+    'crypto_crypt_name' => 'AES-GCM', // The encryption algorithm used
+    'crypto_hash_name' => 'SHA-256', // The hash used to convert password to hash
 
     'terasender_enabled' => true,
     'terasender_disableable' => true,

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -88,9 +88,11 @@ $default = array(
     
     'encryption_enabled' => true,
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 32 + 16, // 32 for IV, 16 checksum for AES-GCM/AES-CBC
-    'crypto_iv_len' => 32,
+    'crypto_iv_len' => 32, // IV length
+    'crypto_crypt_length' => 256, // The block length of the algorithm, 256 because SHA-256
     'crypto_crypt_name' => 'AES-GCM', // The encryption algorithm used
     'crypto_hash_name' => 'SHA-256', // The hash used to convert password to hash
+    'crypto_hash_iterations' => 100, // How many hashing iterations must be done
 
     'terasender_enabled' => true,
     'terasender_disableable' => true,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -83,7 +83,9 @@ window.filesender.config = {
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',
     crypto_crypt_name: '<?php echo Config::get('crypto_crypt_name') ?>',
+    crypto_crypt_length: '<?php echo Config::get('crypto_crypt_length') ?>',
     crypto_hash_name: '<?php echo Config::get('crypto_hash_name') ?>',
+    crypto_hash_iterations: '<?php echo Config::get('crypto_hash_iterations') ?>',
 
     terasender_enabled: <?php  echo value_to_TF(Config::get('terasender_enabled')) ?>,
     terasender_advanced: <?php echo value_to_TF(Config::get('terasender_advanced')) ?>,

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -97,7 +97,7 @@ window.filesender.crypto_app = function () {
                         'decrypt',
                     ]
                 )
-            }, filesender.ui.log).then(callback, filesender.ui.log);
+            }, window.filesender.ui.log).then(callback, window.filesender.ui.log);
         },
         encryptBlob: function encryptBlob(value, password, callback) {
             // NOTE: This function is used per chunk.
@@ -110,7 +110,7 @@ window.filesender.crypto_app = function () {
             // Derive key from password and use it for encryption
             this.generateKey(password, function (key) {
                 // Use 32 bytes, or 256 bits, because SHA-256.
-                var iv = crypto.getRandomValues(new Uint8Array($this.crypto_crypt_length/8));
+                var iv = crypto.getRandomValues(new Uint8Array($this.crypto_iv_len));
                 // Do the actual encryption
                 // Will call the callback with a bytestring consisting of the IV and the ciphertext
                 crypto.subtle.encrypt(
@@ -139,7 +139,7 @@ window.filesender.crypto_app = function () {
                         // encrypt failed
                         function (e) {
                             // error occured during crypt
-                            filesender.ui.log(e);
+                            window.filesender.ui.log(e);
                         }
                 );
 


### PR DESCRIPTION
**WARNING** If you merge this, all existing encrypted files will become unreadable! Explaination follows

The crypto code has a couple of issues:
- [X] Some configurable values are hardcoded, breaking things if you change them from the default
- [X] No key derivation algorithm is used
- [ ] No use of salt in key derivation
- [ ] Encryption is done blockwise, with a new encryption call per block
- [X] Code hard to read because of few comments
- [X] Hard to debug because of errornous message in integrity check
- [ ] Allows offline attacks

Most of the issues have been fixed here, but some are not. Here follows a detailed explanation of the changes made, and what is still missing. Please note that I'm not a cryptographer, but SURFnet will issue an official report from a cryptographer, which will comment these changes.

For every chapter I have made a checklist of things that would be "nice to have", but I was not able to check everything off the list. The report from SURFnet will comment on these.

# 🗝 Key derivation

When encrypting data using a password, you need to convert the password to a key, as encryption/decryption algorithms need a fixed-length key. The naive implementation (as FileSender used) is to hash the password and use the hash as a key. This allows for dictionary attacks, because since there are few passwords, there are few possible keys.

The better solution is to use a key derivation algorithm. In this pull request, I'll use [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2), which takes a **password**, **hashing function**, **salt** and an amount of **iterations**. It will then produce a key. The problem is that the salt should be random for each file, but it must be stored somewhere. Since I have nowhere to store it right now, I was not able to use a random salt. Because of this, **the code in this pull request does not use a salt**, but it should (#195).

- [X] Start using key derivation
- [X] Make derivation parameters configurable
- [ ] Use salt
- [ ] Store used salt alongside file
- [ ] Store parameters alongside file, so an admin can safely change them for newer files
- [ ] Backwards compatibility for decryption keys derived without PBKDF2

## ⚠️ Important

Because the key derivation procedure changed in this pull request, **_no encrypted files uploaded by the old code will be readable by the new code._** I strongly recommend that **encryption algorithm** and **hashing algorithm** will be stored alongside encrypted files, so that future changes can be made without breaking all existing encrypted files. This may be solved in the same fashion as #136.

# 📦 Chunked encryption

As most will know, FileSender chops files up in chunks, which are 5MB size blocks of files. When encrypting files, FileSender will encrypt each block with its own initialization vector (IV). The IV is then prepended to the block (growing the block with the size of the IV, 16 bytes in the old code, 32 bytes in the new code), growing the block with this amount of bytes. Additionally, the `AES-CBC` and `AES-GCM` encryption algorithms will add a checksum to the file, to allow the decryption algorithm to decide whether decryption has succeeded. This grows the chunk with (up to) an additional 16 bytes.

From a cryptographic standpoint, the data is chopped up in smaller chunks (blocks) less than 1K, which all are encrypted. For the first blocks ciphertext, the IV is used together with the derived key to encrypt the plaintext. For the second block and thereafter, the previous ciphertext is used as "IV", together with the derived key it will encrypt the plaintext to the ciphertext. By having FileSender chop up files in 5MB chunks, we have to make a new IV for every chunk. I'm not currently aware of a way to fix this, as the WebCrypto library only allows for encrypting strings and not streams. Doing large files at once could consume too much memory.

- [X] Support both `AES-CBC` and `AES-GCM` block ciphers
- [X] Make block ciphers configurable
- [ ] Store block cipher configuration alongside file, so an admin can safely change them for newer files
- [ ] Sanity check for block cipher configuration instead of silent crash
- [ ] Encrypt whole file without new IV every 5MB

# 🕵️ Offline attacks

When a file is uploaded to FileSender using encryption, it is still possible for anybody who has the download link to download the encrypted file, and start brute-forcing it.  This is not really trivial to solve, as the server is supposed to never see the password, so the user must not send the password to the server.

A possible solution is that the uploader must encrypt a nonce known to the server, and upload that alongside the file. The server can then provide the downloader with the encrypted nonce, and only release the encrypted file if the downloader can proof ownership of it by presenting an unencrypted nonce.

- [ ] Store encrypted and unencrypted nonce alongside the file
- [ ] Prevent downloading the file without presenting the unencrypted nonce