### PR TITLE
stall detection: monitoring bytes within chunk transfers

### DIFF
--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -264,7 +264,8 @@ class RestEndpointFile extends RestEndpoint {
         
         if($mode == 'chunk') {
             // Need to put a chunk of data
-            
+
+
             // File's Transfer must be uploading or just started, fail otherwise
             if(
                 $file->transfer->status != TransferStatuses::STARTED &&

--- a/dev/doc/filesender-2.0-config-directives-markdown.txt
+++ b/dev/doc/filesender-2.0-config-directives-markdown.txt
@@ -582,7 +582,7 @@ User language detection is done in the following order:
 
 
 ###upload_considered_too_slow_if_no_progress_for_seconds
-* __description:__ If 0 this is disabled. If an uploading chunk has not reported any progress in this number of seconds then it is considered in trouble and some action may be taken (eg. force stop and resend of chunk) to try to recover.
+* __description:__ If 0 this is disabled. If an uploading chunk has not reported any progress in this number of seconds then it is considered in trouble and some action may be taken (eg. force stop and resend of chunk) to try to recover. Note that this relies on the browser to report progress messages for ongoing uploads which might only happen every few seconds if a single request is active and maybe for terasender_worker_count=5 you might like to set this to 20 or 30 to avoid thinking a chunk is stalled when it is not.
 * __mandatory:__ no
 * __type:__ int
 * __default:__ 0

--- a/dev/doc/filesender-2.0-config-directives-markdown.txt
+++ b/dev/doc/filesender-2.0-config-directives-markdown.txt
@@ -66,6 +66,7 @@
 * [autocomplete_min_characters](#autocomplete_min_characters)
 * [upload_display_bits_per_sec](#upload_display_bits_per_sec)
 * [upload_display_per_file_stats](#upload_display_per_file_stats)
+* [upload_force_transfer_resume_forget_if_encrypted](#upload_force_transfer_resume_forget_if_encrypted)
 
 
 ##Transfers
@@ -568,6 +569,16 @@ User language detection is done in the following order:
 * __default:__ false
 * __available:__ since version 2.0
 * __1.x name:__
+
+
+
+###upload_force_transfer_resume_forget_if_encrypted
+* __description:__ forget partial transfers when upload page is revisited if they were encrypted.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.0
+
 
 
 

--- a/dev/doc/filesender-2.0-config-directives-markdown.txt
+++ b/dev/doc/filesender-2.0-config-directives-markdown.txt
@@ -67,6 +67,7 @@
 * [upload_display_bits_per_sec](#upload_display_bits_per_sec)
 * [upload_display_per_file_stats](#upload_display_per_file_stats)
 * [upload_force_transfer_resume_forget_if_encrypted](#upload_force_transfer_resume_forget_if_encrypted)
+* [upload_considered_too_slow_if_no_progress_for_seconds](#upload_considered_too_slow_if_no_progress_for_seconds)
 
 
 ##Transfers
@@ -577,6 +578,14 @@ User language detection is done in the following order:
 * __mandatory:__ no
 * __type:__ boolean
 * __default:__ false
+* __available:__ since version 2.0
+
+
+###upload_considered_too_slow_if_no_progress_for_seconds
+* __description:__ If 0 this is disabled. If an uploading chunk has not reported any progress in this number of seconds then it is considered in trouble and some action may be taken (eg. force stop and resend of chunk) to try to recover.
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 0
 * __available:__ since version 2.0
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -48,6 +48,7 @@ $default = array(
     'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds 
     'upload_display_per_file_stats' => false, //
     'upload_force_transfer_resume_forget_if_encrypted' => false, //
+    'upload_considered_too_slow_if_no_progress_for_seconds' => 0, // seconds
     'force_ssl' => true,
     
     'auth_sp_type' => 'saml',  // Authentification type

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -47,6 +47,7 @@ $default = array(
     'relay_unknown_feedbacks' => 'sender',   // Report email feedbacks with unknown type but with identified target (recipient or guest) to target owner
     'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds 
     'upload_display_per_file_stats' => false, //
+    'upload_force_transfer_resume_forget_if_encrypted' => false, //
     'force_ssl' => true,
     
     'auth_sp_type' => 'saml',  // Authentification type

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -546,7 +546,7 @@ table.list .date {
     border-radius: 0.5em;
     -moz-border-radius: 0.5em;
     background-color: #dedede;
-    line-height: 3.6em;
+    line-height: 5.4em;
 }
 
 #upload_form .required_files .file {

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -113,6 +113,7 @@ window.filesender.config = {
     logon_url: '<?php echo AuthSP::logonURL() ?>',
 
     upload_display_per_file_stats: '<?php echo Config::get('upload_display_per_file_stats') ?>',
+    upload_force_transfer_resume_forget_if_encrypted: '<?php echo Config::get('upload_force_transfer_resume_forget_if_encrypted') ?>',
 
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -114,6 +114,7 @@ window.filesender.config = {
 
     upload_display_per_file_stats: '<?php echo Config::get('upload_display_per_file_stats') ?>',
     upload_force_transfer_resume_forget_if_encrypted: '<?php echo Config::get('upload_force_transfer_resume_forget_if_encrypted') ?>',
+    upload_considered_too_slow_if_no_progress_for_seconds: '<?php echo Config::get('upload_considered_too_slow_if_no_progress_for_seconds') ?>',
 
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -82,7 +82,6 @@ window.filesender.progresstracker = function() {
     };
 
     this.latest = function() {
-        return this.mem[this.mem.length-1];
     };
 
     this.isOffending = function() {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -575,47 +575,21 @@ window.filesender.transfer = function() {
                 memToKeep: 5,
                 disabled: false,
 
-                /**
-                 * Reset the tracker for a fresh chunk
-                 */
                 clear: function() {
                 },
                 
-                /**
-                 * remember the reported fine_progress and take a timestamp
-                 * when this is called.
-                 */
                 remember: function( fine_progress ) {
                 },
 
-                /**
-                 * This disables isOffending() from ever returning true.
-                 */
                 setDisabled: function() {
                 },
 
-                /**
-                 * How many bytes were transfered between the last two
-                 * calls to remember().
-                 */
                 latest: function() {
                 },
 
-                /**
-                 * For the current configuration is this worker
-                 * "offending"ly slow.
-                 * 
-                 * The implementation could taken many forms, a simple
-                 * one being if no progress has been reported for 10
-                 * seconds it might have stalled. Or the number of
-                 * bytes transfered could also be considered.
-                 */
                 isOffending: function() {
                 },
 
-                /**
-                 * Just makes this.log() available.
-                 */
                 log: function(message, origin) {
                 },
             },

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -662,7 +662,6 @@ window.filesender.transfer = function() {
         
         this.watchdog_processes[id].started = (new Date()).getTime();
         this.watchdog_processes[id].file = file;
-        this.watchdog_processes[id].progressTracker.clear();
         
     };
 
@@ -670,7 +669,6 @@ window.filesender.transfer = function() {
      * Record chunk upload progress for worker
      */
     this.recordUploadProgressInWatchdog = function(id,fine_progress) {
-        this.watchdog_processes[id].progressTracker.remember( fine_progress );
     };
     
     /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -626,20 +626,6 @@ window.filesender.transfer = function() {
                  * bytes transfered could also be considered.
                  */
                 isOffending: function() {
-                    if( this.disabled )
-                        return false;
-
-                    var tooSlow = filesender.config.upload_considered_too_slow_if_no_progress_for_seconds;
-                    if( !tooSlow )
-                        return false;
-                    
-                    if( (new Date()).getTime() - this.stamp > (tooSlow*1000) )
-                        return true;
-                    return false;
-
-                    // play with bytes?
-//                    var sum = this.mem.reduce(function(a, b) { return a + b; }, 0);
-//                    return sum == 0;
                 },
 
                 /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -646,7 +646,6 @@ window.filesender.transfer = function() {
                  * Just makes this.log() available.
                  */
                 log: function(message, origin) {
-                    filesender.ui.log('[progressTracker ' + origin + '] ' + message);
                 },
             },
         };

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -769,8 +769,8 @@ window.filesender.transfer = function() {
             d[i] = -1;
             if(this.watchdog_processes[id].started != null) {
                 if( this.watchdog_processes[id].file.name == file.name ) {
-                    var v = this.watchdog_processes[id].progressTracker.isOffending();
-                    d[i] = v;
+//                    var v = this.watchdog_processes[id].progressTracker.isOffending();
+//                    d[i] = v;
                 }
             }
             i++;

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -78,7 +78,6 @@ window.filesender.progresstracker = function() {
     };
 
     this.setDisabled = function() {
-        this.disabled = true;
     };
 
     this.latest = function() {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -58,22 +58,78 @@ window.filesender.progresstracker = function() {
     memToKeep: 5;
     disabled: false;
 
+    /**
+     * Reset the tracker for a fresh chunk
+     */
     this.clear = function() {
+        this.mem = [];
+        this.disabled = false;
+        this.stamp = (new Date()).getTime();
     };
                 
+    /**
+     * remember the reported fine_progress and take a timestamp
+     * when this is called.
+     */
     this.remember = function( fine_progress ) {
+        if( !this.mem.length ) {
+            this.mem[0] = 0;
+            
+        }
+        var d = fine_progress - this.mem[this.mem.length-1];
+        this.mem.push( d );
+        if( this.mem.length >= this.memToKeep )
+            this.mem.pop();
+
+        this.stamp = (new Date()).getTime();
     };
 
+    /**
+     * This disables isOffending() from ever returning true.
+     */
     this.setDisabled = function() {
+        this.disabled = true;
     };
 
+    /**
+     * How many bytes were transfered between the last two
+     * calls to remember().
+     */
     this.latest = function() {
+        return this.mem[this.mem.length-1];
     };
 
+    /**
+     * For the current configuration is this worker
+     * "offending"ly slow.
+     * 
+     * The implementation could taken many forms, a simple
+     * one being if no progress has been reported for 10
+     * seconds it might have stalled. Or the number of
+     * bytes transfered could also be considered.
+     */
     this.isOffending = function() {
+        if( this.disabled )
+            return false;
+
+        var tooSlow = filesender.config.upload_considered_too_slow_if_no_progress_for_seconds;
+        if( !tooSlow )
+            return false;
+        
+        if( (new Date()).getTime() - this.stamp > (tooSlow*1000) )
+            return true;
+        return false;
+
+        // play with bytes?
+        // var sum = this.mem.reduce(function(a, b) { return a + b; }, 0);
+        // return sum == 0;
     };
 
+    /**
+     * Just makes this.log() available.
+     */
     this.log = function(message, origin) {
+        filesender.ui.log('[progressTracker ' + origin + '] ' + message);
     };
 };
 
@@ -606,7 +662,7 @@ window.filesender.transfer = function() {
         
         this.watchdog_processes[id].started = (new Date()).getTime();
         this.watchdog_processes[id].file = file;
-//        this.watchdog_processes[id].progressTracker.clear();
+        this.watchdog_processes[id].progressTracker.clear();
         
     };
 
@@ -614,7 +670,7 @@ window.filesender.transfer = function() {
      * Record chunk upload progress for worker
      */
     this.recordUploadProgressInWatchdog = function(id,fine_progress) {
-//        this.watchdog_processes[id].progressTracker.remember( fine_progress );
+        this.watchdog_processes[id].progressTracker.remember( fine_progress );
     };
     
     /**
@@ -684,8 +740,8 @@ window.filesender.transfer = function() {
             d[i] = -1;
             if(this.watchdog_processes[id].started != null) {
                 if( this.watchdog_processes[id].file.name == file.name ) {
-//                    var bc = this.watchdog_processes[id].progressTracker.latest();
-//                    d[i] = bc;
+                    var bc = this.watchdog_processes[id].progressTracker.latest();
+                    d[i] = bc;
                 }
             }
             i++;
@@ -713,8 +769,8 @@ window.filesender.transfer = function() {
             d[i] = -1;
             if(this.watchdog_processes[id].started != null) {
                 if( this.watchdog_processes[id].file.name == file.name ) {
-//                    var v = this.watchdog_processes[id].progressTracker.isOffending();
-//                    d[i] = v;
+                    var v = this.watchdog_processes[id].progressTracker.isOffending();
+                    d[i] = v;
                 }
             }
             i++;

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -103,7 +103,6 @@ window.filesender.progresstracker = function() {
     };
 
     this.log = function(message, origin) {
-        filesender.ui.log('[progressTracker ' + origin + '] ' + message);
     };
 };
 

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -551,12 +551,109 @@ window.filesender.transfer = function() {
             count: 0,
             durations: [],
             started: null,
-            file: null
+            file: null,
+
+            /**
+             * Track progress of an active chunk upload. This collects
+             * information as an xhr call is progressing to send a
+             * chunk of data that is (upload_chunk_size or equiv)
+             * bytes. The idea is that we can track the bytes as they
+             * go over and allow the user or FileSender itself to do
+             * something smart if a chunk has not sent much or any
+             * data for a chunk for a given time. 
+             * 
+             * you will want to call clear() when a chunk starts,
+             * remember() or setDisabled() when progress on a chunk is
+             * reported, and isOffending() to check if this chunk is
+             * deemed to have not enough recent transfer activity
+             * ("the danger zone").
+             */
+            progressTracker: {
+
+                stamp: (new Date()).getTime(),
+                mem: [],
+                memToKeep: 5,
+                disabled: false,
+
+                /**
+                 * Reset the tracker for a fresh chunk
+                 */
+                clear: function() {
+                    mem = [];
+                    disabled = false;
+                    this.stamp = (new Date()).getTime();
+                },
+                
+                /**
+                 * remember the reported fine_progress and take a timestamp
+                 * when this is called.
+                 */
+                remember: function( fine_progress ) {
+                    if( !this.mem.length ) {
+                        this.mem[0] = 0;
+                        
+                    }
+                    var d = fine_progress - this.mem[this.mem.length-1];
+                    this.mem.push( d );
+                    if( this.mem.length >= this.memToKeep )
+                        this.mem.pop();
+
+                    this.stamp = (new Date()).getTime();
+                },
+
+                /**
+                 * This disables isOffending() from ever returning true.
+                 */
+                setDisabled: function() {
+                    this.disabled = true;
+                },
+
+                /**
+                 * How many bytes were transfered between the last two
+                 * calls to remember().
+                 */
+                latest: function() {
+                    return this.mem[this.mem.length-1];
+                },
+
+                /**
+                 * For the current configuration is this worker
+                 * "offending"ly slow.
+                 * 
+                 * The implementation could taken many forms, a simple
+                 * one being if no progress has been reported for 10
+                 * seconds it might have stalled. Or the number of
+                 * bytes transfered could also be considered.
+                 */
+                isOffending: function() {
+                    if( this.disabled )
+                        return false;
+
+                    var tooSlow = filesender.config.upload_considered_too_slow_if_no_progress_for_seconds;
+                    if( !tooSlow )
+                        return false;
+                    
+                    if( (new Date()).getTime() - this.stamp > (tooSlow*1000) )
+                        return true;
+                    return false;
+
+                    // play with bytes?
+//                    var sum = this.mem.reduce(function(a, b) { return a + b; }, 0);
+//                    return sum == 0;
+                },
+
+                /**
+                 * Just makes this.log() available.
+                 */
+                log: function(message, origin='') {
+                    filesender.ui.log('[progressTracker ' + origin + '] ' + message);
+                },
+            },
         };
     };
     
     /**
-     * Record chunk upload started from process
+     * Record chunk upload started for worker
      * 
      * @param string id process identifier
      */
@@ -565,15 +662,24 @@ window.filesender.transfer = function() {
         
         this.watchdog_processes[id].started = (new Date()).getTime();
         this.watchdog_processes[id].file = file;
+        this.watchdog_processes[id].progressTracker.clear();
         
+    };
+
+    /**
+     * Record chunk upload progress for worker
+     */
+    this.recordUploadProgressInWatchdog = function(id,fine_progress) {
+        this.watchdog_processes[id].progressTracker.remember( fine_progress );
     };
     
     /**
-     * Record chunk upload from process
+     * Record chunk upload from worker
      * 
      * @param string id process identifier
      */
     this.recordUploadedInWatchdog = function(id) {
+        
         if(!(id in this.watchdog_processes)) this.registerProcessInWatchdog(id);
         
         if(this.watchdog_processes[id].started == null) return;
@@ -583,7 +689,7 @@ window.filesender.transfer = function() {
         while(this.watchdog_processes[id].durations.length > this.stalling_detection.durations_horizon) {
             this.watchdog_processes[id].durations.shift();
         }
-        this.watchdog_processes[id].started = null;
+        this.watchdog_processes[id].started = null;    
     };
 
     /**
@@ -595,9 +701,9 @@ window.filesender.transfer = function() {
      * or the duraction that the worker has been active on the current
      * chunk for the nominated file
      * 
-     * the return value will be "stable" for an active transfer.
-     * So that worker 0 will always be the first worker in the return value 
-     * this helps you present the information to the UI.
+     * the return value will be "stable" for an active transfer. So
+     * that worker 0 will always be the first worker in the return
+     * value this helps you present the information to the UI.
      */
     this.getMostRecentChunkDurations = function(file) {
         d = [];
@@ -613,7 +719,64 @@ window.filesender.transfer = function() {
             i++;
         }
         return d;
-    }
+    };
+
+    /**
+     * for a nominated file
+     * return an array with entries for each worker 
+     * (only one "worker" for non terasender)
+     *
+     * each item is the number of bytes transfered between the current and previous progress reported
+     * by the worker
+     * 
+     * the return value will be "stable" for an active transfer. So
+     * that worker 0 will always be the first worker in the return
+     * value this helps you present the information to the UI.
+     */
+    this.getMostRecentChunkFineBytes = function(file) {
+        d = [];
+        i = 0;
+        for(var id in this.watchdog_processes) {
+            d[i] = -1;
+            if(this.watchdog_processes[id].started != null) {
+                if( this.watchdog_processes[id].file.name == file.name ) {
+                    var bc = this.watchdog_processes[id].progressTracker.latest();
+                    d[i] = bc;
+                }
+            }
+            i++;
+        }
+        return d;
+    };
+
+    /**
+     * for a nominated file
+     * return an array with entries for each worker 
+     * (only one "worker" for non terasender)
+     *
+     * each item is true if the worker has not progressed enough
+     * recently. the user might like to know or the whole chunk could
+     * be restarted for the user.
+     * 
+     * the return value will be "stable" for an active transfer. So
+     * that worker 0 will always be the first worker in the return
+     * value this helps you present the information to the UI.
+     */
+    this.getIsWorkerOffending = function(file) {
+        d = [];
+        i = 0;
+        for(var id in this.watchdog_processes) {
+            d[i] = -1;
+            if(this.watchdog_processes[id].started != null) {
+                if( this.watchdog_processes[id].file.name == file.name ) {
+                    var v = this.watchdog_processes[id].progressTracker.isOffending();
+                    d[i] = v;
+                }
+            }
+            i++;
+        }
+        return d;
+    };
     
     /**
      * Look for stalled processes
@@ -1052,18 +1215,21 @@ window.filesender.transfer = function() {
         if (last)
             this.file_index++;
         var was_last_file = transfer.file_index >= transfer.files.length;
-        
-        this.recordUploadStartedInWatchdog('main',file);
+
+        // this saves having to think about the id for the watchdog calls.
+        var worker_id = 'main';
+        this.recordUploadStartedInWatchdog(worker_id,file);
 
         this.uploader = filesender.client.putChunk(
             file, blob, offset,
             function(ratio) { // Progress
                 var chunk_size = Math.min(file.size - file.uploaded, filesender.config.upload_chunk_size);
                 file.fine_progress = Math.floor(file.uploaded + ratio * chunk_size);
+                transfer.recordUploadProgressInWatchdog(worker_id,ratio * chunk_size);
                 transfer.reportProgress(file);
             },
             function() { // Done
-                transfer.recordUploadedInWatchdog('main');
+                transfer.recordUploadedInWatchdog(worker_id);
                 
                 if (last) { // File done
                     transfer.reportProgress(file, function() {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -613,7 +613,6 @@ window.filesender.transfer = function() {
                  * calls to remember().
                  */
                 latest: function() {
-                    return this.mem[this.mem.length-1];
                 },
 
                 /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -662,7 +662,7 @@ window.filesender.transfer = function() {
         
         this.watchdog_processes[id].started = (new Date()).getTime();
         this.watchdog_processes[id].file = file;
-        this.watchdog_processes[id].progressTracker.clear();
+//        this.watchdog_processes[id].progressTracker.clear();
         
     };
 

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -72,6 +72,7 @@ window.filesender.progresstracker = function() {
      * when this is called.
      */
     this.remember = function( fine_progress ) {
+        this.stamp = (new Date()).getTime();
         if( !this.mem.length ) {
             this.mem[0] = 0;
             
@@ -81,7 +82,6 @@ window.filesender.progresstracker = function() {
         if( this.mem.length >= this.memToKeep )
             this.mem.pop();
 
-        this.stamp = (new Date()).getTime();
     };
 
     /**
@@ -113,7 +113,7 @@ window.filesender.progresstracker = function() {
             return false;
 
         var tooSlow = filesender.config.upload_considered_too_slow_if_no_progress_for_seconds;
-        if( !tooSlow )
+        if( tooSlow==0 )
             return false;
         
         if( (new Date()).getTime() - this.stamp > (tooSlow*1000) )

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -58,19 +58,12 @@ window.filesender.progresstracker = function() {
     memToKeep: 5;
     disabled: false;
 
-    /**
-     * Reset the tracker for a fresh chunk
-     */
     this.clear = function() {
         this.mem = [];
         this.disabled = false;
         this.stamp = (new Date()).getTime();
     };
                 
-    /**
-     * remember the reported fine_progress and take a timestamp
-     * when this is called.
-     */
     this.remember = function( fine_progress ) {
         if( !this.mem.length ) {
             this.mem[0] = 0;
@@ -84,30 +77,14 @@ window.filesender.progresstracker = function() {
         this.stamp = (new Date()).getTime();
     };
 
-    /**
-     * This disables isOffending() from ever returning true.
-     */
     this.setDisabled = function() {
         this.disabled = true;
     };
 
-    /**
-     * How many bytes were transfered between the last two
-     * calls to remember().
-     */
     this.latest = function() {
         return this.mem[this.mem.length-1];
     };
 
-    /**
-     * For the current configuration is this worker
-     * "offending"ly slow.
-     * 
-     * The implementation could taken many forms, a simple
-     * one being if no progress has been reported for 10
-     * seconds it might have stalled. Or the number of
-     * bytes transfered could also be considered.
-     */
     this.isOffending = function() {
         if( this.disabled )
             return false;
@@ -125,9 +102,6 @@ window.filesender.progresstracker = function() {
         // return sum == 0;
     };
 
-    /**
-     * Just makes this.log() available.
-     */
     this.log = function(message, origin) {
         filesender.ui.log('[progressTracker ' + origin + '] ' + message);
     };

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -740,8 +740,8 @@ window.filesender.transfer = function() {
             d[i] = -1;
             if(this.watchdog_processes[id].started != null) {
                 if( this.watchdog_processes[id].file.name == file.name ) {
-                    var bc = this.watchdog_processes[id].progressTracker.latest();
-                    d[i] = bc;
+//                    var bc = this.watchdog_processes[id].progressTracker.latest();
+//                    d[i] = bc;
                 }
             }
             i++;

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -579,9 +579,6 @@ window.filesender.transfer = function() {
                  * Reset the tracker for a fresh chunk
                  */
                 clear: function() {
-                    this.mem = [];
-                    this.disabled = false;
-                    this.stamp = (new Date()).getTime();
                 },
                 
                 /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -579,8 +579,8 @@ window.filesender.transfer = function() {
                  * Reset the tracker for a fresh chunk
                  */
                 clear: function() {
-                    mem = [];
-                    disabled = false;
+                    this.mem = [];
+                    this.disabled = false;
                     this.stamp = (new Date()).getTime();
                 },
                 

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -65,16 +65,6 @@ window.filesender.progresstracker = function() {
     };
                 
     this.remember = function( fine_progress ) {
-        if( !this.mem.length ) {
-            this.mem[0] = 0;
-            
-        }
-        var d = fine_progress - this.mem[this.mem.length-1];
-        this.mem.push( d );
-        if( this.mem.length >= this.memToKeep )
-            this.mem.pop();
-
-        this.stamp = (new Date()).getTime();
     };
 
     this.setDisabled = function() {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -86,20 +86,6 @@ window.filesender.progresstracker = function() {
     };
 
     this.isOffending = function() {
-        if( this.disabled )
-            return false;
-
-        var tooSlow = filesender.config.upload_considered_too_slow_if_no_progress_for_seconds;
-        if( !tooSlow )
-            return false;
-        
-        if( (new Date()).getTime() - this.stamp > (tooSlow*1000) )
-            return true;
-        return false;
-
-        // play with bytes?
-        // var sum = this.mem.reduce(function(a, b) { return a + b; }, 0);
-        // return sum == 0;
     };
 
     this.log = function(message, origin) {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -59,9 +59,6 @@ window.filesender.progresstracker = function() {
     disabled: false;
 
     this.clear = function() {
-        this.mem = [];
-        this.disabled = false;
-        this.stamp = (new Date()).getTime();
     };
                 
     this.remember = function( fine_progress ) {

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -589,23 +589,12 @@ window.filesender.transfer = function() {
                  * when this is called.
                  */
                 remember: function( fine_progress ) {
-                    if( !this.mem.length ) {
-                        this.mem[0] = 0;
-                        
-                    }
-                    var d = fine_progress - this.mem[this.mem.length-1];
-                    this.mem.push( d );
-                    if( this.mem.length >= this.memToKeep )
-                        this.mem.pop();
-
-                    this.stamp = (new Date()).getTime();
                 },
 
                 /**
                  * This disables isOffending() from ever returning true.
                  */
                 setDisabled: function() {
-                    this.disabled = true;
                 },
 
                 /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -645,7 +645,7 @@ window.filesender.transfer = function() {
                 /**
                  * Just makes this.log() available.
                  */
-                log: function(message, origin='') {
+                log: function(message, origin) {
                     filesender.ui.log('[progressTracker ' + origin + '] ' + message);
                 },
             },

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -670,7 +670,7 @@ window.filesender.transfer = function() {
      * Record chunk upload progress for worker
      */
     this.recordUploadProgressInWatchdog = function(id,fine_progress) {
-        this.watchdog_processes[id].progressTracker.remember( fine_progress );
+//        this.watchdog_processes[id].progressTracker.remember( fine_progress );
     };
     
     /**

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -227,29 +227,9 @@ filesender.ui.files = {
     },
 
     clear_crust_meter_all: function() {
-        for (var i = 0; i < filesender.ui.transfer.files.length; i++) {
-            file = filesender.ui.transfer.files[i];
-            filesender.ui.files.clear_crust_meter( file );
-        }
     },
     
     clear_crust_meter: function( file ) {
-        var imax = 1;
-        if( filesender.config.terasender_enabled ) {
-            imax = filesender.config.terasender_worker_count;
-        }
-
-        for( var i = 0; i < imax; i++ ) {
-            var crust_indicator = filesender.ui.nodes.files.list.find('[data-cid="' + file.cid + '"] .crust' + i);
-            if( crust_indicator ) {
-                crust_indicator.find('.crustage').text( '' );
-                crust_indicator.find('.crustbytes').text( '' );
-                crust_indicator.removeClass('middle');
-                crust_indicator.removeClass('slow');
-                crust_indicator.removeClass('bad');
-                crust_indicator.addClass('good');
-            }
-        }
     },
     
     update_crust_meter: function( file ) {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -185,7 +185,7 @@ filesender.ui.files = {
         return node;
     },
 
-    update_crust_meter_for_worker: function(file,idx,v,b=false) {
+    update_crust_meter_for_worker: function(file,idx,v,b) {
 
         var crust_indicator = filesender.ui.nodes.files.list.find('[data-cid="' + file.cid + '"] .crust' + idx);
         if( crust_indicator ) {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -593,6 +593,9 @@ filesender.ui.startUpload = function() {
     }
     
     this.transfer.oncomplete = function(time) {
+
+        filesender.ui.files.clear_crust_meter_all();
+        
         var redirect_url = filesender.ui.transfer.options.redirect_url_on_complete;
         if(redirect_url) {
             filesender.ui.redirect(redirect_url);
@@ -613,7 +616,6 @@ filesender.ui.startUpload = function() {
             );
         };
 
-        filesender.ui.files.clear_crust_meter_all();
         
         var p = filesender.ui.alert('success', lang.tr('done_uploading'), close);
         

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -499,6 +499,7 @@ filesender.ui.evalUploadEnabled = function() {
 };
 
 filesender.ui.startUpload = function() {
+    
     if(!filesender.ui.nodes.required_files) {
         this.transfer.expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
         
@@ -1001,8 +1002,9 @@ $(function() {
         } else if(!auth || auth == 'guest') {
             id = null; // Cancel
         }
+
         
-        if(id) filesender.client.getTransfer(id, function() {
+        if(id) filesender.client.getTransfer(id, function(xdata) {
             // Transfer still exists on server, lets ask the user what to do with it
             
             var load = function() {
@@ -1062,6 +1064,20 @@ $(function() {
             };
             
             var later = function() {};
+
+
+            // maybe we want to force filesender to forget the transfer
+            var force_forget = false;
+
+            if( filesender.config.upload_force_transfer_resume_forget_if_encrypted
+                && xdata.options.encryption )
+            {
+                force_forget = true;
+            }
+            
+            if( force_forget ) {
+                forget();
+            } else {
             
             var prompt = filesender.ui.popup(lang.tr('restart_failed_transfer'), {'load': load, 'forget': forget, 'later': later}, {onclose: later});
             $('<p />').text(lang.tr('failed_transfer_found')).appendTo(prompt);
@@ -1084,7 +1100,7 @@ $(function() {
             
             if(failed.message)
                 $('<div class="message" />').text(lang.tr('message') + ' : ' + failed.message).appendTo(tctn);
-            
+            }            
         }, function(error) {
             if(error.message == 'transfer_not_found') {
                 // Transfer does not exist anymore on server side, remove from tracker

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -233,43 +233,6 @@ filesender.ui.files = {
     },
     
     update_crust_meter: function( file ) {
-        if (!filesender.config.upload_display_per_file_stats) {
-            return;
-        }
-        
-        if (filesender.ui.transfer.status != 'running') {
-            this.clear_crust_meter( file );
-            return;
-        }
-
-        var durations = filesender.ui.transfer.getMostRecentChunkDurations( file );
-        var bytes     = filesender.ui.transfer.getMostRecentChunkFineBytes( file );
-        var offending = filesender.ui.transfer.getIsWorkerOffending( file );
-        if( durations.length != bytes.length || bytes.length != offending.length ) {
-            filesender.ui.log('WARNING worker tracking stats are wrong' );
-            return;
-        }
-        if( durations.length < 1 ) {
-            filesender.ui.log('WARNING worker tracking stats are missing' );
-            return;
-        }
-        var imax = durations.length;
-        if( filesender.config.terasender_enabled && imax != filesender.config.terasender_worker_count ) {
-            filesender.ui.log('WARNING ts worker tracking stats are too few' );
-            return;
-        }
-        
-        for( i=0; i < imax; i++ ) {
-            v = -1;
-            if( i < durations.length ) {
-                v = durations[i];
-            }
-            b = false;
-            if( i < offending.length ) {
-                b = offending[i];
-            }
-            filesender.ui.files.update_crust_meter_for_worker( file, i, v, b );
-        }
     },
     
     // Update progress bar, run in transfer context

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -196,18 +196,6 @@ filesender.ui.files = {
                 crust_indicator.find('.crustage').text( vd.toFixed(2) );
             }
 
-            crust_indicator.find('.crustbytes').text( '' );
-            if( b ) {
-                crust_indicator.removeClass('good');
-                crust_indicator.removeClass('middle');
-                crust_indicator.removeClass('slow');
-                crust_indicator.addClass('bad');
-            } else {
-                crust_indicator.removeClass('middle');
-                crust_indicator.removeClass('slow');
-                crust_indicator.removeClass('bad');
-                crust_indicator.addClass('good');
-            }
             
             // filesender.config.upload_chunk_size [ def = 5 * 1024 * 1024 ]
 /*            

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -33,7 +33,6 @@
 // Manage files
 filesender.ui.files = {
     invalidFiles: [],
-
     
     // File selection (browse / drop) handler
     add: function(files, source_node) {
@@ -142,10 +141,14 @@ filesender.ui.files = {
 
                 var makeCrust = function( p, idx ) {
                     var crust_meter = $('<div class="crust crust' + idx + '">'
-                                        + '<a class="crust_meter" href="#">'
-                                        + '<div class="label uploadthread">   </div></a></div>');
+                                        + '  <a class="crust_meter" href="#">'
+                                        + '  <div class="label crustage   uploadthread">   </div></a>'
+                                        + '  <a class="crust_meter_bytes" href="#">'
+                                        + '  <div class="label crustbytes uploadthread">   </div></a>'
+                                        + '</div>');
                     crust_meter.appendTo(p);
                     crust_meter.button({disabled: true});
+
                     return crust_meter;
                 };
 
@@ -182,17 +185,30 @@ filesender.ui.files = {
         return node;
     },
 
-    update_crust_meter_for_worker: function(file,idx,v) {
+    update_crust_meter_for_worker: function(file,idx,v,b=false) {
 
         var crust_indicator = filesender.ui.nodes.files.list.find('[data-cid="' + file.cid + '"] .crust' + idx);
         if( crust_indicator ) {
             var vd = v / 1000;
             if( v == -1 ) {
-                crust_indicator.find('.label').text( "" );
+                crust_indicator.find('.crustage').text( "" );
             } else {
-                crust_indicator.find('.label').text( vd.toFixed(2) );
+                crust_indicator.find('.crustage').text( vd.toFixed(2) );
             }
 
+            crust_indicator.find('.crustbytes').text( '' );
+            if( b ) {
+                crust_indicator.removeClass('good');
+                crust_indicator.removeClass('middle');
+                crust_indicator.removeClass('slow');
+                crust_indicator.addClass('bad');
+            } else {
+                crust_indicator.removeClass('middle');
+                crust_indicator.removeClass('slow');
+                crust_indicator.removeClass('bad');
+                crust_indicator.addClass('good');
+            }
+            
             // filesender.config.upload_chunk_size [ def = 5 * 1024 * 1024 ]
 /*            
             var baseline_upload_bps = 20 * 1024 * 1024;
@@ -221,30 +237,70 @@ filesender.ui.files = {
 */
         }
     },
+
+    clear_crust_meter_all: function() {
+        for (var i = 0; i < filesender.ui.transfer.files.length; i++) {
+            file = filesender.ui.transfer.files[i];
+            filesender.ui.files.clear_crust_meter( file );
+        }
+    },
+    
+    clear_crust_meter: function( file ) {
+        var imax = 1;
+        if( filesender.config.terasender_enabled ) {
+            imax = filesender.config.terasender_worker_count;
+        }
+
+        for( var i = 0; i < imax; i++ ) {
+            var crust_indicator = filesender.ui.nodes.files.list.find('[data-cid="' + file.cid + '"] .crust' + i);
+            if( crust_indicator ) {
+                crust_indicator.find('.crustage').text( '' );
+                crust_indicator.find('.crustbytes').text( '' );
+                crust_indicator.removeClass('middle');
+                crust_indicator.removeClass('slow');
+                crust_indicator.removeClass('bad');
+                crust_indicator.addClass('good');
+            }
+        }
+    },
     
     update_crust_meter: function( file ) {
         if (!filesender.config.upload_display_per_file_stats) {
             return;
         }
-
-        if( filesender.config.terasender_enabled ) {
-            var durations = filesender.ui.transfer.getMostRecentChunkDurations( file );
-            for( i=0; i < filesender.config.terasender_worker_count; i++ ) {
-                v = -1;
-                if( i < durations.length ) {
-                    v = durations[i];
-                }
-                filesender.ui.files.update_crust_meter_for_worker( file, i, v );
-            }
+        
+        if (filesender.ui.transfer.status != 'running') {
+            this.clear_crust_meter( file );
+            return;
         }
-        else
-        {
-            var durations = filesender.ui.transfer.getMostRecentChunkDurations( file );
+
+        var durations = filesender.ui.transfer.getMostRecentChunkDurations( file );
+        var bytes     = filesender.ui.transfer.getMostRecentChunkFineBytes( file );
+        var offending = filesender.ui.transfer.getIsWorkerOffending( file );
+        if( durations.length != bytes.length || bytes.length != offending.length ) {
+            filesender.ui.log('WARNING worker tracking stats are wrong' );
+            return;
+        }
+        if( durations.length < 1 ) {
+            filesender.ui.log('WARNING worker tracking stats are missing' );
+            return;
+        }
+        var imax = durations.length;
+        if( filesender.config.terasender_enabled && imax != filesender.config.terasender_worker_count ) {
+            filesender.ui.log('WARNING ts worker tracking stats are too few' );
+            return;
+        }
+        
+        for( i=0; i < imax; i++ ) {
             v = -1;
-            if( durations.length > 0 ) {
-                v = durations[0];
+            if( i < durations.length ) {
+                v = durations[i];
             }
-            filesender.ui.files.update_crust_meter_for_worker( file, 0, v );
+            b = false;
+            if( i < offending.length ) {
+                b = offending[i];
+            }
+            filesender.ui.files.update_crust_meter_for_worker( file, i, v, b );
         }
     },
     
@@ -556,6 +612,8 @@ filesender.ui.startUpload = function() {
                 filesender.ui.transfer.guest_token ? null : 'transfer_' + filesender.ui.transfer.id
             );
         };
+
+        filesender.ui.files.clear_crust_meter_all();
         
         var p = filesender.ui.alert('success', lang.tr('done_uploading'), close);
         

--- a/www/lib/terasender/terasender.js
+++ b/www/lib/terasender/terasender.js
@@ -203,6 +203,16 @@ window.filesender.terasender = {
             filesender.ui.error(error);
         }
     },
+
+    ensureBareWorkerID: function(wid) {
+        if( wid.includes('worker:')) {
+            wid = wid.substr( 'worker:'.length );
+        }
+        return wid;
+    },
+    
+    
+    
     
     /**
      * Evaluate progress and report to transfer
@@ -223,7 +233,7 @@ window.filesender.terasender = {
             this.stop();
             return;
         }
-        
+
         var workers_on_same_file = false;
         var min_offset = file.uploaded;
         var fine_progress = 0;
@@ -325,6 +335,7 @@ window.filesender.terasender = {
         switch(command) {
             case 'jobProgress' :
                 this.log('Worker job progressed', 'worker:' + worker_id);
+                this.transfer.recordUploadProgressInWatchdog('worker:' + worker_id,data.fine_progress);
                 this.evalProgress(worker_id, data);
                 break;
                 
@@ -385,7 +396,7 @@ window.filesender.terasender = {
         this.sendCommand(workerinterface, 'start', id);
         
         this.log('Worker ' + id + ' created');
-        
+
         this.workers.push(workerinterface);
     },
     


### PR DESCRIPTION
The existing stall detection monitors whole chunks. This code
compliments the existing stall detection by monitoring how many bytes
have been transferred and how long it was since the last "subchunk" of
bytes has been transferred over.

By looking at the xhr progress messages like this we can much more
quickly detect when the single (non ts) or ts upload is starting to
struggle. For example, if you force a stall of say, 10 seconds, on the
server and set the following the worker displays will turn red after 5
seconds elapsed with no new bytes sent over.

$config['upload_considered_too_slow_if_no_progress_for_seconds'] = 5;
$config['upload_display_per_file_stats'] = true;

It is useful to know the low level health of each subchunk so that
network issues that might cause the server to timeout on an xhr but
not be reported by the operating system as an xhr failure are detected
quickly and action such as informing the user and restarting lagging chunks
might be considered in a future PR.