### PR TITLE
encryption: ability to set minimum password length

### DIFF
--- a/dev/doc/filesender_wiki/Documentation_v2-0-alpha/filesender-2.0-config-directives-markdown.md
+++ b/dev/doc/filesender_wiki/Documentation_v2-0-alpha/filesender-2.0-config-directives-markdown.md
@@ -83,6 +83,7 @@
 * [user_quota](#user_quota)
 * [max_transfer_file_size](#max_transfer_file_size)
 * [max_transfer_encrypted_file_size](#max_transfer_encrypted_file_size)
+* [encryption_min_password_length](#encryption_min_password_length)
 
 
 ##TeraSender (high speed upload module)
@@ -772,6 +773,17 @@ User language detection is done in the following order:
 * __default:__ 0
 * __available:__ since version 2.0
 * __comment:__ 
+
+
+###encryption_min_password_length
+* __description:__ set to 0 to disable. If set to a positive value it is the minimum number of characters needed in a password for encryption. Note that since the encryption is fully client side, this value could be ignored by a determined user, though they would do that at the loss of their own security not of others.
+* __mandatory:__ no 
+* __type:__ int
+* __default:__ 0
+* __available:__ since version 2.0
+* __comment:__ 
+
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -92,6 +92,7 @@ $default = array(
     'download_chunk_size' => 5 * 1024 * 1024,
     
     'encryption_enabled' => true,
+    'encryption_min_password_length' => 0,
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -173,6 +173,7 @@ $lang['encryption'] = 'Encryption';
 $lang['decrypting'] = 'Decrypting';
 $lang['file_encryption'] = 'File Encryption (beta)';
 $lang['file_encryption_password'] = 'Password';
+$lang['file_encryption_password_too_short'] = 'Sorry, your password is too short';
 $lang['file_encryption_show_password'] = 'Show / Hide Password';
 $lang['file_encryption_wrong_password'] = 'Incorrect Password';
 $lang['file_encryption_enter_password'] = 'Enter a password';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -125,6 +125,9 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                                 <label for="encryption_password" style="cursor: pointer;">{tr:file_encryption_password} : </label>
                                 <input id="encryption_password" name="encryption_password" type="password" autocomplete="off"/>
                             </div>
+                            <div class="fieldcontainer" id="encryption_password_container_too_short_message">
+                                {tr:file_encryption_password_too_short}
+                            </div>
                             <div class="fieldcontainer" id="encryption_password_container_generate">
                                 <a id='encryption_generate_password' href="#">{tr:file_encryption_generate_password}</a>
                             </div>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1259,6 +1259,7 @@ table.guests .guest .to .errors .details {
 
 /* Encryption */
 #encryption_password_container,
+#encryption_password_container_too_short_message,
 #encryption_password_container_generate,
 #encryption_password_show_container,
 #encryption_description_container_disabled,
@@ -1267,6 +1268,10 @@ table.guests .guest .to .errors .details {
 #encryption_description_disabled_container,
 #encryption_description_container {
     display: none;
+}
+
+#encryption_password_container_too_short_message {
+    color: #f00;
 }
 
 table.paginator .pageprev0 {

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -83,6 +83,7 @@ window.filesender.config = {
     chunk_upload_security: '<?php echo Config::get('chunk_upload_security') ?>',
     
     encryption_enabled: '<?php echo Config::get('encryption_enabled') ?>',
+    encryption_min_password_length: '<?php echo Config::get('encryption_min_password_length') ?>',
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',
     crypto_crypt_name: '<?php echo Config::get('crypto_crypt_name') ?>',

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -349,6 +349,33 @@ filesender.ui.files = {
         
         filesender.ui.evalUploadEnabled();
     },
+
+    checkEncryptionPassword: function(input) {
+        input = $(input);
+
+        var invalid = false;
+        var pass = input.val();
+        var minLength = filesender.config.encryption_min_password_length;
+        if( minLength > 0 ) {
+            if( !pass || pass.length < minLength ) {
+                invalid = true;
+            }
+        }
+        
+        var msg = $('#encryption_password_container_too_short_message');
+        
+        if(invalid) {
+            input.addClass('invalid');
+            if( msg.css('display')=='none') {
+                msg.slideToggle();
+            }
+        }else{
+            input.removeClass('invalid');
+            if( msg.css('display')!='none') {
+                msg.slideToggle();
+            }
+        }
+    },
 };
 
 // Manage recipients
@@ -826,6 +853,13 @@ $(function() {
         
         filesender.ui.recipients.addFromInput($(this));
     });
+
+
+    // Bind encryption password events
+    filesender.ui.nodes.encryption.password.on('keyup', function(e) {
+        filesender.ui.files.checkEncryptionPassword($(this));
+    });
+
     
     // Bind file list select button
     filesender.ui.nodes.files.input.on('change', function() {
@@ -929,7 +963,14 @@ $(function() {
         $('#encryption_password_show_container').slideToggle();
         $('#encryption_description_container').slideToggle();
         filesender.ui.transfer.encryption = filesender.ui.nodes.encryption.toggle.is(':checked');
-
+        
+        if( filesender.ui.transfer.encryption ) {
+            filesender.ui.files.checkEncryptionPassword(filesender.ui.nodes.encryption.password );
+        } else {
+            var msg = $('#encryption_password_container_too_short_message');
+            msg.hide();
+        }
+        
         for(var i=0; i<filesender.ui.transfer.files.length; i++) {
             var file = filesender.ui.transfer.files[i];
             
@@ -955,9 +996,16 @@ $(function() {
         return false;
     });
     filesender.ui.nodes.encryption.generate.on('click', function() {
-        filesender.ui.nodes.encryption.password.val(Math.random().toString(36).substr(2, 14));
+        var genp = function() { return Math.random().toString(36).substr(2, 14); }
+        var pass = genp();
+        for( var i=0; i < filesender.config.encryption_min_password_length; i++ ) {
+            pass = pass + genp();
+        }
+        pass = pass.substr(0,filesender.config.encryption_min_password_length);
+        filesender.ui.nodes.encryption.password.val(pass);
         filesender.ui.nodes.encryption.show_hide.prop('checked',true);
         filesender.ui.nodes.encryption.show_hide.trigger('change');
+        filesender.ui.files.checkEncryptionPassword(filesender.ui.nodes.encryption.password );
     });
     filesender.ui.nodes.encryption.show_hide.on('change', function() {
         if (filesender.ui.nodes.encryption.show_hide.is(':checked')) {


### PR DESCRIPTION
New encryption_min_password_length setting to set the minimum password
length for encryption. This also changes the generate password to make
sure that is the correct length as per system policy.