### PR TITLE
db: initial support for views

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -100,6 +100,18 @@ class AuditLog extends DBObject {
         
     );
 
+    public static function getViewMap() {
+
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+        
+    }
+    
     /**
      * Set selectors
      */

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -59,6 +59,16 @@ class ClientLog extends DBObject {
         )
     );
 
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
+    
     protected static $secondaryIndexMap = array(
         'user_id' => array( 
             'user_id' => array()

--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -63,6 +63,8 @@ class DBObject {
      */
     protected static $dataMap = array();
 
+    protected static $viewMap = array();
+    
     /**
      * Defines secondary indexes for this table
      *
@@ -85,6 +87,10 @@ class DBObject {
         return static::$dataMap;
     }
 
+    public static function getViewMap() {
+        return static::$viewMap;
+    }
+    
     /**
      * Secondary Index map getter
      * 

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -108,7 +108,23 @@ class Guest extends DBObject {
             'null' => true
         )
     );
-    
+
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_age($dbtype,'expires')
+                        . DBView::columnDefinition_age($dbtype,'last_activity','last_activity_days_ago')
+                        . DBView::columnDefinition_age($dbtype,'last_reminder','last_reminder_days_ago')
+                        . ' , expires < now() as expired '
+                        . " , status = 'available' as is_available "
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+        
+    }
+
     /**
      * Set selectors
      */

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -85,6 +85,17 @@ class StatLog extends DBObject {
         )
     );
 
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_is_encrypted()
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
+    
     /**
      * Properties
      */

--- a/classes/data/TrackingEvent.class.php
+++ b/classes/data/TrackingEvent.class.php
@@ -72,6 +72,17 @@ class TrackingEvent extends DBObject
         )
     );
 
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_age($dbtype,'reported')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
+    
     protected static $secondaryIndexMap = array(
         'type_id' => array( 
             'target_type' => array(),

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -115,6 +115,19 @@ class Transfer extends DBObject {
         
     );
 
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_age($dbtype,'expires')
+                        . DBView::columnDefinition_age($dbtype,'made_available')
+                        . DBView::columnDefinition_is_encrypted('options','is_encrypted')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
+
     protected static $secondaryIndexMap = array(
         'user_id' => array( 
             'user_id' => array()

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -73,6 +73,18 @@ class TranslatableEmail extends DBObject {
             'type' => 'datetime'
         ),
     );
+
+    public static function getViewMap() {
+
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+
+    }
     
     /**
      * Properties

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -98,6 +98,22 @@ class User extends DBObject {
             'null' => true
         ),
     );
+
+
+    public static function getViewMap() {
+        $a = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_is_encrypted('transfer_preferences','prefers_enceyption')
+                        . DBView::columnDefinition_age($dbtype,'last_activity','last_activity_days_ago')
+                        . DBView::columnDefinition_age($dbtype,'aup_last_ticked_date','aup_last_ticked_days_ago')
+                        . ' , id as email_address '
+                        . ' , id is not null as is_active '
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
     
     /**
      * Properties

--- a/classes/utils/DBView.class.php
+++ b/classes/utils/DBView.class.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if(!defined('FILESENDER_BASE')) die('Missing environment');
+
+/**
+ * Base class for database stored objects
+ */
+class DBView {
+
+    public static function columnDefinition_age( $dbtype,
+                                                 $basecolname,
+                                                 $viewcolname = '' )
+    {
+        if( !strlen($viewcolname)) {
+            $viewcolname = $basecolname . "_days_ago";
+        }
+        if( $dbtype == 'pgsql' ) {
+            return ' , extract(day from now() - ' . $basecolname . ' ) as ' . $viewcolname . ' ';
+        }
+        if( $dbtype == 'mysql' ) {
+            return ' , DATEDIFF(now(),' . $basecolname . ') as ' . $viewcolname . ' ';
+        }
+    }
+    public static function columnDefinition_is_encrypted( $basecolname = 'additional_attributes',
+                                                          $viewcolname = 'is_encrypted' )
+    {
+        return "  , " . $basecolname . " LIKE '%encryption\":true%' as " . $viewcolname . " ";
+    }
+};

--- a/classes/utils/Database.class.php
+++ b/classes/utils/Database.class.php
@@ -141,8 +141,8 @@ class Database {
     /**
      * Create a table
      * 
-     * @param string $table the table name
-     * @param array $definition dataMap entry
+     * @param string $table     the table name
+     * @param array $definition the datamap to define the table
      * 
      */
     public static function createTable($table, $definition) {
@@ -151,6 +151,20 @@ class Database {
         return call_user_func($class.'::createTable', $table, $definition);
     }
     
+    /**
+     * Create a table
+     * 
+     * @param string $table    the table name
+     * @param string $viewname the table name
+     * @param array $definitionsql the SQL query to back the view
+     * 
+     */
+    public static function createView($table, $viewname, $definitionsql) {
+        $class = self::getDelegationClass();
+        
+        return call_user_func($class.'::createView', $table, $viewname, $definitionsql);
+    }
+
     /**
      * Get selected database delegation class
      * 

--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -71,6 +71,12 @@ class DatabaseMysql {
 
         DBI::exec($query);
     }
+
+    public static function createView($table, $viewname, $definitionsql) {
+        DBI::exec('DROP VIEW IF EXISTS '.$viewname);
+        $query = 'CREATE OR REPLACE VIEW '.$viewname.' as '.$definitionsql;
+        DBI::exec($query);
+    }
     
     /**
      * Table columns getter.

--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -76,6 +76,12 @@ class DatabasePgsql {
             }
         }
     }
+
+    public static function createView($table, $viewname, $definitionsql) {
+        DBI::exec('DROP VIEW IF EXISTS '.$viewname);
+        $query = 'CREATE OR REPLACE VIEW '.$viewname.' as '.$definitionsql;
+        DBI::exec($query);
+    }
     
     /**
      * Table columns getter.

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -80,6 +80,7 @@ try {
         echo 'Checking class '.$class."\n";
         
         $datamap = call_user_func($class.'::getDataMap');
+        $viewmap = call_user_func($class.'::getViewMap');
         $secindexmap = call_user_func($class.'::getSecondaryIndexMap');
         $table = call_user_func($class.'::getDBTable');
         
@@ -146,7 +147,18 @@ try {
                 Database::createTableSecondaryIndex( $table, $index, $definition );
             }
         } 
+        echo 'Done for secondary indexes for table '.$table."\n";
 
+        echo 'Updating views for table '.$table."\n";
+        foreach($viewmap as $viewname => $maker) {
+            foreach($maker as $dbtype => $def) {
+                if( $dbtype == Config::get('db_type')) {
+                    echo "Updating views $dbtype $def \n";
+                    Database::createView($table,$viewname,$def);
+                }
+            }
+        }
+        echo 'Done updating views for table '.$table."\n";
         
     }
     


### PR DESCRIPTION
These views are designed to have some support for retiring data
that has gone past a given number of days of age. Hopefully in the
future they can be expanded and other views added to help make queries
simpler by offloading things like date handling which is different in
pgsql and mysql into the view definitions. Capturing database
differences in a single view definition is likely to give much better
maintenance.

As dropping and creating views doesn't do any actual data changes
other than updating view definitions the entire view is dropped and
recreated each time the upgrade/database.php script is executed.

Refinements to the views and removal of complexity from some of the
SQL will follow, for example, the query in www/lib/graph/uploadGraph.php