### PR TITLE
defconfig: dirtree has to be enabled by default

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -183,6 +183,7 @@ $default = array(
     'cloud_s3_key'    => 'accessKey1',
     'cloud_s3_secret' => 'verySecretKey1',
 
+    'disable_directory_upload' => true,
 
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
This is more to reflect the relative newness of this feature and the feature can be reenabled by adding the following to the config.php
```
$config['disable_directory_upload'] = false;
```