### PR TITLE
Storage filesystem preserve name

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -190,9 +190,10 @@ class AuthSPSaml {
         if(!$target)
             $target = Config::get('site_logouturl');
         
-        $url = self::$config['simplesamlphp_url'].'module.php/core/as_logout.php?';
-        $url .= 'AuthId='.self::$config['authentication_source'];
-        $url .= '&ReturnTo='.urlencode($target);
+        $url = Utilities::http_build_query(array(
+            'AuthId' => self::$config['authentication_source'],
+            'ReturnTo' => $target,
+        ), self::$config['simplesamlphp_url'].'module.php/core/as_logout.php?' );
         
         return $url;
     }

--- a/classes/storage/StorageFilesystemPreserveName.class.php
+++ b/classes/storage/StorageFilesystemPreserveName.class.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+if (!defined('FILESENDER_BASE')) die('Missing environment');
+
+/**
+ *  Gives access to a file on the filesystem, preserving uploaded filenames
+ *  
+ *  Main use case is where after upload into Filesender's storage
+ *  another application on the same system needs access to the files in
+ *  the storage preserving the original filenames for easy recognition.
+ *  
+ */
+class StorageFilesystemPreserveName extends StorageFilesystem {
+  
+    /**
+     * Build file storage name (without base path)
+     * 
+     * @param File $file
+     * 
+     * @return string filename
+     */
+    public static function buildFilename(File $file) {
+        static::setup();
+        return $file->name;
+    }
+  
+    /**
+     * Build file storage path (without filename)
+     * 
+     * @param File $file
+     * 
+     * @return string path
+     */
+    public static function buildPath(File $file) {
+        static::setup();
+
+        $owner = $file->__get('owner');
+        $path = self::$path;
+
+        if (empty($owner)) {
+            $owner = 'guest';
+        }
+
+        // $owner may be prefixed with # by filesender
+        $pos = strrpos($owner, '#');
+
+        $subpath = '/'.$owner;
+      
+        if (!($pos === false)) {
+          $subpath = '/'.substr($owner, $pos + 1);
+        }
+        
+        // validate owner subpath, creating dir if needed
+        $p = $path;
+        foreach(array_filter(explode('/', $subpath)) as $sub) {
+            $p .= $sub;
+            
+            if(!is_dir($p) && !mkdir($p))
+                throw new StorageFilesystemCannotCreatePathException($p, $file);
+            
+            if(!is_writable($p))
+                throw new StorageFilesystemCannotWriteException($p, $file);
+            
+            $p .= '/';
+        }
+        $path = $p;
+        
+        return $path;
+    }
+}

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -405,21 +405,27 @@ filesender.ui.files = {
 
 //FOLDERUPLOAD
 // from https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree
-function traverseFileTree(item, path) {
+function traverseFileTree(fileList, item, path) {
+  console.log(typeof fileList);
   path = path || "";
   if (item.isFile) {
     // Get file
     //filesender.ui.files.add(item.file.name);
     item.file(function(file) {
-      console.log("File:", path + file.name);
-   
+       console.log("File:", path + file.name);
+       console.log("Type:", file.type);
+       console.log("Size:", file.size);
+       fileList.item(0).name = path + file.name;
+       fileList.item(0).type = file.type;
+       fileList.item(0).size = file.syze;
+       filesender.ui.files.add(fileList);
     });
   } else if (item.isDirectory) {
     // Get folder contents
     var dirReader = item.createReader();
     dirReader.readEntries(function(entries) {
       for (var i=0; i<entries.length; i++) {
-        traverseFileTree(entries[i], path + item.name + "/");
+        traverseFileTree(fileList, entries[i], path + item.name + "/");
       }
     });
   }
@@ -888,21 +894,22 @@ $(function() {
         console.log("FOLDERUPLOAD");
 
         if (isChrome()) {
+            //var fileInput = document.querySelector('input');
+            //fileInput.files = e.originalEvent.dataTransfer.files;
+            var fileInput = Object.assign({}, e.originalEvent.dataTransfer.files);
+            console.log(typeof fileInput);
             var items = e.originalEvent.dataTransfer.items;
-        console.log("FOLDERUPLOAD1");
             for (var i=0; i<items.length; i++) {
-        console.log("FOLDERUPLOAD2");
               // webkitGetAsEntry is where the magic happens
               var item = items[i].webkitGetAsEntry();
-        console.log("FOLDERUPLOAD3");
               if (item) {
-        console.log("FOLDERUPLOAD4");
-                traverseFileTree(item);
+                traverseFileTree(fileInput, item);
               }
             }
          }
-
-        filesender.ui.files.add(e.originalEvent.dataTransfer.files);
+         else {
+           filesender.ui.files.add(e.originalEvent.dataTransfer.files);
+         }
        });
     
     // Bind recipients events

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -30,6 +30,31 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+//FOLDERUPLOAD
+// from https://stackoverflow.com/questions/4565112/javascript-how-to-find-out-if-the-user-browser-is-chrome
+function isChrome() {
+  var isChromium = window.chrome,
+    winNav = window.navigator,
+    vendorName = winNav.vendor,
+    isOpera = winNav.userAgent.indexOf("OPR") > -1,
+    isIEedge = winNav.userAgent.indexOf("Edge") > -1,
+    isIOSChrome = winNav.userAgent.match("CriOS");
+
+  if (isIOSChrome) {
+    return true;
+  } else if (
+    isChromium !== null &&
+    typeof isChromium !== "undefined" &&
+    vendorName === "Google Inc." &&
+    isOpera === false &&
+    isIEedge === false
+  ) {
+    return true;
+  } else { 
+    return false;
+  }
+}
+
 // Manage files
 filesender.ui.files = {
     invalidFiles: [],
@@ -377,6 +402,28 @@ filesender.ui.files = {
         }
     },
 };
+
+//FOLDERUPLOAD
+// from https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree
+function traverseFileTree(item, path) {
+  path = path || "";
+  if (item.isFile) {
+    // Get file
+    //filesender.ui.files.add(item.file.name);
+    item.file(function(file) {
+      console.log("File:", path + file.name);
+   
+    });
+  } else if (item.isDirectory) {
+    // Get folder contents
+    var dirReader = item.createReader();
+    dirReader.readEntries(function(entries) {
+      for (var i=0; i<entries.length; i++) {
+        traverseFileTree(entries[i], path + item.name + "/");
+      }
+    });
+  }
+}
 
 // Manage recipients
 filesender.ui.recipients = {
@@ -833,10 +880,30 @@ $(function() {
         if(!e.originalEvent.dataTransfer.files.length) return;
         
         e.preventDefault();
-        e.stopPropagation();
-        
+        //e.stopPropagation();
+
+        // FOLDERUPLOAD
+        // From https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree
+        console.log("File:", e.originalEvent.dataTransfer.items.length);
+        console.log("FOLDERUPLOAD");
+
+        if (isChrome()) {
+            var items = e.originalEvent.dataTransfer.items;
+        console.log("FOLDERUPLOAD1");
+            for (var i=0; i<items.length; i++) {
+        console.log("FOLDERUPLOAD2");
+              // webkitGetAsEntry is where the magic happens
+              var item = items[i].webkitGetAsEntry();
+        console.log("FOLDERUPLOAD3");
+              if (item) {
+        console.log("FOLDERUPLOAD4");
+                traverseFileTree(item);
+              }
+            }
+         }
+
         filesender.ui.files.add(e.originalEvent.dataTransfer.files);
-    });
+       });
     
     // Bind recipients events
     filesender.ui.nodes.recipients.input.on('keydown', function(e) {
@@ -1119,7 +1186,7 @@ $(function() {
             var sel = $(this)
             var file = sel.clone();
             
-            // TODO check file size, reject if over filesender.config.max_legacy_file_size
+            // TODO check file size, reject if over filesender.config.max_legacy_file_size // FOLDERUPLOAD
             
             var node = filesender.ui.files.add(this.files, file.get(0));
             if(!node) return;

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -30,31 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//FOLDERUPLOAD
-// from https://stackoverflow.com/questions/4565112/javascript-how-to-find-out-if-the-user-browser-is-chrome
-function isChrome() {
-  var isChromium = window.chrome,
-    winNav = window.navigator,
-    vendorName = winNav.vendor,
-    isOpera = winNav.userAgent.indexOf("OPR") > -1,
-    isIEedge = winNav.userAgent.indexOf("Edge") > -1,
-    isIOSChrome = winNav.userAgent.match("CriOS");
-
-  if (isIOSChrome) {
-    return true;
-  } else if (
-    isChromium !== null &&
-    typeof isChromium !== "undefined" &&
-    vendorName === "Google Inc." &&
-    isOpera === false &&
-    isIEedge === false
-  ) {
-    return true;
-  } else { 
-    return false;
-  }
-}
-
 // Manage files
 filesender.ui.files = {
     invalidFiles: [],
@@ -402,34 +377,6 @@ filesender.ui.files = {
         }
     },
 };
-
-//FOLDERUPLOAD
-// from https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree
-function traverseFileTree(fileList, item, path) {
-  console.log(typeof fileList);
-  path = path || "";
-  if (item.isFile) {
-    // Get file
-    //filesender.ui.files.add(item.file.name);
-    item.file(function(file) {
-       console.log("File:", path + file.name);
-       console.log("Type:", file.type);
-       console.log("Size:", file.size);
-       fileList.item(0).name = path + file.name;
-       fileList.item(0).type = file.type;
-       fileList.item(0).size = file.syze;
-       filesender.ui.files.add(fileList);
-    });
-  } else if (item.isDirectory) {
-    // Get folder contents
-    var dirReader = item.createReader();
-    dirReader.readEntries(function(entries) {
-      for (var i=0; i<entries.length; i++) {
-        traverseFileTree(fileList, entries[i], path + item.name + "/");
-      }
-    });
-  }
-}
 
 // Manage recipients
 filesender.ui.recipients = {
@@ -886,31 +833,10 @@ $(function() {
         if(!e.originalEvent.dataTransfer.files.length) return;
         
         e.preventDefault();
-        //e.stopPropagation();
-
-        // FOLDERUPLOAD
-        // From https://stackoverflow.com/questions/3590058/does-html5-allow-drag-drop-upload-of-folders-or-a-folder-tree
-        console.log("File:", e.originalEvent.dataTransfer.items.length);
-        console.log("FOLDERUPLOAD");
-
-        if (isChrome()) {
-            //var fileInput = document.querySelector('input');
-            //fileInput.files = e.originalEvent.dataTransfer.files;
-            var fileInput = Object.assign({}, e.originalEvent.dataTransfer.files);
-            console.log(typeof fileInput);
-            var items = e.originalEvent.dataTransfer.items;
-            for (var i=0; i<items.length; i++) {
-              // webkitGetAsEntry is where the magic happens
-              var item = items[i].webkitGetAsEntry();
-              if (item) {
-                traverseFileTree(fileInput, item);
-              }
-            }
-         }
-         else {
-           filesender.ui.files.add(e.originalEvent.dataTransfer.files);
-         }
-       });
+        e.stopPropagation();
+        
+        filesender.ui.files.add(e.originalEvent.dataTransfer.files);
+    });
     
     // Bind recipients events
     filesender.ui.nodes.recipients.input.on('keydown', function(e) {
@@ -1193,7 +1119,7 @@ $(function() {
             var sel = $(this)
             var file = sel.clone();
             
-            // TODO check file size, reject if over filesender.config.max_legacy_file_size // FOLDERUPLOAD
+            // TODO check file size, reject if over filesender.config.max_legacy_file_size
             
             var node = filesender.ui.files.add(this.files, file.get(0));
             if(!node) return;


### PR DESCRIPTION
Created StorageFilesystemPreserveName which extends StorageFilesystem by overloading the buildPath and adding a buildFilename method, which in StorageFilesystem just returns ->uid. To have methods in StorageFilesystem call the outer implementation, switched most self::buildPath to static::buildFile, used static::buildFilename exclusively

Updated StorageFilesystemPreserveName so files uploaded will go into a subdirectory path called "owner/uid=name" to avoid name collision and satisfy archiveval systems usually wanting sets of files in a directory