### PR TITLE
actually use UTF-8 for MySQL/MariaDB

### DIFF
--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -471,7 +471,7 @@ Create the filesender database:
 
 ```
 mysql -u root -p
-CREATE DATABASE `filesender` DEFAULT CHARACTER SET utf8;
+CREATE DATABASE `filesender` DEFAULT CHARACTER SET utf8mb4;
 GRANT USAGE ON *.* TO 'filesender'@'localhost' IDENTIFIED BY '<your password>';
 GRANT CREATE, ALTER, SELECT, INSERT, INDEX, UPDATE, DELETE ON `filesender`.* TO 'filesender'@'localhost';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
See: https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434