### PR TITLE
AUP: bring back the checkmark to bind users to the site terms and conditions

### DIFF
--- a/language/en_AU/accepttoc.html.php
+++ b/language/en_AU/accepttoc.html.php
@@ -1,0 +1,1 @@
+I accept the following Terms and Conditions of using this service.

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -233,7 +233,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
             </tr>
         </table>
         
-        <?php if (Config::get('AuP')) { ?>
+        <?php if (Config::get('aup_enabled')) { ?>
         <div class="aup fieldcontainer box">
             <label for="aup" title="{tr:showhide}">
                 {tr:accepttoc} [<span>{tr:showhide}</span>]


### PR DESCRIPTION
There seemed to be some partial renaming going on there. This should make the T&C checkmark work again when you have
```
$config['aup_enabled'] = true;
$config['aup_default'] = false;       // AuP value is NOT already ticked
```
