### PR TITLE
generated password use better rng

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -965,6 +965,14 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __available:__ since version 2.0
 * __comment:__ 
 
+###encryption_generated_password_encoding
+* __description:__ which encoding to use to encode generated passwords. Since the random information obtained during password generation is completely random it is useful to encode that into text characters, for example in the range a,b,c etc. By doing this one single byte of random data (0 to 255 inclusive) will likely be encoded to more than one character of output. The base64 encoding turns x bytes of input into 1.33 times as long output. Because ascii85 uses more possible characters it turns each 4 bytes into 5 bytes. This means that for the same length of encoded string the ascii85 will have more entropy. Note that the ascii85 used is the Z85 from ZeroMQ to avoid the use of the quote character in output.
+* __mandatory:__ no 
+* __type:__ string
+* __default:__ base64
+* __available:__ since version 2.1
+* __comment:__ either base64 or ascii85 
+
 
 ###encryption_generated_password_length
 * __description:__ The exact number of characters used in a generated password for encryption. This must be equal or greater than encryption_min_password_length.

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -94,6 +94,7 @@ $default = array(
     'encryption_enabled' => true,
     'encryption_min_password_length' => 0,
     'encryption_generated_password_length' => 0,
+    'encryption_generated_password_encoding' => 'base64',
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -85,6 +85,8 @@ window.filesender.config = {
     encryption_enabled: '<?php echo Config::get('encryption_enabled') ?>',
     encryption_min_password_length: '<?php echo Config::get('encryption_min_password_length') ?>',
     encryption_generated_password_length: '<?php echo Config::get('encryption_generated_password_length') ?>',
+    encryption_generated_password_encoding: '<?php echo Config::get('encryption_generated_password_encoding') ?>',
+    
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',
     crypto_crypt_name: '<?php echo Config::get('crypto_crypt_name') ?>',

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -244,7 +244,7 @@ window.filesender.crypto_app = function () {
          * @param bindata Uint8Array containing data binary data to convert. 
          * @param encoding ascii85 or base64 as a string
          */
-        encodeToString: function( bindata, encoding = "base64" ) {
+        encodeToString: function( bindata, encoding ) {
             var $this = this;
             if( encoding == "ascii85" ) {
                 return $this.encodeToAscii85( bindata );

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -160,6 +160,96 @@ window.filesender.crypto_app = function () {
             // Add a field to the prompt
             var input = $('<input type="text" class="wide" />').appendTo(prompt);
             input.focus();
+        },
+        /**
+         * Get secure random bytes of a given length
+         * @param number of octets of random data to get
+         * @return Uint8Array containing your random data of random data
+         */
+        generateSecureRandomBytes: function( len ) {
+            var entropybuf = new Uint8Array(len);
+            window.crypto.getRandomValues(entropybuf);
+            return entropybuf;
+        },
+        /**
+         * This should encode to 'HelloWorld'
+         */
+//        encodeToAscii85( [0x86, 0x4F, 0xD2, 0x6F, 0xB5, 0x59, 0xF7, 0x5B] );
+        /**
+         * binary data to ascii 85 converter using the Z85 encoding. 
+         * This encodes 4 octets into 5 bytes of presentable text.
+         *
+         * Note that bindata will be padded with 0 bytes if it was not an even
+         * multiple of 4 bytes.
+         *
+         * https://en.wikipedia.org/wiki/Ascii85
+         * 
+         * @param bindata Uint8Array containing data binary data to convert. 
+         * @return a Z85 encoded string containing bindata 
+         * @see encodeToString() for a dispatch function
+         */
+        encodeToAscii85: function (bindata) {
+
+            var a85encTable = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.-:+=^!/*?&<>()[]{}@%$#";
+
+            // allow for zero padding to cater for
+            // data that is not an array length of mulitples of 4
+            var datalen = bindata.length;
+            var paddinglength = 0;
+            if( datalen % 4 ) {
+                paddinglength = 4 - ( datalen % 4 );
+                datalen += paddinglength;
+            }
+
+            // allocate with padding (zeros) and copy
+            // bindata over the start of the array
+            var data = new Uint8Array(datalen);
+            data.set( bindata );
+            
+            var size = data.length;
+            var encodedSize = data.length * 5/4;
+            var encoded = "";
+            var value = 0;
+            var i = 0;
+
+            // transform 4 bytes of data at a time to 5 bytes of output
+            for( i=0; i<size; i+= 4 ) {
+
+                value = data[i]*256*256*256 + data[i+1]*256*256 + data[i+2]*256 + data[i+3];
+                var divisor = 85 * 85 * 85 * 85;
+                while (divisor >= 1) {
+                    encoded += a85encTable[ Math.floor(value / divisor) % 85 ];
+
+                    // do not go fractional
+                    if( divisor==1 ) {
+                        break;
+                    }
+                    divisor /= 85;
+                }
+            }
+
+            return encoded;
+        },
+        /**
+         * convert array to base64 encoded string
+         * @param bindata Uint8Array containing data binary data to convert. 
+         * @return a base64 encoded string containing bindata 
+         * @see encodeToString() for a dispatch function
+         */
+        encodeToBase64: function (bindata) {
+            return btoa(String.fromCharCode.apply(null, bindata)); 
+        },
+        /**
+         * encode the bindata using the named encoding or base64 by default.
+         * @param bindata Uint8Array containing data binary data to convert. 
+         * @param encoding ascii85 or base64 as a string
+         */
+        encodeToString: function( bindata, encoding = "base64" ) {
+            var $this = this;
+            if( encoding == "ascii85" ) {
+                return $this.encodeToAscii85( bindata );
+            }
+            return $this.encodeToBase64( bindata );
         }
     };
 };

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1015,13 +1015,14 @@ $(function() {
         return false;
     });
     filesender.ui.nodes.encryption.generate.on('click', function() {
-        var genp = function() { return Math.random().toString(36).substr(2, 14); }
-        var pass = genp();
-        for( var i=0; i < filesender.config.encryption_generated_password_length; i++ ) {
-            pass = pass + genp();
-        }
-        pass = pass.substr(0,filesender.config.encryption_generated_password_length);
-        filesender.ui.nodes.encryption.password.val(pass);
+        var encoding = filesender.config.encryption_generated_password_encoding;
+        var desiredPassLen = filesender.config.encryption_generated_password_length;
+        var crypto = window.filesender.crypto_app();
+
+        var entropybuf = crypto.generateSecureRandomBytes( desiredPassLen );
+        password = crypto.encodeToString( entropybuf, encoding );
+        password = password.substr(0,desiredPassLen);
+        filesender.ui.nodes.encryption.password.val(password);
         filesender.ui.nodes.encryption.show_hide.prop('checked',true);
         filesender.ui.nodes.encryption.show_hide.trigger('change');
         filesender.ui.files.checkEncryptionPassword(filesender.ui.nodes.encryption.password );


### PR DESCRIPTION
Update for https://github.com/filesender/filesender/issues/334

This retains the old password length setting. There is a min length even for generated passwords because the password box is editable. If the user trims the generated password they might make it too small. On the other hand, the user might like most of a generated password but want to edit it a little bit so leaving it editable can be handy for that use case.

This includes a new setting allowing the encoding to be set for the generated password. ascii85 will give more entropy per byte of text password than base64. With ascii85 encoding a 20 byte password will have 16 bytes of entropy in it. On the other hand a base64 encoded password of length 20 will have 15 bytes of entropy. The encoding used shouldn't matter because it is a one way method used to generate the text password that is shown to the user. The base64 or ascii85 password is the used password to encrypt with and so no base64 or ascii85 decoding of that text ever needs to happen as it is the password already.

Relative to https://github.com/filesender/filesender/pull/336/files this PR creates some functions in crypto app and keeps the original configuration settings, adding a new one for optional setting of the to text encoding that is used.
