### PR TITLE
privacy: sunsets on how long data is held

### DIFF
--- a/classes/constants/GUIPages.class.php
+++ b/classes/constants/GUIPages.class.php
@@ -49,5 +49,6 @@ class GUIPages extends Enum {
     const EXCEPTION       = 'exception';
     const MAINTENANCE     = 'maintenance';
     const ABOUT           = 'about';
+    const PRIVACY         = 'privacy';
     const HELP            = 'help';
 }

--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -106,6 +106,7 @@ class AuditLog extends DBObject {
         foreach(array('mysql','pgsql') as $dbtype) {
             $a[$dbtype] = 'select *'
                         . DBView::columnDefinition_age($dbtype,'created')
+                        . DBView::columnDefinition_as_number($dbtype,'target_id')
                         . '  from ' . self::getDBTable();
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a );
@@ -377,4 +378,30 @@ class AuditLog extends DBObject {
         foreach(self::fromTransfer($transfer) as $log)
             $log->delete();
     }
+
+    public static function cleanup() {
+        
+        // delete auditlogs entries for guests who have
+        // already been removed from the system
+        DBI::exec(
+            ""
+           ."delete from ".self::getDBTable()." where id in ("
+           ."   select al.id from ".self::getViewName()." al"
+           ."   left outer join ".Guest::getDBTable()." g"
+           ."      on g.id = target_id_as_number "
+           ."   where target_type = 'Guest' and g.id is null"
+           ." )"
+        );
+        
+        // if there is a sunset lifetime for the auditlog 
+        // then cleanup records that are too old.
+        $lifetime = Config::get('auditlog_lifetime');
+        if( !is_null($lifetime) && $lifetime > 0 ) {
+            // delete auditlogs entries that are too old
+            $statement = DBI::prepare("delete from ".self::getDBTable()." where created < :cutoff ");
+            $statement->execute(array(':cutoff' => date('Y-m-d H:i:s', time() - ($lifetime*24*3600))));
+        }
+        
+    }
+    
 }

--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -608,4 +608,8 @@ class DBObject {
     public function __toString() {
         return static::getClassName().'#'.($this->id ? $this->id : 'unsaved');
     }
+
+    public function getViewName() {
+        return strtolower(self::getDBTable()) . 'view';
+    }
 }

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -346,6 +346,17 @@ class Guest extends DBObject {
         $today = (24 * 3600) * floor(time() / (24 * 3600));
         return $this->expires < $today;
     }
+
+    /**
+     * Tells wether the guest has expired before a given number of days 
+     * from now
+     * 
+     * @return bool
+     */
+    public function isExpiredDaysAgo( $days ) {
+        $d = (24 * 3600) * floor(time() / (24 * 3600) - ($days * (24*3600)));
+        return $this->expires < $d;
+    }
     
     /**
      * Check if user owns current gueest

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -329,4 +329,6 @@ class StatLog extends DBObject {
         $s = DBI::prepare('DELETE FROM '.self::getDBTable().' WHERE created < DATE_SUB(NOW(), INTERVAL :days DAY)');
         $s->execute(array(':days' => (int)$lt));
     }
+
+    
 }

--- a/classes/data/TrackingEvent.class.php
+++ b/classes/data/TrackingEvent.class.php
@@ -281,4 +281,16 @@ class TrackingEvent extends DBObject
     public function __set($property, $value) {
         throw new PropertyAccessException($this, $property);
     }
+
+    /**
+     * Clean old entries
+     */
+    public static function clean() {
+        $days = Config::get('trackingevents_lifetime');
+        
+        /** @var PDOStatement $statement */
+        $statement = DBI::prepare('DELETE FROM '.self::getDBTable().' WHERE created < :date');
+        $statement->execute(array(':date' => date('Y-m-d', time() - $days * 86400)));
+    }
+    
 }

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -359,4 +359,17 @@ class TranslatableEmail extends DBObject {
     public function __set($property, $value) {
         throw new PropertyAccessException($this, $property);
     }
+
+
+    /**
+     * Clean old entries
+     */
+    public static function clean() {
+        $days = Config::get('translatable_emails_lifetime');
+        
+        /** @var PDOStatement $statement */
+        $statement = DBI::prepare('DELETE FROM '.self::getDBTable().' WHERE created < :date');
+        $statement->execute(array(':date' => date('Y-m-d', time() - $days * 86400)));
+    }
+    
 }

--- a/classes/utils/DBView.class.php
+++ b/classes/utils/DBView.class.php
@@ -57,4 +57,19 @@ class DBView {
     {
         return "  , " . $basecolname . " LIKE '%encryption\":true%' as " . $viewcolname . " ";
     }
+    public static function columnDefinition_as_number( $dbtype,
+                                                       $basecolname,
+                                                       $viewcolname = '' )
+    {
+        if( !strlen($viewcolname)) {
+            $viewcolname = $basecolname . "_as_number";
+        }
+        if( $dbtype == 'pgsql' ) {
+            return ', cast( '. $basecolname . ' as bigint) as ' . $viewcolname;
+        }
+        if( $dbtype == 'mysql' ) {
+            return ', cast( '. $basecolname . ' as integer) as ' . $viewcolname;
+        }
+        
+    }    
 };

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -284,10 +284,10 @@ class GUI {
             if(Auth::isAuthenticated(false)) {
                 if(Auth::isGuest()) {
                     self::$allowed_pages = array('upload',
-                                                 GUIPages::HELP, GUIPages::ABOUT );
+                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY );
                 } else {
                     self::$allowed_pages = array('home', 'upload', 'transfers', 'guests', 'download',
-                                                 GUIPages::HELP, GUIPages::ABOUT );
+                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY );
                     
                     // ... and admin to even more !
                     if(Auth::isAdmin()) self::$allowed_pages[] = 'admin';

--- a/classes/utils/Mail.class.php
+++ b/classes/utils/Mail.class.php
@@ -520,6 +520,7 @@ class Mail {
         $source = $this->build();
 
         if( self::$TESTING_MODE_SO_DO_NOT_SEND_EMAIL ) {
+            // Logger::warn('testing mode so not really sending mail');
             return true;
         }        
         Logger::warn('Sending mail');

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -193,6 +193,10 @@ $default = array(
     'automatic_resume_number_of_retries' =>  10,
     'automatic_resume_delay_to_resume'   => 360,
 
+    'guests_expired_lifetime' => 0,
+    'translatable_emails_lifetime' => 30,
+    'trackingevents_lifetime' => 90,
+    
     'testsuite_run_locally' => false,
 
     'transfer_options' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -446,3 +446,13 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['empty_file'] = 'Empty file';
+
+$lang['privacy_page'] = 'Privacy';
+$lang['privacy_page_days_old_table_text'] = 'Number of days information is retained';
+$lang['value'] = 'Value';
+$lang['description'] = 'Description';
+$lang['privacy_page_max_transfer_days_valid'] = 'Maximum number of days until a transfer expires';
+$lang['privacy_page_clientlogs_lifetime'] = 'If a transfer fails you might be offered the ability to report the issue directly through this web interface. That report will be removed from the server database after this many days have passed.';
+$lang['privacy_page_translatable_emails_lifetime'] = 'Number of days emails sent to a user will be retained';
+$lang['privacy_page_guests_expired_lifetime'] = 'Once a guest has expired they are removed after this many days';
+$lang['privacy_page_auditlog_lifetime'] = 'Days that a log of what actions have happened is retained.';

--- a/language/en_AU/privacy_text.html.php
+++ b/language/en_AU/privacy_text.html.php
@@ -1,0 +1,23 @@
+<h1>Welcome to {cfg:site_name}</h1>
+<p>
+    In order for this service to operate it must retain some
+    information about files, who can access them, and what has
+    happened. Files will be automatically removed from the system when
+    they expire and other retained information will be removed from
+    the system and database after some amount of time has passed. This
+    page allows you to see how long various pieces of information are
+    retained by this installation.
+</p>
+<p>
+    Note that when a transfer is deleted, all the related files are
+    also deleted along with the copies of any emails that have been sent out
+    which relate to the transfer.
+</p>
+<?php
+if( ShredFile::shouldUseShredFile()) {
+    echo "<p>This site is configured to shred uploaded files when they are deleted. ";
+    echo "Shredding a file involves writing data into the same location on the disk";
+    echo " many times in order to truely remove the user data from the system. ";
+    echo "This provides additional privacy for users of this service.</p>";
+}
+?>

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -35,6 +35,11 @@ require_once(dirname(__FILE__).'/../../includes/init.php');
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');
 
+$testingMode = (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
+if( $testingMode ) {
+    Mail::TESTING_SET_DO_NOT_SEND_EMAIL();
+}
+
 // Log some daily statistics first
 $storage_usage = Storage::getUsage();
 if(!is_null($storage_usage)) {
@@ -65,11 +70,18 @@ foreach(Transfer::allFailed() as $transfer) {
 }
 
 // Close expired guests
+$days = Config::get('guests_expired_lifetime');
 foreach(Guest::allExpired() as $guest) {
-    if($guest->status == GuestStatuses::CLOSED) continue;
     if($guest->getOption(GuestOptions::DOES_NOT_EXPIRE)) continue;
-    Logger::info($guest.' expired, closing it');
-    $guest->close(false);
+
+    if( $days != -1 && $guest->isExpiredDaysAgo($days)) {
+        Logger::info($guest.' expired and before guests_expired_lifetime so deleting it');
+        $guest->delete();
+    } else {
+        if($guest->status == GuestStatuses::CLOSED) continue;
+        Logger::info($guest.' expired, closing it');
+        $guest->close(false);
+    }
 }
 
 // Delete expired audit logs and related data
@@ -142,3 +154,16 @@ User::removeInactive();
 
 // Clean old client logs
 ClientLog::clean();
+
+// Clean old translated emails
+TranslatableEmail::clean();
+
+// Clean old tracking events 
+TrackingEvent::clean();
+
+// Clean old tracking events 
+StatLog::clean();
+
+// Clean old auditlog events
+AuditLog::cleanup();
+

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -46,6 +46,7 @@ $pagemenuitem = function($page) {
 
             $pagemenuitem('help');
             $pagemenuitem('about');
+            $pagemenuitem('privacy');
 
             if (Auth::isAuthenticated() && Auth::isSP()) {
                 $url = AuthSP::logoffURL();

--- a/templates/privacy_page.php
+++ b/templates/privacy_page.php
@@ -1,0 +1,39 @@
+<?php
+
+function config_VisString( $k, $specialv, $specialret ) {
+    $v = Config::get($k);
+    if($v == $specialv) {
+        return $specialret;
+    }
+    return $v;
+}
+?>
+<div class="box">
+   
+    <div id="dialog-privacy" title="Privacy">
+        {tr:privacy_text}
+        <h2>{tr:privacy_page_days_old_table_text}</h2>
+        <table columns="2">
+            <tr><th><?php echo Lang::tr('value')?></th>
+                <th><?php echo Lang::tr('Description')?></th>
+            </tr>
+            <tr><td><?php echo Config::get('max_transfer_days_valid') ?></td>
+                <td><?php echo Lang::tr('privacy_page_max_transfer_days_valid')?></td>
+            </tr>
+            <tr><td><?php echo Config::get('clientlogs_lifetime') ?></td>
+                <td><?php echo Lang::tr('privacy_page_clientlogs_lifetime')?> </td>
+            </tr>
+            <tr><td><?php echo Config::get('translatable_emails_lifetime') ?></td>
+                <td><?php echo Lang::tr('privacy_page_translatable_emails_lifetime')?> </td>
+            </tr>
+            <tr><td><?php echo config_VisString('guests_expired_lifetime',-1,Lang::tr('never')) ?></td>
+                <td><?php echo Lang::tr('privacy_page_guests_expired_lifetime')?> </td>
+            </tr>
+            <tr><td><?php echo Config::get('auditlog_lifetime') ?></td>
+                <td><?php echo Lang::tr('privacy_page_auditlog_lifetime')?> </td>
+            </tr>
+
+        </table>
+    </div>
+    
+</div>


### PR DESCRIPTION
Some row types in auditlog were not reclaimed, for example, user
created entries. Now also old auditlog entries for guests who have
been deleted are also deleted rather than left orphaned.

A new privacy tab is added to the web interface allowing users to
see how long some of the information is retained by the system.