### PR TITLE
Race condition of file.complete and transaction.complete

### DIFF
--- a/www/lib/terasender/terasender.js
+++ b/www/lib/terasender/terasender.js
@@ -227,6 +227,12 @@ window.filesender.terasender = {
         var workers_on_same_file = false;
         var min_offset = file.uploaded;
         var fine_progress = 0;
+
+        var uploading_count = 0;
+        for(var i=0; i<this.workers.length; i++) {
+            if(this.workers[i].status.match(/^(uploading)$/)) 
+                uploading_count++;
+        }
         
         for(var i=0; i<this.workers.length; i++) {
             if(!this.workers[i].status.match(/^(running|uploading)$/)) continue;
@@ -276,7 +282,24 @@ window.filesender.terasender = {
                     break;
                 }
 
-        if(chunks_pending || workers_uploading) return;
+            if(chunks_pending || workers_uploading) return;
+            
+            //
+            // If the final chunks of the final two files are
+            // uploading it is possible that we can get here for the
+            // second last file and that would present a race
+            // condition between this reportComplete() whih itself
+            // calls transferComplete() which is not the case until we
+            // are finishing the last chunk of the last file.
+            //
+            // NOTE that we can not simply place the uploading_count
+            // test above and set 'var complete = false' because
+            // reportProgress() uses the callable complete as a
+            // boolean to indicate if we are on the last chunk of the
+            // file, which we are, but maybe not the last file as
+            // well.
+            //
+            if( uploading_count > 1 ) return;
           
             // Notify all done
             t.transfer.reportComplete();


### PR DESCRIPTION
The patch is mostly comment, better to be informative there than here.

The basic version is that there was a race between calling
file.complete and transaction.complete. Logging can show that for the
final two chunks nothing was explicitly stopping transaction.complete
from landing before the last chunk of the last file. A test was
already stopping transaction.complete from being called more than
once. There are multiple timeout delays involved in eventually calling
transaction.complete so the chances of that happening on a LAN were
less. Normally on a LAN the workers would themselves complete and call
file.complete before the timeouts ran and the already scheduled
transaction.complete would actually call the server.

This patch makes it explicit that transaction.complete is only
scheduled for the final chunk uploaded on the final file.

So I guess like many races, the finding and reasoning largely
outweighs the size of the code patch required to mitigate the
scenario.