### PR TITLE
ux: sort error file entries to the top

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -37,7 +37,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 <div class="box">
     <form id="upload_form" class="<?php echo $formClasses; ?>" enctype="multipart/form-data" accept-charset="utf-8" method="post" autocomplete="off" data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>">
         <div class="box">
-            <div class="files"></div>
+            <div class="files" id="fileslist"></div>
             
             <div class="file_selector">
                 <label for="files" class="mandatory">{tr:select_file} :</label>

--- a/www/js/dragdrop-dirtree.js
+++ b/www/js/dragdrop-dirtree.js
@@ -66,6 +66,12 @@ filesender.dragdrop = {
                 filesender.dragdrop.recurseTree(tree);
             }
         }
+
+        // calling this directly doesn't seem to sort on Firefox/Linux 2018
+        window.setTimeout(
+            function() { filesender.ui.files.sortErrorLinesToTop(); },
+            1000 );
+        
         return true;
     },
 };

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -33,6 +33,26 @@
 // Manage files
 filesender.ui.files = {
     invalidFiles: [],
+
+    // Sort error cases to the top
+    sortErrorLinesToTop: function() {
+        var $selector = $("#fileslist");
+        var $element = $selector.children(".file");
+        
+        $element.sort(function(a, b) {
+            var ainv = a.className.includes('invalid');
+            var binv = b.className.includes('invalid');
+            // no difference for files in same group
+            if( (ainv && binv) || (!ainv && !binv )) {
+                return 0;
+            }
+            if( ainv ) return -1;
+            if( binv ) return  1;
+            return 0;
+        });
+        
+        $element.detach().appendTo($selector);
+    },
     
     // File selection (browse / drop) handler
     addList: function(files, source_node) {
@@ -43,6 +63,7 @@ filesender.ui.files = {
                 node = latest_node;
             }
         }
+        this.sortErrorLinesToTop();
         return node;
     },
     


### PR DESCRIPTION
This is to help with issue https://github.com/filesender/filesender/issues/368 after files are added to the list, entries with error conditions are moved to the top for easy viewing by the user and less confusion.
