### PR TITLE
Limits: ability to set maximum file size for encrypted files

### DIFF
--- a/classes/exceptions/TransferExceptions.class.php
+++ b/classes/exceptions/TransferExceptions.class.php
@@ -152,6 +152,36 @@ class TransferMaximumSizeExceededException extends DetailedException {
 }
 
 /**
+ * Maximum file size exeeded exception
+ */
+class TransferMaximumFileSizeExceededException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param int $size
+     * @param int $max
+     */
+    public function __construct($size, $max) {
+        parent::__construct('transfer_maximum_file_size_exceeded', 'size='.$wanted.' max='.$max);
+    }
+}
+
+/**
+ * Maximum file size exeeded exception
+ */
+class TransferMaximumEncryptedFileSizeExceededException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param int $size
+     * @param int $max
+     */
+    public function __construct($size, $max) {
+        parent::__construct('transfer_maximum_encrypted_file_size_exceeded', 'size='.$wanted.' max='.$max);
+    }
+}
+
+/**
  * Validation failed exception
  */
 class TransferRejectedException extends DetailedException {

--- a/dev/doc/filesender_wiki/Documentation_v2-0-alpha/filesender-2.0-config-directives-markdown.md
+++ b/dev/doc/filesender_wiki/Documentation_v2-0-alpha/filesender-2.0-config-directives-markdown.md
@@ -81,6 +81,9 @@
 * [transfer_options](#transfer_options) (email receipt control)
 * [upload_chunk_size](#upload_chunk_size)
 * [user_quota](#user_quota)
+* [max_transfer_file_size](#max_transfer_file_size)
+* [max_transfer_encrypted_file_size](#max_transfer_encrypted_file_size)
+
 
 ##TeraSender (high speed upload module)
 * [terasender_enabled](#terasender_enabled)
@@ -751,6 +754,26 @@ User language detection is done in the following order:
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ user quote can be implemented in a much more flexible way as well.  As we're doing lazy loading of configuration parameters we can change this value (and max. file size) based on user profile.  In stead of defining this config parameter with a number you can give a function to it.  The value returned by this function is cached for a login session.  For example a function that uses eduPersonAffiliation can give a "student" 10 GB and "faculty" 1 TB.  You could also change max. days valid based on user profile.  The function can use the current application state and user session to compute the value for a logged in user, because the function would run after everything else.  <span style="background-color:orange">Calculated maximum values should have its own chapter to explain, with examples especially for using eduPersonAffiliation.</style>
+
+
+###max_transfer_file_size
+* __description:__ set to 0 to disable. If set to a positive value it sets the maximum file size for a not encrypted file that the user can upload. Attempts to upload a larger file is rejected with an error message in the web-UI.
+* __mandatory:__ no 
+* __type:__ int (bytes) or function
+* __default:__ 0
+* __available:__ since version 2.0
+* __comment:__ 
+
+
+###max_transfer_encrypted_file_size
+* __description:__ set to 0 to disable. If set to a positive value it sets the maximum file size for an encrypted file that the user can upload. Attempts to upload a larger file is rejected with an error message in the web-UI.
+* __mandatory:__ no 
+* __type:__ int (bytes) or function
+* __default:__ 0
+* __available:__ since version 2.0
+* __comment:__ 
+
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -80,6 +80,8 @@ $default = array(
     'default_transfer_days_valid' => 10,
     'failed_transfer_cleanup_days' => 7,
     'transfer_recipients_lang_selector_enabled' => false,
+    'max_transfer_file_size' => 0,
+    'max_transfer_encrypted_file_size' => 0,
     
     'max_guest_recipients' => 50,
     

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -562,6 +562,8 @@ $lang['transfer_expiry_extension_not_allowed'] = 'Transfer expiry date extension
 $lang['transfer_expiry_extension_count_exceeded'] = 'Transfer expiry date extension maximum reached';
 $lang['transfer_files_incomplete'] = 'Transfer\'s files are not done uploading';
 $lang['transfer_file_name_invalid'] = 'File name contains bad characters';
+$lang['maximum_file_size_exceeded'] = 'Maximum size of a single file is exceeded';
+$lang['maximum_encrypted_file_size_exceeded'] = 'Maximum size of a single file with encryption is exceeded';
 
 // User related exceptions
 $lang['user_not_found'] = 'User not found';

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -65,7 +65,10 @@ window.filesender.config = {
 
     max_transfer_size: <?php echo Config::get('max_transfer_size') ?>,
     max_transfer_files: <?php echo Config::get('max_transfer_files') ?>,
-    
+
+    max_transfer_file_size: <?php echo Config::get('max_transfer_file_size') ?>,
+    max_transfer_encrypted_file_size: <?php echo Config::get('max_transfer_encrypted_file_size') ?>,
+
     ban_extension: <?php echo is_string($banned) ? "'".$banned."'" : 'null' ?>,
     extension_whitelist_regex: <?php echo is_string($extension_whitelist_regex) ? "'".$extension_whitelist_regex."'" : 'null' ?>,
     


### PR DESCRIPTION
This is checked client and server side. One little twist on the client
side is that enabling and disabling encryption will have a toggle
effect on if files are valid.

The code sort of assumes that if the client side transaction.addFile()
doesn't work then it will not magically start to work. The max file
size stuff toggles so that you can enable encryption and see an error
for file too large, but if you then disable encryption again you
should see that the file is ok again.