### PR TITLE
crypto and resume: option to not remember transfer if if crypto is on

### DIFF
--- a/dev/doc/filesender-2.0-config-directives-markdown.txt
+++ b/dev/doc/filesender-2.0-config-directives-markdown.txt
@@ -66,6 +66,7 @@
 * [autocomplete_min_characters](#autocomplete_min_characters)
 * [upload_display_bits_per_sec](#upload_display_bits_per_sec)
 * [upload_display_per_file_stats](#upload_display_per_file_stats)
+* [upload_force_transfer_resume_forget_if_encrypted](#upload_force_transfer_resume_forget_if_encrypted)
 
 
 ##Transfers
@@ -568,6 +569,16 @@ User language detection is done in the following order:
 * __default:__ false
 * __available:__ since version 2.0
 * __1.x name:__
+
+
+
+###upload_force_transfer_resume_forget_if_encrypted
+* __description:__ forget partial transfers when upload page is revisited if they were encrypted.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.0
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -47,6 +47,7 @@ $default = array(
     'relay_unknown_feedbacks' => 'sender',   // Report email feedbacks with unknown type but with identified target (recipient or guest) to target owner
     'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds 
     'upload_display_per_file_stats' => false, //
+    'upload_force_transfer_resume_forget_if_encrypted' => false, //
     'force_ssl' => true,
     
     'auth_sp_type' => 'saml',  // Authentification type

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -113,6 +113,7 @@ window.filesender.config = {
     logon_url: '<?php echo AuthSP::logonURL() ?>',
 
     upload_display_per_file_stats: '<?php echo Config::get('upload_display_per_file_stats') ?>',
+    upload_force_transfer_resume_forget_if_encrypted: '<?php echo Config::get('upload_force_transfer_resume_forget_if_encrypted') ?>',
 
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -499,6 +499,7 @@ filesender.ui.evalUploadEnabled = function() {
 };
 
 filesender.ui.startUpload = function() {
+    
     if(!filesender.ui.nodes.required_files) {
         this.transfer.expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
         
@@ -1001,8 +1002,9 @@ $(function() {
         } else if(!auth || auth == 'guest') {
             id = null; // Cancel
         }
+
         
-        if(id) filesender.client.getTransfer(id, function() {
+        if(id) filesender.client.getTransfer(id, function(xdata) {
             // Transfer still exists on server, lets ask the user what to do with it
             
             var load = function() {
@@ -1062,6 +1064,20 @@ $(function() {
             };
             
             var later = function() {};
+
+
+            // maybe we want to force filesender to forget the transfer
+            var force_forget = false;
+
+            if( filesender.config.upload_force_transfer_resume_forget_if_encrypted
+                && xdata.options.encryption )
+            {
+                force_forget = true;
+            }
+            
+            if( force_forget ) {
+                forget();
+            } else {
             
             var prompt = filesender.ui.popup(lang.tr('restart_failed_transfer'), {'load': load, 'forget': forget, 'later': later}, {onclose: later});
             $('<p />').text(lang.tr('failed_transfer_found')).appendTo(prompt);
@@ -1084,7 +1100,7 @@ $(function() {
             
             if(failed.message)
                 $('<div class="message" />').text(lang.tr('message') + ' : ' + failed.message).appendTo(tctn);
-            
+            }            
         }, function(error) {
             if(error.message == 'transfer_not_found') {
                 // Transfer does not exist anymore on server side, remove from tracker


### PR DESCRIPTION
This only effects when you break an upload and then enter the Upload
page again. Normally a dialog "Restart failed transfer" appears
offering to setup the transfer again and "Restart" instead of start
the transfer.

This could be problematic if the user enters a different password for
the resume, having part of the upload encoded with one password and
part with another. It was also reported on
https://github.com/filesender/filesender/issues/80 that resumed
crypted uploads were having issues, so until that is tested to a
greater extent it is better to offer the abilitiy to not allow resume
for crypted transfers.