### PR TITLE
stall: new mode to show more info to user

### DIFF
--- a/dev/doc/filesender-2.0-config-directives-markdown.txt
+++ b/dev/doc/filesender-2.0-config-directives-markdown.txt
@@ -65,6 +65,7 @@
 * [autocomplete_max_pool](#autocomplete_max_pool)
 * [autocomplete_min_characters](#autocomplete_min_characters)
 * [upload_display_bits_per_sec](#upload_display_bits_per_sec)
+* [upload_display_per_file_stats](#upload_display_per_file_stats)
 
 
 ##Transfers
@@ -558,6 +559,17 @@ User language detection is done in the following order:
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ does this actually work?
+
+
+###upload_display_per_file_stats
+* __description:__ show the duration of the current chunk for each worker to the user during uploads
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.0
+* __1.x name:__
+
+
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -46,6 +46,7 @@ $default = array(
     'email_use_html' => true,   // By default, use HTML on mails
     'relay_unknown_feedbacks' => 'sender',   // Report email feedbacks with unknown type but with identified target (recipient or guest) to target owner
     'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds 
+    'upload_display_per_file_stats' => false, //
     'force_ssl' => true,
     
     'auth_sp_type' => 'saml',  // Authentification type

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -1,5 +1,10 @@
 <?php
 
+$formClasses = "upload_form_regular";
+if (Config::get('upload_display_per_file_stats')) {
+   $formClasses = "upload_form_stats";
+}
+
 if(Auth::isGuest()) {
     $guest = AuthGuest::getGuest();
     
@@ -30,7 +35,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 ?>
 
 <div class="box">
-    <form id="upload_form" enctype="multipart/form-data" accept-charset="utf-8" method="post" data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>">
+    <form id="upload_form" class="<?php echo $formClasses; ?>" enctype="multipart/form-data" accept-charset="utf-8" method="post" data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>">
         <div class="box">
             <div class="files"></div>
             

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -524,8 +524,8 @@ table.list .date {
     overflow-y: scroll;
 }
 
-#upload_form .files .file,
-#upload_form .required_files .file {
+.upload_form_regular .files .file,
+.upload_form_regular .required_files .file {
     position: relative;
     margin: 0.2em;
     padding: 0.5em;
@@ -535,6 +535,18 @@ table.list .date {
     background-color: #dedede;
     line-height: 1.8em;
     /*height: 1.8em;*/
+}
+
+.upload_form_stats .files .file,
+.upload_form_stats .required_files .file {
+    position: relative;
+    margin: 0.2em;
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 0.5em;
+    -moz-border-radius: 0.5em;
+    background-color: #dedede;
+    line-height: 3.6em;
 }
 
 #upload_form .required_files .file {
@@ -1277,4 +1289,40 @@ table.paginator .pageheader {
 }
 table.paginator a {
     text-decoration: none;
+}
+
+.good {
+    background: #1cff1c;
+}
+
+.middle {
+    background: #ffff1c;
+}
+
+.slow {
+    background: #ff1c1c;
+}
+
+.bad {
+    background: #ff0000;
+}
+
+.uploadthread {
+    font-family: monospace;
+    font: "Lucida Console", Monaco, monospace;
+    font-size: 10px;
+    width: 4em;
+    height: 10px;
+}
+
+.workercrust {
+    width: 100%;
+    position: absolute;
+    right: 0px;
+    bottom: 0px;
+    padding: 3px;
+}
+
+.crust {
+       float:right;
 }

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -112,6 +112,8 @@ window.filesender.config = {
     
     logon_url: '<?php echo AuthSP::logonURL() ?>',
 
+    upload_display_per_file_stats: '<?php echo Config::get('upload_display_per_file_stats') ?>',
+
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",
 		decrypting : "<?php echo Lang::tr('decrypting')->out(); ?>",

--- a/www/lib/terasender/terasender.js
+++ b/www/lib/terasender/terasender.js
@@ -336,7 +336,7 @@ window.filesender.terasender = {
                 
             case 'requestJob' :
                 var gave = this.giveJob(worker_id, workerinterface);
-                if(gave) this.transfer.recordUploadStartedInWatchdog('worker:' + worker_id);
+                if(gave) this.transfer.recordUploadStartedInWatchdog('worker:' + worker_id, gave.file);
                 break;
             
             case 'securityTokenChanged' :


### PR DESCRIPTION
A new mode is available which shows the duration that a chunk has been
active in the upload page. This way a user can see a chunk that is
taking a long time and also get more information that a transfer is
not stalled even though it is a huge file and the progress meter will
move very slowly.

It is early days for the feature. Hopefully the insights gained will
help work out the final kinks in the stall detection and also offer
the user the ability to report a stall that they think is invalid.