### PR TITLE
Shredding: new clearing house to shred deleted files

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -61,6 +61,7 @@ class Autoloader {
         'DBObject' => 'data/',
         'Transfer' => 'data/',
         'File' => 'data/',
+        'ShredFile' => 'data/',
         'Recipient' => 'data/',
         'Guest' => 'data/',
         'User' => 'data/',

--- a/classes/data/ShredFile.class.php
+++ b/classes/data/ShredFile.class.php
@@ -1,0 +1,233 @@
+<?php
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) 
+    die('Missing environment');
+
+/**
+ *  Represents file in the database
+ */
+class ShredFile extends DBObject
+{
+
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        //file id, as in the database
+        'id' => array(
+            'type' => 'uint',   //data type of 'id'
+            'size' => 'medium', //size of the integer stored in 'id' (in bytes, or otherwise)
+            'primary' => true,  //indicates that 'id' is the primary key in the DB
+            'autoinc' => true,   //indicates that 'id' is auto-incremented
+        ),
+        'name' => array(
+            'type' => 'string',
+            'size' => 60
+        ),
+        'errormessage' => array(
+            'type' => 'string',
+            'size' => 300,
+            'null' => true
+        ),
+    );
+
+
+    /**
+     * Properties
+     */
+    protected $id   = null;
+    protected $name = null;
+    protected $errormessage = null;
+   
+
+    /**
+     * Constructor
+     * 
+     * @param integer $id identifier of file to load from database (null if loading not wanted)
+     * @param array $data data to create the file from (if already fetched from database)
+     * 
+     * @throws FileNotFoundException
+     */
+    public function __construct($id = null, $data = null) {
+    
+        if(!is_null($id)) {
+            // Load from database if id given
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+            if(!$data) throw new FileNotFoundException('id = '.$id);
+        }
+
+        // Fill properties from provided data
+        if($data) $this->fillFromDBData($data);
+    }
+
+
+    public static function getShredPath() {
+    
+        $path = Config::get('storage_filesystem_shred_path');
+        if(!$path) throw new ConfigMissingParameterException('storage_filesystem_shred_path');
+        
+        // Check if storage path exists and is writable
+        if(!is_dir($path) || !is_writable($path))
+            throw new ConfigMissingParameterException('storage_filesystem_shred_path');
+        
+        // Build final path and cache
+        if(substr($path, -1) != '/') $path .= '/';
+        return $path;
+    }
+
+    /**
+     * Create a new junk file
+     * 
+     * @param original_path the file path to move to the junk area for shredding
+     * 
+     * @return ShredFile
+     */
+    public static function create( $original_path ) {
+        $file = new self();
+
+        $shredpath = self::getShredPath();
+
+        if( !is_dir($shredpath)) {
+            throw new StorageFilesystemCannotDeleteException($original_path, $file);
+        }
+
+        // Generate uid until it is indeed unique
+        $file->name = Utilities::generateUID(function($uid, $tries) {
+            $statement = DBI::prepare('SELECT * FROM '.File::getDBTable().' WHERE uid = :uid');
+            $statement->execute(array(':uid' => $uid));
+            $data = $statement->fetch();
+            if(!$data) Logger::info('File uid generation took '.$tries.' tries');
+            return !$data;
+        });
+
+        if( !rename( $original_path, $shredpath.$file->name )) {
+            throw new StorageFilesystemCannotDeleteException($original_path, $file);
+        }
+
+        return $file;
+    }
+
+    /**
+     * Shred the file on disk
+     */
+    public function shred() {
+        $ret = true;
+        $shredpath = self::getShredPath();
+        $path = $shredpath.$this->name;
+
+        $cmd = Config::get('storage_filesystem_file_shred_command');
+        $cmd = str_replace('{path}', escapeshellarg($path), $cmd);
+        exec($cmd, $out, $ret);
+
+        if($ret) {
+            $this->errormessage = substr(implode("\n",$out),0,300);
+            $this->save();
+            $ret = false;
+        } else {
+            // remove ourselves from database, we are done.
+            $this->delete();            
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Get file from uid
+     * 
+     * @param string $uid
+     * 
+     * @return File
+     */
+    public static function fromName($name) {
+        $s = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE name = :uid');
+        $s->execute(array('name' => $name));
+        $data = $s->fetch();
+        
+        if(!$data) throw FileNotFoundException('name = '.$name);
+        
+        return self::fromData($data['id'], $data); // Don't query twice, use loaded data
+    }
+    
+    
+    /**
+     * Getter
+     * 
+     * @param string $property property to get
+     * 
+     * @throws PropertyAccessException
+     * 
+     * @return property value
+     */
+    public function __get($property) {
+        if(in_array($property, array(
+            'id', 'name'
+        ))) return $this->$property;
+        
+        throw new PropertyAccessException($this, $property);
+    }
+    
+    /**
+     * Setter
+     * 
+     * @param string $property property to get
+     * @param mixed $value value to set property to
+     * 
+     * @throws FileBadHashException
+     * @throws PropertyAccessException
+     */
+    public function __set($property, $value) {
+        if($property == 'name') {
+            $this->name = (string)$value;
+        } else {
+            throw new PropertyAccessException($this, $property);
+        }
+    }
+    
+    /**
+     * String caster
+     * 
+     * @return string
+     */
+    public function __toString() {
+        return static::getClassName().'#'.($this->id ? $this->id : 'unsaved').'('.$this->name.')';
+    }
+
+
+    public static function shouldUseShredFile() {
+        $cmd = Config::get('storage_filesystem_file_shred_command');
+        return strlen($cmd) > 0;
+    }
+
+}

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -421,29 +421,8 @@ class StorageFilesystem {
      */
     public static function deleteFile(File $file) {
         $file_path = static::buildPath($file).static::buildFilename($file);
-        
-        if(!file_exists($file_path)) return;
-        
-        if(is_link($file_path)) {
-            if(!unlink($file_path))
-                throw new StorageFilesystemCannotDeleteException($file_path, $file);
-            
-            return;
-        }
-        
-        $rm_command = Config::get('storage_filesystem_file_deletion_command');
-        
-        if($rm_command) {
-            $cmd = str_replace('{path}', escapeshellarg($file_path), $rm_command);
-            exec($cmd, $out, $ret);
-            
-            if($ret)
-                throw new StorageFilesystemCannotDeleteException($file_path, $file);
-            
-        } else {
-            if(!unlink($file_path))
-                throw new StorageFilesystemCannotDeleteException($file_path, $file);
-        }
+
+        Filesystem::deleteFile( $file_path, $file );
     }
     
     /**

--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -165,22 +165,8 @@ class StorageFilesystemChunked extends StorageFilesystem {
      */
     public static function deleteFile(File $file) {
         $file_path = self::buildPath($file).$file->uid;
-        
-        if(!file_exists($file_path)) return;
-        
-        if(is_link($file_path)) {
-            if(!unlink($file_path))
-                throw new StorageFilesystemCannotDeleteException($file_path, $file);
-            return;
-        }
-        
-        $rm_command = Config::get('storage_filesystem_tree_deletion_command');
-        $cmd = str_replace('{path}', escapeshellarg($file_path), $rm_command);
-        exec($cmd, $out, $ret);
-        
-        if($ret)
-            throw new StorageFilesystemCannotDeleteException($file_path, $file);
-        
+
+        Filesystem::deleteTreeRecursive( $file_path, $file );
     }
     
     

--- a/classes/utils/Filesystem.class.php
+++ b/classes/utils/Filesystem.class.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE'))
+    die('Missing environment');
+
+require_once(FILESENDER_BASE.'/lib/random_compat/lib/random.php');
+
+/**
+ * Filesystem functions holder
+ */
+class Filesystem {
+
+    /**
+     * Deletes a file
+     * 
+     * @param String $path - full path to file to delete
+     * @param File   $file - optional, used only in logging.
+     * 
+     * @throws StorageFilesystemCannotDeleteException
+     */
+    public static function deleteFile( $file_path, File $file = null) {
+        
+        if(!file_exists($file_path)) return;
+        
+        if(is_link($file_path)) {
+            if(!unlink($file_path))
+                throw new StorageFilesystemCannotDeleteException($file_path, $file);
+            
+            return;
+        }
+
+        if( ShredFile::shouldUseShredFile()) {
+            Logger::info('deleteFile() creating a new shred file for file: ' . $file_path );
+            $shredfile = ShredFile::create($file_path);
+            $shredfile->save();
+            return;
+        }
+        
+        $rm_command = Config::get('storage_filesystem_file_deletion_command');
+        
+        if($rm_command) {
+            $cmd = str_replace('{path}', escapeshellarg($file_path), $rm_command);
+            exec($cmd, $out, $ret);
+            
+            if($ret)
+                throw new StorageFilesystemCannotDeleteException($file_path, $file);
+            
+        } else {
+            if(!unlink($file_path))
+                throw new StorageFilesystemCannotDeleteException($file_path, $file);
+        }
+    }
+
+    /**
+     * Deletes a whole directory tree
+     * 
+     * @param String $path - full path to delete recursively
+     * @param File   $file - optional, used only in logging.
+     * 
+     * @throws StorageFilesystemCannotDeleteException
+     */
+    public static function deleteTreeRecursive( $file_path, File $file = null ) {
+        
+        if(!file_exists($file_path)) return;
+        
+        if(is_link($file_path)) {
+            if(!unlink($file_path))
+                throw new StorageFilesystemCannotDeleteException($file_path, $file);
+            return;
+        }
+        
+        $rm_command = Config::get('storage_filesystem_tree_deletion_command');
+        $cmd = str_replace('{path}', escapeshellarg($file_path), $rm_command);
+        exec($cmd, $out, $ret);
+        
+        if($ret)
+            throw new StorageFilesystemCannotDeleteException($file_path, $file);
+        
+    }
+
+}

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -39,6 +39,12 @@ A note about colours;
 * [storage_filesystem_hashing](#storage_filesystem_hashing)
 * [storage_filesystem_ignore_disk_full_check](#storage_filesystem_ignore_disk_full_check)
 
+## Shredding
+
+* [storage_filesystem_shred_path](#storage_filesystem_shred_path)
+* [storage_filesystem_file_shred_command](#storage_filesystem_file_shred_command)
+
+
 ## Database
 
 * [db_type](#db_type)
@@ -394,6 +400,33 @@ A note about colours;
 * __default:__ false
 * __available:__ since version 2.0
 * __comment:__ If you are using FUSE to interface with some other storage such as EOS then you might like to set this to true to avoid having to do a distributed search to find out of there is storage for each upload
+
+
+---
+
+## Shredding
+
+---
+
+### storage_filesystem_shred_path
+
+* __description:__ Path to store files that should be fed to shred.
+* __mandatory:__ no.  
+* __type:__ string
+* __default:__ ['filesenderbase'].'/shredfiles'
+* __available:__ since version 2.0 beta 4
+* __comment:__ This should be on the same filesystem as storage_filesystem_path
+       so that a 'mv' of a file between the two paths does not require new files
+       to be made.
+
+### storage_filesystem_file_shred_command
+
+* __description:__ command to shred files
+* __mandatory:__ no.  
+* __type:__ string
+* __default:__ nothing
+* __available:__ since version 2.0 beta 4
+* __comment:__ If this is set then file shredding will be enabled. See the [shredding page](http://docs.filesender.org/v2.0/shredding) for more information.
 
 
 ---

--- a/docs/v2.0/shredding/index.md
+++ b/docs/v2.0/shredding/index.md
@@ -1,0 +1,55 @@
+---
+title: Documentation v2.0-beta
+---
+
+# FileSender Shredding deleted files
+
+FileSender 2.0 can execute shred or other long running tasks to
+securely delete user files when they are discarded by the user.
+Explicit support was added in FileSender 2.0 beta 4 for this
+functionality.
+
+The problem with shredding files right at the time the user deletes a
+transfer is that a secure shredding on a large file may take a very
+long time. A user may not be interested in waiting for this shredding
+to complete before continuing to use the FileSender Web interface.
+
+If you wish to run shred at the time a user deletes a file simply
+continue to use shred in the storage_filesystem_file_deletion_command
+configuration directive. Otherwise, the new
+storage_filesystem_file_shred_command can be set which will also
+enable the new shredding functionality.
+
+If you are using this shredding support, when a user deletes a
+transfer files are renamed into the directory specified by the
+storage_filesystem_shred_path configuration directive. For best, and
+most secure, results you should have storage_filesystem_shred_path on
+the same filesystem as storage_filesystem_path. On security grounds,
+the code may reject configurations where these two paths are not on
+the same filesystem in the future.
+
+Files that are moved to storage_filesystem_shred_path have a new file
+name and are inserted into the shredfiles table in the database. That
+table has a synthetic tuple id, the file name, and an optional
+errormessage field. To actually shred the files you should arrange to
+execute the scripts/task/cron-handle-shred-files.php script on a
+regular basis. This script will perform the actual shredding of the
+files and remove them from the database after a successful shred.
+
+If shredding failed then the output of
+storage_filesystem_file_shred_command is inserted into the
+errormessage field to help the system administrator to track down the
+problem. Each time your run the cron-handle-shred-files.php script
+every file in the shredfiles table will be attempted to be shredded.
+So if you have had a problem shredding a file and have changed things
+such as file permissions to fix the problem simply rerun the
+cron-handle-shred-files.php script and an attempt will be made to
+shred all files in the shredfiles table.
+
+## Configuration directives of interest
+
+* storage_filesystem_file_shred_command
+* storage_filesystem_shred_path
+* storage_filesystem_path (Note: should be on same filesystem as storage_filesystem_shred_path).
+
+

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -115,6 +115,8 @@ $default = array(
     'storage_filesystem_tree_deletion_command' => 'rm -rf {path}',
     'storage_filesystem_ignore_disk_full_check' => false,
     'storage_filesystem_external_script' => FILESENDER_BASE.'/scripts/StorageFilesystemExternal/external.py',
+
+    'storage_filesystem_shred_path' => FILESENDER_BASE.'/shredfiles',
     
     'email_from' => 'sender',
     'email_return_path' => 'sender',

--- a/scripts/commands/file_deletion_command_testing_fast
+++ b/scripts/commands/file_deletion_command_testing_fast
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo 'rm -f $1' >> /tmp/deletes
+

--- a/scripts/commands/file_deletion_command_testing_slow
+++ b/scripts/commands/file_deletion_command_testing_slow
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sleep 30
+echo 'rm -f $1' >> /tmp/deletes
+

--- a/scripts/commands/file_deletion_command_testing_very_slow
+++ b/scripts/commands/file_deletion_command_testing_very_slow
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sleep 240
+echo 'rm -f $1' >> /tmp/deletes
+

--- a/scripts/commands/file_deletion_command_with_shred
+++ b/scripts/commands/file_deletion_command_with_shred
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+shred -zu -n 2 $1;

--- a/scripts/task/cron-handle-shred-files.php
+++ b/scripts/task/cron-handle-shred-files.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once(dirname(__FILE__).'/../../includes/init.php');
+
+Logger::setProcess(ProcessTypes::CRON);
+Logger::info('Cron started');
+
+// Send daily summaries
+foreach(ShredFile::all() as $shredfile) {
+   echo "shred file " . $shredfile->name . "\n";
+   $shredfile->shred();
+}


### PR DESCRIPTION
Running shred(1) directly in the
storage_filesystem_file_deletion_command can make the Web interface
appear to be broken at times. This is due to the execution of shred
being done synchronously.

This new code creates a clearing house for shredding. When a file is
deleted through the Web interface it is moved and marked for shredding.
See the new docs shredding page at docs/v2.0/shredding/index.md
for details.

There are many design options for this. Having a database table allows
failures to be tracked which might not otherwise be noticed. The
original file names are scrubbed so the files to be shredded does not
expose the user who used to own the files.