### PR TITLE
Config validation: fail very fast for bad configuration settings in guest

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -419,8 +419,19 @@ class Guest extends DBObject {
         // Get defaults
         $options = Config::get('guest_options');
         if(!is_array($options)) $options = array();
-        
+
+        self::validateOptions($options);
         return $options;
+    }
+
+    /**
+     * Perform reasonably fast validation of config options.
+     * This allows the global config loader to check with many classes
+     * by calling class::validateConfig() so that particular pages do not
+     * have to be loaded to find configuration issues.
+     */
+    public static function validateConfig() {
+        self::allOptions();
     }
     
     /**
@@ -471,7 +482,8 @@ class Guest extends DBObject {
     }
     
     /**
-     * Validate and format options
+     * Validate and format options.
+     * throws an exception if the raw_options contain invalid data
      * 
      * @param mixed $raw_options
      * 
@@ -480,9 +492,12 @@ class Guest extends DBObject {
     public static function validateOptions($raw_options) {
         $options = array();
         foreach((array)$raw_options as $name => $value) {
-            if(!GuestOptions::isValidValue($name))
-                throw new BadOptionNameException($name);
-            
+            if(!GuestOptions::isValidValue($name)) {
+                throw new BadOptionNameException($name,
+                   'Please check if you have an invalid key in your guest_options configuration. '
+                   . GuestOptions::getConfigKeysAsLogString()
+                );
+            }
             $value = (bool)$value;
             
             $options[$name] = $value;

--- a/classes/exceptions/BadExceptions.class.php
+++ b/classes/exceptions/BadExceptions.class.php
@@ -130,10 +130,10 @@ class BadOptionNameException extends DetailedException {
      * 
      * @param string $name
      */
-    public function __construct($name) {
+    public function __construct($name,$notetoadmin = '') {
         parent::__construct(
             'bad_option_name', // Message to give to the user
-            array('name' => $name) // Details to log
+            array('name' => $name,'noteToAdmin' => $notetoadmin) // Details to log
         );
     }
 }

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -221,6 +221,9 @@ class Config {
             'Maybe you have set $config["log_facilities"] = array("type" => "file",...) instead of $config["log_facilities"] = array(array("type" => "file",...))' );
         }
 
+        // verify classes are happy
+        Guest::validateConfig();
+        
     }
             
     /**

--- a/classes/utils/Enum.class.php
+++ b/classes/utils/Enum.class.php
@@ -102,4 +102,23 @@ abstract class Enum {
     public static function all() {
         return self::getConstants();
     }
+
+    /**
+     * get an array of the config keys from all()
+     */
+    public static function getConfigKeys() {
+        $constants = self::getConstants();
+        $keys = array_map('strtolower', array_keys($constants));
+        return $keys;        
+    }
+
+    /**
+     * helper function for logging invalid keys. This returns the prefix
+     * string and all the possible config keys for this enum type to help
+     * the administrator.
+     */
+    public static function getConfigKeysAsLogString( $msgprefix = ' possible keys are: ') {
+        $vv = implode(' ',GuestOptions::getConfigKeys());
+        return $msgprefix . print_r($vv,true);
+    }
 }


### PR DESCRIPTION
As has been reported in issue 197, if you have a configuration for
guest_options that uses an invalid key then you will have only
discovered this when a guest voucher sent out is attempted.

This PR moves the detection of an invalid option to a top level event.
You will not see a filesender website if there is an invalid setting
but will get a log message telling you about this, what key is
offending, and what the possible keys are in case you have mistyped
something.