### PR TITLE
Fixed bug where simplesaml Logoff URL wasn't properly set if filesend…

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -190,9 +190,10 @@ class AuthSPSaml {
         if(!$target)
             $target = Config::get('site_logouturl');
         
-        $url = self::$config['simplesamlphp_url'].'module.php/core/as_logout.php?';
-        $url .= 'AuthId='.self::$config['authentication_source'];
-        $url .= '&ReturnTo='.urlencode($target);
+        $url = Utilities::http_build_query(array(
+            'AuthId' => self::$config['authentication_source'],
+            'ReturnTo' => $target,
+        ), self::$config['simplesamlphp_url'].'module.php/core/as_logout.php?' );
         
         return $url;
     }


### PR DESCRIPTION
Fixed bug where simplesaml Logoff URL wasn't properly set if filesender url is not directly under http://<domain>/, ie http://<domain>/upload/. Fix entailed updating AuthSPSaml.logoffURL() to use the same logic/code template as AuthSPSaml.logonURL()