### PR TITLE
auth: some protection from recursive loops during setup

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -68,13 +68,23 @@ class Auth {
      * Last authentication exception for systematic rethrow
      */
     private static $exception = null;
-    
+
+    /**
+     * There can be call loops when setting up classes. For example
+     * if some code calls Auth::user() indirectly while the auth system
+     * is being setup then that can cause troubles.
+     * 
+     * While this is public it should be only used by classes inside
+     * the auth system
+     */
+    public static $authClassLoadingCount = 0;
+
     /**
      * Return current user if it exists.
      * 
      * @return User instance or false
      */
-    public static function user() {
+    private static function user_protected() {
         if(self::$exception)
             throw self::$exception;
         
@@ -171,6 +181,44 @@ class Auth {
         }
         
         return self::$user;
+    }
+
+    /**
+     * Return current user if it exists.
+     *
+     * see the private user_protected() for implementation.
+     *
+     * implementation note: this nests a call to user_protected() so that
+     * authClassLoadingCount can be incr/decr paired around the auth work
+     *
+     * This allows code to call other methods that might themselves want
+     * to indirectly call auth::user(). This can happen for example if 
+     * any code calls Logger::info() or the like as that code might well 
+     * call user() on your behalf. Note that if user() is called from code 
+     * inside user() then the nested call will return false, which is better 
+     * than infinite recursion but might not be quite what you expected.
+     * 
+     * @return User instance or false
+     */
+    public static function user() {
+        if(self::$exception)
+            throw self::$exception;
+
+        if( self::$authClassLoadingCount ) {
+            return false;
+        }
+
+        try {
+            self::$authClassLoadingCount++;
+
+            $ret = self::user_protected();
+            self::$authClassLoadingCount--;
+            return $ret;
+        } catch(Exception $e) {
+            self::$authClassLoadingCount--;
+            self::$exception = $e;
+            throw $e;
+        }
     }
 
     /**

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -214,20 +214,11 @@ class AuthSPSaml {
             ) as $key) if(!array_key_exists($key, self::$config))
             throw new ConfigMissingParameterException('auth_sp_saml_'.$key);
         }
-        
+
+        Auth::$authClassLoadingCount++;
         if(is_null(self::$simplesamlphp_auth_simple)) {
             $saml_auto_load_path = self::$config['simplesamlphp_location'] . 'lib/_autoload.php';
-            if( !file_exists($saml_auto_load_path)) {
-                Logger::haltWithErorr('SimpleSAMLphp not found at expected path ' . $saml_auto_load_path);
-            }
-            if( !is_readable($saml_auto_load_path)) { 
-                Logger::haltWithErorr('SimpleSAMLphp can not read file at path ' . $saml_auto_load_path);
-            }
-
-            // actually bring in the autoload file
-            if ((include_once($saml_auto_load_path)) == FALSE) {
-                Logger::haltWithErorr('Failed to include SimpleSAMLphp from path ' . $saml_auto_load_path);
-            }
+            Utilities::include_once_or_halt( $saml_auto_load_path, 'Failed to include SimpleSAMLphp' );
 
             // grab the version of the library that is in use.
             $samlConfig = SimpleSAML_Configuration::getInstance();
@@ -237,6 +228,7 @@ class AuthSPSaml {
             self::$simplesamlphp_auth_simple = new SimpleSAML_Auth_Simple(self::$config['authentication_source']);
         }
         
+        Auth::$authClassLoadingCount--;
         return self::$simplesamlphp_auth_simple;
     }
 }

--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -108,7 +108,7 @@ class Autoloader {
                 
                 if(!file_exists($file)) {
 
-                    Logger::error('Looking for class '.$class.', expecting it at '.$file.' but nothing found, may (or may not) be a problem ...');
+                    Logger::debug('Looking for class '.$class.', expecting it at '.$file.' but nothing found, may (or may not) be a problem ...');
                     return;
                 }
                 

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -202,7 +202,7 @@ class Logger {
     public static function warn($message) {
         self::log(LogLevels::WARN, $message);
     }
-    
+
     /**
      * Log info
      * 

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -582,14 +582,43 @@ class Utilities {
      * true if $v is array( array( ... ) )
      */
     public static function is_array_of_array( $v ) {
-            if( !is_array($v)) {
-                return false;
-            }
-            $sl = array_slice($v,0,1);
-            if( is_array(array_shift($sl))) {
-                return true;
-            }
+        if( !is_array($v)) {
             return false;
+        }
+        $sl = array_slice($v,0,1);
+        if( is_array(array_shift($sl))) {
+            return true;
+        }
+        return false;
     }
 
+    /**
+     * This does some sniffing around first to see if the file exists
+     * and can be read before trying to include it. If the include
+     * fails then the haltmsg is logged and the function does not return.
+     *
+     * Note that at the moment no syntax checks are done on the included
+     * file. If the file has errors in it then script execution will halt.
+     *
+     * @param string path the file to include_once()
+     * @param haltmsg the message to halt with. This may be decorated with additional
+     * info such as "file not found" if that specific error has occurred.
+     */
+    public static function include_once_or_halt( $path, $haltmsg ) {
+
+        if( !file_exists($path)) {
+            Logger::haltWithErorr( 'File not found at expected path ' . $path 
+                                 . ' ' . $haltmsg);
+        }
+        if( !is_readable($path)) { 
+            Logger::haltWithErorr('Can not read file at path ' . $path
+                                . ' ' . $haltmsg);
+        }
+
+        // actually bring in the autoload file
+        if ((include_once($path)) == FALSE) {
+            Logger::haltWithErorr('Failed to include file from path ' . $path
+                                . ' ' . $haltmsg);
+        }
+    }
 }


### PR DESCRIPTION
It was easy for code that is executed during auth setup to call back into the auth setup which would cause an infinite loop. This brings in some protection against that happening. 