### PR TITLE
externalStorage: share the run() and streams update

### DIFF
--- a/classes/storage/StorageFilesystemExternal.class.php
+++ b/classes/storage/StorageFilesystemExternal.class.php
@@ -197,7 +197,7 @@ class StorageFilesystemExternal extends StorageFilesystem {
 
     public static function getStream(File $file) {
         StorageFilesystemExternalStream::ensureRegistered();
-        $path = "StorageFilesystemiExternalStream://" . $file->uid;
+        $path = "StorageFilesystemExternalStream://" . $file->uid;
         $fp = fopen( $path, "r+");
         return $fp;
     }


### PR DESCRIPTION
The stream class is updated to avoid a name clash with the Chunked stream.