### PR TITLE
terasender: automatically restart uploading a chunk if the previous upload failed 

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1058,7 +1058,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __type:__ int
 * __default:__ 20
 * __available:__ since version 2.0 beta5
-* __comment:__ The terasender worker will perform this many retries to upload a chunk before considering that it is a failure. Having 5 or more here will greatly improve the chances of an upload completing without user interaction.
+* __comment:__ The terasender worker will perform this many retries to upload a chunk before considering that it is a failure. Having 5 or more here will greatly improve the chances of an upload completing without user interaction. Note that this is the number of times a single chunk upload attempt can be retried, not the number of times a worker might try to retry in total. So if the value is 10 and the first chunk takes 8 attempts that is fine, the next chunk given to the worker can itself take up to the 10 times to upload. So a value of 20 would need *each* chunk to be retried up to 20 times and finally one chunk to push over that 20 in order to fail.
 
 
 <span style="background-color:orange">when set to "single" uploads don't work?  Bug?</span>
@@ -1681,6 +1681,21 @@ Changes are saved in config_overrides.json in the config directory.  The config.
 * __available:__
 * __1.x name:__
 * __comment:__
+
+---
+
+### testing_terasender_worker_uploadRequestChange_function_name
+
+* __description:__ the name of a javascript method to call to mutilate the state for testing.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ 
+* __available:__ since version 2.0 beta5
+* __comment:__ Putting these in the config allows testing to be optionally turned on for select cases without the risk
+     of leaving those testing code paths turned on during a git commit. Usable values for this are methods that start with
+     testing_uploadRequestChange_ in the terasender worker object. These will selectively enable failure states on the client
+     to test that it recovers from those if it is intended to do so.
+
 
 <span style="background-color:orange">
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -118,6 +118,7 @@ A note about colours;
 * [terasender_advanced](#terasenderadvanced)
 * [terasender_worker_count](#terasenderworkercount)
 * [terasender_start_mode](#terasenderstartmode)
+* [terasender_worker_max_chunk_retries](#terasender_worker_max_chunk_retries)
 * [stalling_detection](#stallingdetection)
 
 ## Download
@@ -1048,6 +1049,17 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ when looking for a file to put a worker on in multiple mode we look at file which has compbination of least worker and least progress.  Try to put available worker on file that is the slowest.  In multiple-mode we try to make all files progress at about the same speed.
+
+
+### terasender_worker_max_chunk_retries
+
+* __description:__ number of times a terasender worker retries to upload a chunk
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 20
+* __available:__ since version 2.0 beta5
+* __comment:__ The terasender worker will perform this many retries to upload a chunk before considering that it is a failure. Having 5 or more here will greatly improve the chances of an upload completing without user interaction.
+
 
 <span style="background-color:orange">when set to "single" uploads don't work?  Bug?</span>
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -106,6 +106,9 @@ $default = array(
     'terasender_worker_max_chunk_retries' => 20,    
     'stalling_detection' => false,
 
+    'testing_terasender_worker_uploadRequestChange_function_name' => '',
+
+
     // There are not so many options here, so they are listed
     // to make it easy for users to know what values might be interesting
     'storage_type' => 'filesystem',

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -103,6 +103,7 @@ $default = array(
     'terasender_disableable' => true,
     'terasender_start_mode' => 'multiple',
     'terasender_worker_count' => 6,
+    'terasender_worker_max_chunk_retries' => 20,    
     'stalling_detection' => false,
 
     // There are not so many options here, so they are listed

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -96,7 +96,8 @@ window.filesender.config = {
     terasender_start_mode: '<?php echo Config::get('terasender_start_mode') ?>',
     terasender_worker_file: 'lib/terasender/terasender_worker.js?v=<?php echo Utilities::runningInstanceUID() ?>',
     terasender_upload_endpoint: '<?php echo Config::get('site_url') ?>rest.php/file/{file_id}/chunk/{offset}',
-
+    terasender_worker_max_chunk_retries: <?php echo Config::get('terasender_worker_max_chunk_retries')  ?>,
+    
     stalling_detection: <?php echo value_to_TF(Config::get('stalling_detection')); ?>,
 
     max_legacy_file_size: <?php echo Config::get('max_legacy_file_size') ?>,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -122,13 +122,17 @@ window.filesender.config = {
     upload_force_transfer_resume_forget_if_encrypted: '<?php echo Config::get('upload_force_transfer_resume_forget_if_encrypted') ?>',
     upload_considered_too_slow_if_no_progress_for_seconds: '<?php echo Config::get('upload_considered_too_slow_if_no_progress_for_seconds') ?>',
 
+    testing_terasender_worker_uploadRequestChange_function_name: '<?php echo Config::get('testing_terasender_worker_uploadRequestChange_function_name') ?>',
+
+
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",
 		decrypting : "<?php echo Lang::tr('decrypting')->out(); ?>",
 		file_encryption_wrong_password : "<?php echo Lang::tr('file_encryption_wrong_password')->out(); ?>",
 		file_encryption_enter_password : "<?php echo Lang::tr('file_encryption_enter_password')->out(); ?>",
 		file_encryption_need_password : "<?php echo Lang::tr('file_encryption_need_password')->out(); ?>"
-	}
+	},
+
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>


### PR DESCRIPTION
This allows up to a configurable amount of attempts reuploading a chunk before it is considered to have failed. The default is 20 retries, which is per chunk, so should cover most network issues.

There is also a new testing option to simulate a chunk failure on the third chunk up to allowed_retries-1 in order to test the recovery path. This is off by default and enabled through the config so that Travis can possibly enable the code to ensure recovery is working on a CI run.

This should mitigate https://github.com/filesender/filesender/issues/305 and currently will turn the failure of the 20th time a chunk upload is attempted into a user viewable failure message. Better than silent failure as the user does not expect more data to have been transferred than will be shown.