### PR TITLE
saml: better reporting for things going wrong in setup

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -59,7 +59,12 @@ class AuthSPSaml {
      * Cache attributes
      */
     private static $attributes = null;
-    
+
+    /**
+     * Cache authentication status
+     */
+    private static $SimpleSAMLphpVersion = null;
+
     /**
      * Authentication check.
      * 
@@ -211,7 +216,23 @@ class AuthSPSaml {
         }
         
         if(is_null(self::$simplesamlphp_auth_simple)) {
-            require_once(self::$config['simplesamlphp_location'] . 'lib/_autoload.php');
+            $saml_auto_load_path = self::$config['simplesamlphp_location'] . 'lib/_autoload.php';
+            if( !file_exists($saml_auto_load_path)) {
+                Logger::haltWithErorr('SimpleSAMLphp not found at expected path ' . $saml_auto_load_path);
+            }
+            if( !is_readable($saml_auto_load_path)) { 
+                Logger::haltWithErorr('SimpleSAMLphp can not read file at path ' . $saml_auto_load_path);
+            }
+
+            // actually bring in the autoload file
+            if ((include_once($saml_auto_load_path)) == FALSE) {
+                Logger::haltWithErorr('Failed to include SimpleSAMLphp from path ' . $saml_auto_load_path);
+            }
+
+            // grab the version of the library that is in use.
+            $samlConfig = SimpleSAML_Configuration::getInstance();
+            self::$SimpleSAMLphpVersion = $samlConfig->getVersion();
+            // Logger::info('Loaded SimpleSAMLphp version is ' . self::$SimpleSAMLphpVersion);
             
             self::$simplesamlphp_auth_simple = new SimpleSAML_Auth_Simple(self::$config['authentication_source']);
         }

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -175,7 +175,16 @@ class Logger {
         // Remove failsafe facility if everything went well
         if(count(self::$facilities) >= 2) array_shift(self::$facilities);
     }
-    
+
+    /**
+     * Log terminating error. This does not return.
+     * 
+     * @param string $message
+     */
+    public static function haltWithErorr($message) {
+        self::log(LogLevels::ERROR, $message);
+        exit('An error has occurred');    
+    }
     /**
      * Log error
      * 
@@ -184,7 +193,7 @@ class Logger {
     public static function error($message) {
         self::log(LogLevels::ERROR, $message);
     }
-    
+
     /**
      * Log warn
      * 


### PR DESCRIPTION
This offers some more information in the log if the saml files are not found where FileSender is expecting them to be or for some reason they are not readable (permissions, selinux).
