### PR TITLE
crypto and download: some checks and better handling when not available

### DIFF
--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -55,6 +55,9 @@
             {tr:download_disclamer_archive}
         <?php } ?>
     </div>
+    <div class="crypto_not_supported_message">
+         {tr:file_encryption_disabled}
+    </div>
     
     <div class="general box" data-transfer-size="<?php echo $transfer->size ?>">
         <div class="from">{tr:from} : <?php echo Template::sanitizeOutputEmail($transfer->user_email) ?></div>
@@ -121,5 +124,9 @@
         <div class="transfer" data-id="<?php echo $transfer->id ?>"></div>
     </div>
 </div>
+
+    <div class="transfer_is_encrypted not_displayed">
+        <?php echo $isEncrypted ? 1 : 0;  ?>
+    </div>
 
 <script type="text/javascript" src="{path:js/download_page.js}"></script>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1326,3 +1326,11 @@ table.paginator a {
 .crust {
        float:right;
 }
+
+div.not_displayed {
+    display: none;
+}
+
+.crypto_not_supported_message {
+    display: none;
+}

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -78,7 +78,12 @@ $(function() {
         if (!encrypted && confirm){
             filesender.ui.confirm(lang.tr('confirm_download_notify'), dlcb(true), dlcb(false), true);
         }else{
-             if(encrypted){
+            if(encrypted){
+                if(!filesender.supports.crypto ) {
+                    filesender.ui.alert('error', lang.tr('file_encryption_description_disabled'));
+                    return;
+                }
+                
                 var filename = $($this).find("[data-id='" + ids[0] + "']").attr('data-name');
                 var mime = $($this).find("[data-id='" + ids[0] + "']").attr('data-mime');
 
@@ -128,6 +133,12 @@ $(function() {
     
     var bigger_than_4gb = parseInt($('[data-transfer-size]').attr('data-transfer-size')) > 4 * 1024 * 1024 * 1024;
     var macos = navigator.platform.match(/Mac/);
-    if(!bigger_than_4gb || !macos)
+    if( !bigger_than_4gb || !macos )
         $('.mac_archive_message').hide();
+
+    // only worry the user with this banner if any files are encrypted
+    // and they will not be able to download them.
+    var transfer_is_encrypted = $('.transfer_is_encrypted').text()==1;
+    if( transfer_is_encrypted && !filesender.supports.crypto ) 
+        $('.crypto_not_supported_message').show();
 });


### PR DESCRIPTION
This is a partial solution to
https://github.com/filesender/filesender/issues/191 where dialogs and
messages are presented on the download page when encryption is not
detected. The next step is to work out which is the minimal version of
IE that is needed for things to happily work and ensure that
filesender.supports.crypto is set to false for the failing versions of
IE.