### PR TITLE
allow for mandatory config settings

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -155,7 +155,22 @@ class Config {
             
             self::merge(self::$parameters, $config);
         }
+
+        // ensure mandatory config settings file exists
+        $mandatory_config_file = FILESENDER_BASE.'/includes/ConfigMandatorySettings.php';
+        if (!file_exists($mandatory_config_file)) {
+            throw new ConfigBadParameterException('Mandatory config settings file is missing. '
+                                                + 'Please recheck your filesender php code is all installed. '
+                                                + 'Looking for ' . $mandatory_config_file );
+        }
         
+        // load mandatory config settings
+        $config = array();
+        include_once($mandatory_config_file);
+        self::merge(self::$parameters, $config);
+        
+
+
         // Load config overrides if any
         $overrides_cfg = self::get('config_overrides');
         if ($overrides_cfg) {

--- a/includes/ConfigMandatorySettings.php
+++ b/includes/ConfigMandatorySettings.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+$config['config_mandatory_settings_file_loaded'] = true;
+
+


### PR DESCRIPTION
Instead of removing config settings and placing them in magic constants or using some other mechanism a new provision for mandatory settings is being introduced. From there some settings will be documented as private and there is an explicit location that a system admin can look to see what the chosen value for these mandatory settings is for the installation.
