### PR TITLE
baddata: mitigation for issue 293

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -658,6 +658,9 @@ window.filesender.transfer = function() {
         
         // From here we should have everything we need to restart
         filesender.ui.log('Restarting failed transfer #' + this.id);
+        for(var i=0; i<tracker.files.length; i++) {
+            filesender.ui.log('uploaded: ' + tracker.files[i].uploaded);
+        }
         
         this.time = (new Date()).getTime();
         
@@ -1240,12 +1243,11 @@ window.filesender.transfer = function() {
         var slicer = file.blob.slice ? 'slice' : (file.blob.mozSlice ? 'mozSlice' : (file.blob.webkitSlice ? 'webkitSlice' : 'slice'));
         
         var blob = file.blob[slicer](offset, end);
+        var file_uploaded_when_chunk_complete = end;
+        if (file_uploaded_when_chunk_complete > file.size)
+            file_uploaded_when_chunk_complete = file.size;
         
-        file.uploaded = end;
-        if (file.uploaded > file.size)
-            file.uploaded = file.size;
-        
-        var last = file.uploaded >= file.size;
+        var last = file_uploaded_when_chunk_complete >= file.size;
         var fncache = file.name;
         if (last)
             this.file_index++;
@@ -1258,13 +1260,14 @@ window.filesender.transfer = function() {
         this.uploader = filesender.client.putChunk(
             file, blob, offset,
             function(ratio) { // Progress
-                var chunk_size = Math.min(file.size - file.uploaded, filesender.config.upload_chunk_size);
-                file.fine_progress = Math.floor(file.uploaded + ratio * chunk_size);
+                var chunk_size = Math.min(file.size - file_uploaded_when_chunk_complete, filesender.config.upload_chunk_size);
+                file.fine_progress = Math.floor(file_uploaded_when_chunk_complete + ratio * chunk_size);
                 transfer.recordUploadProgressInWatchdog(worker_id,ratio * chunk_size);
                 transfer.reportProgress(file);
             },
             function() { // Done
                 transfer.recordUploadedInWatchdog(worker_id);
+                file.uploaded = file_uploaded_when_chunk_complete;
                 
                 if (last) { // File done
                     transfer.reportProgress(file, function() {


### PR DESCRIPTION
Setting file.uploaded to the end of the chunk before the actual putChunk() was complete could cause a bad upload if there was a forced stall (turn wifi off during upload). This is a non terasender path mitigation.

If file.uploaded is set before the putChunk() is complete then that value is stored into local storage by transfer.reportProgress(), when it calls this.updateFileInRestartTracker(). This is fine as long as file.uploaded is actually the data that *is* uploaded and not what would be uploaded if the currently being processed chunk of data was completed.

So now I have moved setting file.uploaded to when the putChunk() is actually done. 
