### PR TITLE
Allow back-feed of last client side logs to server

### DIFF
--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -37,8 +37,6 @@ if(!defined('FILESENDER_BASE')) die('Missing environment');
  * Represents a client log entry in database
  */
 class ClientLog extends DBObject {
-    const STASH_LEN = 10;
-    
     /**
      * Database map
      */
@@ -137,7 +135,8 @@ class ClientLog extends DBObject {
      */
     public static function stash(User $user, $logs) {
         $stash = self::fromUser($user);
-        while($logs && (count($stash) + count($logs) > self::STASH_LEN)) {
+        $len = self::stashSize();
+        while($logs && (count($stash) + count($logs) > $len)) {
             $log = array_shift($stash);
             $log->delete();
         }
@@ -149,6 +148,16 @@ class ClientLog extends DBObject {
         }
         
         return $stash;
+    }
+    
+    /**
+     * Get stash size
+     *
+     * @return int
+     */
+    public static function stashSize() {
+        $size = Config::get('clientlogs_stashsize');
+        return (is_int($size) && ($size > 0)) ? $size : 10;
     }
     
     /**

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if(!defined('FILESENDER_BASE')) die('Missing environment');
+
+/**
+ * Represents a client log entry in database
+ */
+class ClientLog extends DBObject {
+    const STASH_LEN = 10;
+    
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        'id' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'primary' => true,
+            'autoinc' => true
+        ),
+        'user_id' => array(
+            'type' => 'string',
+            'size' => 250
+        ),
+        'created' => array(
+            'type' => 'datetime'
+        ),
+        'message' => array(
+            'type' => 'text'
+        )
+    );
+
+    protected static $secondaryIndexMap = array(
+        'user_id' => array( 
+            'user_id' => array()
+        )
+    );
+
+    /**
+     * Properties
+     */
+    protected $id = null;
+    protected $user_id = null;
+    protected $created = 0;
+    protected $message = null;
+    
+    /**
+     * Constructor
+     * 
+     * @param integer $id identifier of transfer to load from database (null if loading not wanted)
+     * @param array $data data to create the transfer from (if already fetched from database)
+     * 
+     * @throws TransferNotFoundException
+     */
+    protected function __construct($id = null, $data = null) {
+        if(!is_null($id)) {
+            // Load from database if id given
+            /** @var PDOStatement $statement */
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+            if(!$data) throw new TransferNotFoundException('id = '.$id);
+        }
+        
+        // Fill properties from provided data
+        if($data) $this->fillFromDBData($data);
+    }
+    
+    /**
+     * Get client logs from user
+     * 
+     * @param mixed $user User or user id
+     *
+     * @return ClientLog[]
+     */
+    public static function fromUser($user) {
+        if($user instanceof User) $user = $user->id;
+
+        return self::all('user_id = :user_id ORDER BY id ASC', array(':user_id' => $user));
+    }
+    
+    /**
+     * Create a new client log
+     *
+     * @param User $user
+     * @param string $message
+     *
+     * @return self
+     */
+    public static function create(User $user, $message) {
+        $log = new self();
+        $log->user_id = $user->id;
+        $log->message = $message;
+        $log->created = time();
+        
+        return $log;
+    }
+    
+    /**
+     * Stash logs
+     *
+     * @param User $user
+     * @param string[] $logs
+     *
+     * @return self[]
+     */
+    public static function stash(User $user, $logs) {
+        $stash = self::fromUser($user);
+        while($logs && (count($stash) + count($logs) > self::STASH_LEN)) {
+            $log = array_shift($stash);
+            $log->delete();
+        }
+        
+        foreach($logs as $message) {
+            $log = self::create($user, $message);
+            $log->save();
+            $stash[] = $log;
+        }
+        
+        return $stash;
+    }
+    
+    /**
+     * Getter
+     * 
+     * @param string $property property to get
+     * 
+     * @throws PropertyAccessException
+     * 
+     * @return mixed
+     */
+    public function __get($property) {
+        if(in_array($property, array(
+            'id', 'user_id', 'message'
+        ))) return $this->$property;
+        
+        if($property == 'user' || $property == 'owner')
+            return User::fromId($this->user_id);
+        
+        throw new PropertyAccessException($this, $property);
+    }
+    
+    /**
+     * Setter
+     * 
+     * @param string $property property to get
+     * @param mixed $value value to set property to
+     * 
+     * @throws PropertyAccessException
+     */
+    public function __set($property, $value) {
+        throw new PropertyAccessException($this, $property);
+    }
+}

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -152,6 +152,18 @@ class ClientLog extends DBObject {
     }
     
     /**
+     * Clean old entries
+     */
+    public static function clean() {
+        $days = Config::get('clientlogs_lifetime');
+        if(!$days || !is_int($days) || $days <= 0) $days = 10;
+        
+        /** @var PDOStatement $statement */
+        $statement = DBI::prepare('DELETE FROM '.self::getDBTable().' WHERE created < :date');
+        $statement->execute(array(':date' => date('Y-m-d', time() - $days * 86400)));
+    }
+    
+    /**
      * Getter
      * 
      * @param string $property property to get

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -183,7 +183,7 @@ class ClientLog extends DBObject {
      */
     public function __get($property) {
         if(in_array($property, array(
-            'id', 'user_id', 'message'
+            'id', 'user_id', 'message', 'created'
         ))) return $this->$property;
         
         if($property == 'user' || $property == 'owner')

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -136,11 +136,14 @@ class ClientLog extends DBObject {
     public static function stash(User $user, $logs) {
         $stash = self::fromUser($user);
         $len = self::stashSize();
-        while($logs && (count($stash) + count($logs) > $len)) {
+        while($stash && (count($stash) + count($logs) > $len)) {
             $log = array_shift($stash);
             $log->delete();
         }
-        
+    
+        while(count($logs) > $len) // stash is empty if this runs
+            array_shift($logs);
+    
         foreach($logs as $message) {
             $log = self::create($user, $message);
             $log->save();

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -222,6 +222,19 @@ class User extends DBObject {
     }
     
     /**
+     * Search users
+     *
+     * @param string $match
+     *
+     * @return self[]
+     */
+    public static function search($match) {
+        $match = str_replace('\\', '', $match); // Remove to-be-used escape char
+        $match = str_replace(array('%', '_'), array('\\%', '\\_'), $match); // Escape special chars
+        return self::all("id LIKE :match ESCAPE '\\\\'", array(':match' => '%'.$match.'%'));
+    }
+    
+    /**
      * Get active users
      * 
      * @return array of User

--- a/classes/rest/endpoints/RestEndpointClientlogs.class.php
+++ b/classes/rest/endpoints/RestEndpointClientlogs.class.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) 
+    die('Missing environment');
+
+/**
+ * REST client logs endpoint
+ */
+class RestEndpointClientlogs extends RestEndpoint {
+    /**
+     * Cast to output
+     *
+     * @param ClientLog $log
+     *
+     * @return array
+     */
+    public static function cast(ClientLog $log) {
+        return array(
+            'id' => $log->id,
+            'message' => $log->message
+        );
+    }
+    
+    /**
+     * Get user logs
+     * 
+     * Call examples :
+     *  /clientlogs/@me (or /clientlogs): get current user logs
+     *  /clientlogs/foobar: get logs of specific user (admin restrited)
+     *
+     * @param string $uid : user id
+     * 
+     * @return array
+     *
+     * @throws RestAuthenticationRequiredException
+     * @throws RestBadParameterException
+     */
+    public function get($id = null) {
+        // Need to be authenticated ...
+        if(!Auth::isAuthenticated()) throw new RestAuthenticationRequiredException();
+        
+        // ... and not guest
+        if(Auth::isGuest()) throw new RestOwnershipRequiredException((string)AuthGuest::getGuest(), 'user_info');
+        
+        $user = Auth::user();
+        
+        // Check ownership
+        if($id && $id != '@me') {
+            $user = User::fromId($id);
+            
+            if(!$user->is(Auth::user()) && !Auth::isAdmin())
+                throw new RestOwnershipRequiredException(Auth::user()->id, 'user = '.$user->id);
+        }
+    
+        return array_map(function($log) {
+            return self::cast($log);
+        }, ClientLog::fromUser($user));
+    }
+    
+    /**
+     * Set user client logs
+     * 
+     * Call examples :
+     *  /clientlogs/@me (or /clientlogs) : set client logs of current user
+     *  /clientlogs/foo@bar.tld : set client of user with uid foo@bar.tld
+     *
+     * @param string $id user id
+     *
+     * @return mixed
+     * 
+     * @throws RestAuthenticationRequiredException
+     * @throws RestOwnershipRequiredException
+     */
+    public function put($id = null) {
+        // Need to be authenticated
+        if(!Auth::isAuthenticated()) throw new RestAuthenticationRequiredException();
+        
+        // Check ownership if specific user id given
+        if($id & $id != '@me') {
+            $user = User::fromId($id);
+            
+            if(!Auth::user()->is($user) && !Auth::isAdmin())
+                throw new RestOwnershipRequiredException(Auth::user()->id, 'user = '.$user->id);
+        } else {
+            $user = Auth::user();
+        }
+        
+        $stash = ClientLog::stash($user, (array)$this->request->input);
+        
+        return array_map(function($log) {
+            return self::cast($log);
+        }, $stash);
+    }
+}

--- a/classes/rest/endpoints/RestEndpointClientlogs.class.php
+++ b/classes/rest/endpoints/RestEndpointClientlogs.class.php
@@ -48,7 +48,8 @@ class RestEndpointClientlogs extends RestEndpoint {
     public static function cast(ClientLog $log) {
         return array(
             'id' => $log->id,
-            'message' => $log->message
+            'message' => $log->message,
+            'created' => RestUtilities::formatDate($log->created, true)
         );
     }
     
@@ -85,7 +86,7 @@ class RestEndpointClientlogs extends RestEndpoint {
     
         return array_map(function($log) {
             return self::cast($log);
-        }, ClientLog::fromUser($user));
+        }, array_values(ClientLog::fromUser($user)));
     }
     
     /**

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -90,6 +90,7 @@ class GUI {
             'js/lang.js',
             'js/client.js',
             'js/transfer.js',
+            'js/logger.js',
             'js/ui.js',
             'js/FileSaver.js',
             'js/crypter/crypto_common.js',

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -171,6 +171,7 @@ A note about colours;
 * [report_format](#reportformat)
 * [exception_additional_logging_regex](#exceptionadditionalloggingregex)
 * [clientlogs_stashsize](#clientlogsstashsize)
+* [clientlogs_lifetime](#clientlogslifetime)
 
 
 ## Webservices API
@@ -1552,6 +1553,15 @@ different options for different types.</span>
 * __available:__ since version 2.0
 * __comment:__ Number of last client console entries that are to be back-fed to the server in case there is a client error.
 
+
+### clientlogs_lifetime
+
+* __description:__ Client log backfeed lifetime
+* __mandatory:__ no
+* __type:__ positive integer
+* __default:__ 10
+* __available:__ since version 2.0
+* __comment:__ Number of days after which collected client logs are automatically deleted.
 
 
 ---

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -170,6 +170,7 @@ A note about colours;
 * [auditlog_lifetime](#auditloglifetime)
 * [report_format](#reportformat)
 * [exception_additional_logging_regex](#exceptionadditionalloggingregex)
+* [clientlogs_stashsize](#clientlogsstashsize)
 
 
 ## Webservices API
@@ -1541,6 +1542,15 @@ different options for different types.</span>
 * __available:__ since version 2.0
 * __comment:__ Sometimes a site might want to capture down extra logging for some exception types. This configuration is a regular expression to match the name of an exception against to see if you want this extra log info. This allows extra log info to be turned on and off fairly easily without having to edit code and possibly break something. Note that only some exceptions can give extra info.
 
+
+### clientlogs_stashsize
+
+* __description:__ Client log backfeed stash size
+* __mandatory:__ no
+* __type:__ positive integer
+* __default:__ 10
+* __available:__ since version 2.0
+* __comment:__ Number of last client console entries that are to be back-fed to the server in case there is a client error.
 
 
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -417,5 +417,15 @@ $lang['with_identity'] = 'Sender email';
 $lang['yes'] = 'Yes';
 $lang['you_can_report_exception'] = 'When reporting this error please give the following code to help the support finding out details';
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
-
+$lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
+$lang['send_client_logs'] = 'Send logs';
+$lang['client_logs_sent'] = 'Logs successfully sent';
+$lang['admin_users_section'] = 'Users';
+$lang['users'] = 'Users';
+$lang['search_user'] = 'Search for user (based on user ID)';
+$lang['search'] = 'Search';
+$lang['searching'] = 'Searching ...';
+$lang['no_results'] = 'No results';
+$lang['last_activity'] = 'Last activity';
+$lang['show_client_logs'] = 'Show client logs';
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -418,6 +418,7 @@ $lang['yes'] = 'Yes';
 $lang['you_can_report_exception'] = 'When reporting this error please give the following code to help the support finding out details';
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
+$lang['nothing_happened_as_of_late_you_can_send_client_logs'] = 'No progress has been reported for your currently uploading transfer for some time, if you think it is stuck and before reporting it to your support team please send the last log entries from your user interface by clicking this button :';
 $lang['send_client_logs'] = 'Send logs';
 $lang['client_logs_sent'] = 'Logs successfully sent';
 $lang['admin_users_section'] = 'Users';

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -139,3 +139,6 @@ if((int)$level) {
 
 // Remove inactive users preferences
 User::removeInactive();
+
+// Clean old client logs
+ClientLog::clean();

--- a/templates/admin_page.php
+++ b/templates/admin_page.php
@@ -1,7 +1,7 @@
 <div class="box">
     <?php
     
-    $sections = array('statistics', 'transfers', 'guests');
+    $sections = array('statistics', 'users', 'transfers', 'guests');
     
     if(Config::get('config_overrides'))
         $sections[] = 'config';

--- a/templates/admin_statistics_section.php
+++ b/templates/admin_statistics_section.php
@@ -155,9 +155,12 @@ WHERE event='file_uploaded'
 GROUP BY "encryption","os","browser"
 ORDER BY COUNT(ID) DESC, maxsize DESC
 EOF;
+/**
 $statement = DBI::prepare($sql);
 $statement->execute(array());
 $result = $statement->fetchAll();
+ */
+$results=array();
 $transfered=0;
 $transfers=0;
 $now=time();

--- a/templates/admin_users_section.php
+++ b/templates/admin_users_section.php
@@ -1,0 +1,52 @@
+<h2>{tr:users}</h2>
+
+<fieldset class="search">
+    <legend>{tr:search_user}</legend>
+    
+    <input type="text" name="match" /> <input type="button" name="go" value="{tr:search}" />
+</fieldset>
+
+<table class="results">
+    <tr>
+        <th>{tr:user_id}</th>
+        <th>{tr:last_activity}</th>
+        <th>&nbsp;</th>
+    </tr>
+    
+    <tr class="searching">
+        <td colspan="3">{tr:searching}</td>
+    </tr>
+    <tr class="no_results">
+        <td colspan="3">{tr:no_results}</td>
+    </tr>
+    
+    <tr class="tpl">
+        <td class="uid"></td>
+        <td class="last_activity"></td>
+        
+        <td>
+            <input type="button" data-action="show-client-logs" value="{tr:show_client_logs}" />
+        </td>
+    </tr>
+</table>
+
+<table class="client-logs">
+    <tr>
+        <th>{tr:date}</th>
+        <th>{tr:message}</th>
+    </tr>
+    
+    <tr class="searching">
+        <td colspan="3">{tr:searching}</td>
+    </tr>
+    <tr class="no_results">
+        <td colspan="2">{tr:no_results}</td>
+    </tr>
+    
+    <tr class="tpl">
+        <td class="date"></td>
+        <td class="message"></td>
+    </tr>
+</table>
+
+<script type="text/javascript" src="{path:js/admin_users.js}"></script>

--- a/unittests/config_tests_filesender.xml
+++ b/unittests/config_tests_filesender.xml
@@ -51,6 +51,7 @@
 <!--            <file>tests/mail/MailTest.php</file>            <! - Failed -->
 <!--            <file>tests/report/ReportTest.php</file>        <! - Failed -->
             <file>tests/transfer/TransferTest.php</file>    <!-- Failed -->
+            <file>tests/clientlog/ClientlogTest.php</file>    <!-- Success -->
         </testsuite>
 
         <testsuite name="selenium">

--- a/unittests/tests/clientlog/ClientlogTest.php
+++ b/unittests/tests/clientlog/ClientlogTest.php
@@ -145,9 +145,29 @@ class ClientlogTest extends CommonUnitTestCase {
     }
     
     /**
-     * Function to test cleanup of Clientlogs
+     * Function to test over-stashing of Clientlogs
      *
      * @depends testStash
+     *
+     * @return boolean: true if test succeed
+     */
+    public function testOverStash() {
+        $size = ClientLog::stashSize();
+        
+        ClientLog::stash(Auth::user(), array_fill(0, 2 * $size, 'message'));
+        
+        $logs = ClientLog::fromUser(Auth::user());
+        $this->assertLessThanOrEqual($size, count($logs));
+        
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- '.self::CREATE.' ClientLog stash size applied');
+        
+        return true;
+    }
+    
+    /**
+     * Function to test cleanup of Clientlogs
+     *
+     * @depends testOverStash
      *
      * @return boolean: true if test succeed
      */

--- a/unittests/tests/clientlog/ClientlogTest.php
+++ b/unittests/tests/clientlog/ClientlogTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__) . '/../common/CommonUnitTestCase.php';
+
+/**
+ * Auditlog class test
+ * 
+ * @backupGlobals disabled
+ */
+class ClientlogTest extends CommonUnitTestCase {
+    /*
+     * Some variables used in tests case
+     */
+    
+    const CREATE = 5;
+    
+    /**
+     * Init variables, first function called
+     */
+
+    public static function setUpBeforeClass() {
+        echo "ClientlogTest@ " . date("Y-m-d H:i:s") . "\n\n";
+
+        echo "Client logs stash size: " . ClientLog::stashSize() . "\n";
+        
+        if (!Auth::isAuthenticated(false))
+            throw new AuthAuthenticationNotFoundException();
+        
+        // Ensure empty set
+        DBI::exec('DELETE FROM '.ClientLog::getDBTable());
+    }
+    
+    /**
+     * Cleanup in any case
+     */
+    public static function tearDownAfterClass() {
+        // Clean any trash
+        DBI::exec('DELETE FROM '.ClientLog::getDBTable());
+    }
+
+    /**
+     * Function to create a Clientlog on database
+     * 
+     * @return bool: if test succeeds
+     */
+    public function testCreate() {
+        // Creating log objects
+        $message = 'unique message '.uniqid();
+        $log = ClientLog::create(Auth::user(), $message);
+        $log->save();
+
+        $this->assertNotNull($log->id);
+        $this->assertEquals($message, $log->message);
+        $this->assertEquals(Auth::user()->id, $log->user_id);
+        
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- ClientLog created');
+        
+        return true;
+    }
+    
+    /**
+     * Function to test getting ClientLog from cache
+     * 
+     * @depends testCreate
+     * 
+     * @return int: count of logs if test succeed
+     */
+    public function testRead() {
+        $logs = ClientLog::fromUser(Auth::user());
+
+        $this->assertNotNull($logs);
+        $this->assertTrue(is_array($logs));
+        $this->assertNotEmpty($logs);
+
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- ClientLog got:'.count($logs));
+
+        return count($logs);
+    }
+    
+    /**
+     * Function to test deletion of Clientlog
+     *
+     * @depends testRead
+     *
+     * @return boolean: true if test succeed
+     */
+    public function testDelete() {
+        $logs = ClientLog::fromUser(Auth::user());
+        
+        array_shift($logs)->delete();
+        
+        $this->assertEmpty(ClientLog::fromUser(Auth::user()));
+        
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- ClientLog deleted');
+        
+        return true;
+    }
+    
+    /**
+     * Function to test stashing of Clientlogs
+     *
+     * @depends testDelete
+     *
+     * @return boolean: true if test succeed
+     */
+    public function testStash() {
+        ClientLog::stash(Auth::user(), array_fill(0, self::CREATE, 'message'));
+        
+        $logs = ClientLog::fromUser(Auth::user());
+        $this->assertEquals(self::CREATE, count($logs));
+        
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- '.self::CREATE.' ClientLog stashed');
+        
+        return true;
+    }
+    
+    /**
+     * Function to test cleanup of Clientlogs
+     *
+     * @depends testStash
+     *
+     * @return boolean: true if test succeed
+     */
+    public function testClean() {
+        // Update dates so clean works
+        $days = Config::get('clientlogs_lifetime');
+        if(!$days) $days = 10;
+        $days += 2; // margin to ensure logs are old enough
+        
+        $st = DBI::prepare('UPDATE '.ClientLog::getDBTable().' SET created = :date');
+        $st->execute(array(':date' => date('Y-m-d', time() - $days * 86400)));
+        
+        // Ensure update did its job
+        $logs = ClientLog::fromUser(Auth::user());
+        $log = array_shift($logs);
+        $this->assertNotNull($log);
+        $this->assertLessThanOrEqual(time() - $days * 86400, $log->created);
+        
+        // Actual cleanup
+        ClientLog::clean();
+        
+        $this->assertEmpty(ClientLog::fromUser(Auth::user()));
+        
+        $this->displayInfo(get_class(), __FUNCTION__, ' -- ClientLog cleaned');
+        
+        return true;
+    }
+}

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1237,7 +1237,44 @@ table.guests .guest .to .errors .details {
 }
 
 
-/* Popups */
+/** Admin users */
+
+.admin_page .users_section .searching,
+.admin_page .users_section .no_results,
+.admin_page .users_section .client-logs,
+.admin_page .users_section .tpl {
+    display: none;
+}
+
+.admin_page .users_section .searching .searching,
+.admin_page .users_section .no_results .no_results {
+    display: table-row;
+    text-align: center;
+}
+
+.admin_page .users_section table {
+    margin: 0.5rem 0;
+    width: 100%;
+}
+
+.admin_page .users_section th {
+    border: 1px solid silver;
+    text-align: center;
+    font-weight: bold;
+}
+
+.admin_page .users_section td {
+    border: 1px solid silver;
+}
+
+.admin_page .users_section .results th+th,
+.admin_page .users_section .results td+td,
+.admin_page .users_section .client-logs th:first-child,
+.admin_page .users_section .client-logs td:first-child {
+    width: 8rem;
+}
+
+    /* Popups */
 #dialog-help h4 {
     font-size: 1.2em;
     margin: 0.5em 1em;

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -55,8 +55,6 @@ if (typeof window === 'undefined') {
 if (!('filesender' in window)) window.filesender = {};
 
 window.filesender.config = {
-    log: true,
-    
     site_name: '<?php echo Config::get('site_name') ?>',
     
     upload_chunk_size: <?php echo Config::get('upload_chunk_size') ?>,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -125,7 +125,11 @@ window.filesender.config = {
 		file_encryption_wrong_password : "<?php echo Lang::tr('file_encryption_wrong_password')->out(); ?>",
 		file_encryption_enter_password : "<?php echo Lang::tr('file_encryption_enter_password')->out(); ?>",
 		file_encryption_need_password : "<?php echo Lang::tr('file_encryption_need_password')->out(); ?>"
-	}
+	},
+    
+    clientlogs: {
+        stash_len: <?php echo ClientLog::stashSize() ?>
+    }
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/js/admin_users.js
+++ b/www/js/admin_users.js
@@ -1,0 +1,117 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+$(function() {
+    var section = $('#page.admin_page .users_section');
+    if(!section.length) return;
+
+    var go = section.find('.search [name="go"]').prop('disabled', true);
+    var match = section.find('.search [name="match"]');
+    var results = section.find('.results');
+    var logs = section.find('.client-logs');
+
+    var clean_logs = function() {
+        logs.find('.log').remove();
+    };
+
+    var add_log = function(log) {
+        var l = logs.find('.tpl').clone().removeClass('tpl').addClass('log');
+        l.attr({'data-id': log.id});
+        l.find('.date').text(log.created.formatted);
+        l.find('.message').text(log.message);
+        l.appendTo(logs);
+    };
+
+    var show_logs = function(id) {
+        logs.show().removeClass('no_results').addClass('searching');
+        filesender.client.get('/clientlogs/' + id, function(found) {
+            clean_logs();
+
+            logs.toggleClass('no_results', !found.length);
+
+            for(var i=0; i<found.length; i++)
+                add_log(found[i]);
+
+            logs.removeClass('searching');
+        });
+    };
+
+    var clean_users = function() {
+        results.find('.user').remove();
+    };
+
+    var add_user = function(user) {
+        var u = results.find('.tpl').clone().removeClass('tpl').addClass('user');
+        u.attr({'data-id': user.id});
+        u.find('.uid').text(user.id);
+        u.find('.last_activity').text(user.last_activity.formatted);
+        u.appendTo(results);
+
+        u.find('[data-action="show-client-logs"]').on('click', function() {
+            var id = $(this).closest('.user').attr('data-id');
+            show_logs(id);
+        });
+    };
+
+    var search_user = function() {
+        results.removeClass('no_results').addClass('searching');
+        filesender.client.get('/user', function(matches) {
+            clean_users();
+
+            results.toggleClass('no_results', !matches.length);
+
+            for(var i=0; i<matches.length; i++)
+                add_user(matches[i]);
+
+            results.removeClass('searching');
+        }, {
+            args: {match: match.val()}
+        });
+    };
+
+    var eval_go = function() {
+        go.prop('disabled', match.val().length < 3)
+    };
+
+    match.on('change, input', function() {
+        eval_go();
+    }).on('keyup', function(e) {
+        if(e.keyCode === 13 && $(this).val().length >= 3)
+            search_user();
+    });
+
+    go.on('click', function() {
+        search_user();
+    });
+
+    eval_go();
+});

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -49,6 +49,9 @@ window.filesender.logger = {
      * @param {String} msg
      */
     log: function(msg) {
+        if(!(typeof msg).match(/^(number|string)$/))
+            msg = JSON.stringify(msg);
+
         var len = filesender.config ? filesender.config.clientlogs.stash_len : 10;
 
         this.stash.push(msg);

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -1,0 +1,99 @@
+/**
+ * Created by etienne on 5/2/18.
+ */
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Client side language handling
+ */
+
+if(!('filesender' in window)) window.filesender = {};
+
+window.filesender.logger = {
+    // Log stash (memory)
+    stash_len: 10,
+    stash: [],
+
+    /**
+     * Log message
+     *
+     * @param {String} msg
+     */
+    log: function(msg) {
+        this.stash.push(msg);
+        this.stash = this.stash.slice(-1 * this.stash_len);
+
+        if(filesender.supports.localStorage) {
+            window.localStorage.setItem('client_logs', JSON.stringify(this.stash))
+        }
+    },
+
+    /**
+     * Load from storage
+     */
+    load: function() {
+        if(filesender.supports.localStorage) {
+            var s = window.localStorage.getItem('client_logs');
+            if(s) this.stash = JSON.parse(s);
+            if(!this.stash) this.stash = [];
+        }
+    },
+
+    /**
+     * Send logs to server
+     *
+     * @param {Function} callback
+     */
+    send: function(callback) {
+        filesender.client.put('/clientlogs/@me', this.stash, function(data) {
+            if(callback) callback(data);
+        });
+    }
+};
+
+filesender.logger.load();
+
+// Wrap console utilities
+var wrap = ['log', 'info' ,'warn', 'error'];
+if(!window.console) window.console = {};
+
+$(wrap).each(function() {
+    var f = (this in window.console) ? window.console[this] : function() {};
+    window.console[this] = function(msg) {
+        // Custom log
+        filesender.logger.log(msg);
+
+        // Forward to internal
+        f(msg);
+    };
+});

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -41,7 +41,6 @@ if(!('filesender' in window)) window.filesender = {};
 
 window.filesender.logger = {
     // Log stash (memory)
-    stash_len: 10,
     stash: [],
 
     /**
@@ -50,8 +49,10 @@ window.filesender.logger = {
      * @param {String} msg
      */
     log: function(msg) {
+        var len = filesender.config ? filesender.config.clientlogs.stash_len : 10;
+
         this.stash.push(msg);
-        this.stash = this.stash.slice(-1 * this.stash_len);
+        this.stash = this.stash.slice(-1 * len);
 
         if(filesender.supports.localStorage) {
             window.localStorage.setItem('client_logs', JSON.stringify(this.stash))

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -98,3 +98,8 @@ $(wrap).each(function() {
         f(msg);
     };
 });
+
+// Capture js errors
+window.addEventListener('error', function(e) {
+    filesender.logger.log('[js error] ' + e.filename + '@' + e.lineno + ':' + e.colno + ' ' + e.message);
+});

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -104,5 +104,5 @@ $(wrap).each(function() {
 
 // Capture js errors
 window.addEventListener('error', function(e) {
-    filesender.logger.log('[js error] ' + e.filename + '@' + e.lineno + ':' + e.colno + ' ' + e.message);
+    filesender.logger.log('[' + (new Date()).toLocaleTimeString() + '] JS ERROR in ' + e.filename + '@' + e.lineno + ':' + e.colno + ' ' + e.message);
 });

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -47,7 +47,7 @@ window.filesender.ui = {
      * @param mixed message
      */
     log: function(message) {
-        if(filesender.config.log) console.log('[' + (new Date()).toLocaleTimeString() + '] ' + message);
+        console.log('[' + (new Date()).toLocaleTimeString() + '] ' + message);
     },
     
     /**

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -355,6 +355,13 @@ window.filesender.ui = {
         } else if(error.uid) {
             r.append(lang.tr('you_can_report_exception') + ' : "' + error.uid + '"');
         }
+
+        r.append('<br /><br />' + lang.tr('you_can_send_client_logs') + ' ');
+        r.append($('<button class="send_client_logs" />').text(lang.tr('send_client_logs').out()).on('click', function() {
+            filesender.logger.send(function() {
+                filesender.ui.notify('success', lang.tr('client_logs_sent'));
+            });
+        }));
         
         return error.message;
     },

--- a/www/lib/terasender/terasender.js
+++ b/www/lib/terasender/terasender.js
@@ -189,11 +189,9 @@ window.filesender.terasender = {
      * @param string origin "driver" (default) or "worker"
      */
     error: function(error, origin) {
-        if(filesender.config.log) {
-            console.log('[terasender ' + (origin ? origin : 'driver') + ' error] ' + error.message + (error.details ? ', details follow :' : ''));
-            if(error.details) console.log(error.details); // Whatever type it is ...
-        }
-        
+        console.log('[terasender ' + (origin ? origin : 'driver') + ' error] ' + error.message + (error.details ? ', details follow :' : ''));
+        if(error.details) console.log(error.details); // Whatever type it is ...
+
         error.message = 'terasender_' + error.message;
         
         // Trigger global error


### PR DESCRIPTION
As discussed during the workshop (2018-05-01) and requested in issue filesender/filesender#241 here are the changes that allow user to send the last client log entries (that is console entries) to the server and related admin UI to search for users and see sent logs.
It embeds buttons to send the logs in the error popups and if there is no progress at all for a long while when uploading files.