### PR TITLE
ci: move the database migration generic code calls up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ before_install:
 - chmod -R a+x ./travis/scripts
 - phpenv config-add ./travis/myconfig.ini
 install:
-- "./travis/scripts/postgresql-setup.sh"
-- "./travis/scripts/simplesamlphp-setup.sh"
 - mkdir ./log
 - mkdir ./tmp
 - mkdir ./files
+- "./travis/scripts/postgresql-setup.sh"
+- "./travis/scripts/simplesamlphp-setup.sh"
+- php scripts/upgrade/database.php
+- php scripts/upgrade/database.php --db_database filesenderdataset
 before_script:
 - sudo apt-get update
 - sudo apt-get install apache2 libapache2-mod-fastcgi
@@ -47,8 +49,6 @@ before_script:
 - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
 - sudo service postgresql restart
 - sudo service apache2 restart
-- php scripts/upgrade/database.php
-- php scripts/upgrade/database.php --db_database filesenderdataset
 after_failure:
 - sudo cat /var/log/apache2/error.log
 - sudo cat /var/log/apache2/access.log

--- a/travis/scripts/mysql-setup.sh
+++ b/travis/scripts/mysql-setup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
+#
+# These are only the commands that are specific to mysql/mariadb which need
+# to be executed before the scripts/upgrade/database.php can be used
+#
 set -ev
 mysql -e "create database IF NOT EXISTS filesender;" -uroot;
 mysql -e "UPDATE user SET password=PASSWORD('password') WHERE user='travis';" -uroot;
-php ./scripts/upgrade/database.php;

--- a/travis/scripts/postgresql-setup.sh
+++ b/travis/scripts/postgresql-setup.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
+#
+# These are only the commands that are specific to postgresql which need
+# to be executed before the scripts/upgrade/database.php can be used
+#
 set -ev
 # psql -c 'SELECT version();' -U postgres
 psql -c 'create database filesender;'        -U postgres
 psql -U postgres -c "alter user postgres with password 'password';"
-php ./scripts/upgrade/database.php;
 
 psql -c 'create database filesenderdataset;' -U postgres
 bzcat ./scripts/dataset/dumps/filesender-2.0beta1.pg.bz2 | psql -d filesenderdataset 
+


### PR DESCRIPTION
It is confusing having two calls to these. I moved the database.php calls up from the mysql/postgresql scripts because the database php is designed to run on any database backend. I think it makes sense to limit the database specific scripts to database specific tasks.