### PR TITLE
upload: some client side hint in the log as to why resume is silently dropped

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1254,6 +1254,7 @@ $(function() {
                 $('<div class="message" />').text(lang.tr('message') + ' : ' + failed.message).appendTo(tctn);
             }            
         }, function(error) {
+            console.log('getTransfer() msg: ' + error.message);
             if(error.message == 'transfer_not_found') {
                 // Transfer does not exist anymore on server side, remove from tracker
                 filesender.ui.transfer.removeFromRestartTracker(failed.id);


### PR DESCRIPTION
Nothing major is inserted into the log() but this might be handy for tracking down why server side.