### PR TITLE
i18n: graphs can be internationalized

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -390,6 +390,10 @@ $lang['undergoing_maintenance'] = 'This application is under maintenance';
 $lang['unexpected_file'] = 'This file is not part of the restarting transfer';
 $lang['unknown_page'] = 'Unknown page';
 $lang['upload_page'] = 'Upload';
+$lang['upload_page_graph_title_upload_speed_of_files_over'] = 'Global Average Upload Speed of Files over {size}';
+$lang['upload_page_graph_mb_per_second'] = 'MB/sec';
+$lang['upload_page_graph_encryption_in_transit_and_rest'] = 'Encryption in transit & rest';
+$lang['upload_page_graph_encryption_in_transit'] = 'Encryption in transit';
 $lang['uploaded'] = 'Uploaded';
 $lang['uploading_transfers'] = 'Currently uploading transfers';
 $lang['user_additional'] = 'Additional information';
@@ -413,3 +417,5 @@ $lang['with_identity'] = 'Sender email';
 $lang['yes'] = 'Yes';
 $lang['you_can_report_exception'] = 'When reporting this error please give the following code to help the support finding out details';
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
+
+

--- a/www/lib/graph/uploadGraph.php
+++ b/www/lib/graph/uploadGraph.php
@@ -39,13 +39,13 @@ $data = array(
 	'labels' => array(),
 	'datasets' => array(
 	    array(
-		'label' => 'Encryption in transit & rest',
+                'label' => Lang::tr('upload_page_graph_encryption_in_transit_and_rest')->out(),
 		'data' => array(),
 		'backgroundColor' => 'rgba(10,220,10,0.6)',
 		'spanGaps' => true
 	    ),
 	    array(
-		'label' => 'Encryption in transit',
+                'label' => Lang::tr('upload_page_graph_encryption_in_transit')->out(),
 		'data' => array(),
 		'backgroundColor' => 'rgba(255,147,02,0.6)',
 		'spanGaps' => true
@@ -57,7 +57,7 @@ $data = array(
 	'maintainAspectRatio' => false,
 	'title' => array(
 	    'display' => true,
-	    'text' => 'Global Average Upload Speed of Files over ' . Utilities::formatBytes($minSz)
+	    'text' => Lang::tr('upload_page_graph_title_upload_speed_of_files_over')->r('size',Utilities::formatBytes($minSz))->out()
 	),
 	'legend' => array(
 	    'position' => 'bottom'
@@ -67,11 +67,16 @@ $data = array(
 		array(
 		    'ticks' => array( 'min' => 0 ),
                     'scaleLabel' => array( 'display' => true,
-                                            'labelString' => 'MB/sec'
+                                            'labelString' => Lang::tr('upload_page_graph_mb_per_second')->out()
                                          ),
 		),
-                
-	    )
+	    ),
+            'xAxes' => array(
+                array(
+                    'type' => 'time',
+		    'ticks' => array( 'min' => 0 ),
+                ),
+            ),
 	)
     )
 );


### PR DESCRIPTION
This is a fix for https://github.com/filesender/filesender/issues/285. The new terms are 
```
$lang['upload_page_graph_title_upload_speed_of_files_over'] = 'Global Average Upload Speed of Files over {size}';
$lang['upload_page_graph_mb_per_second'] = 'MB/sec';
$lang['upload_page_graph_encryption_in_transit_and_rest'] = 'Encryption in transit & rest';
$lang['upload_page_graph_encryption_in_transit'] = 'Encryption in transit';
```
which are exported to poeditor already.