### PR TITLE
db: Move from scattered user_id strings to userid numeric ids

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -51,6 +51,7 @@ class Autoloader {
         'GUIPages' => 'constants/',
         'LogLevels' => 'constants/',
         'ReportFormats' => 'constants/',
+        'DatabaseSchemaVersions' => 'constants/',
         
         'Storage' => 'storage/',
         'Storage*' => 'storage/',
@@ -70,6 +71,8 @@ class Autoloader {
         'User' => 'data/',
         'TrackingEvent' => 'data/',
         'TranslatableEmail' => 'data/',
+        'Metadata' => 'data/',
+        'Authentication' => 'data/',
         '*Log' => 'data/',
 
         'DBLayer' => 'utils/',

--- a/classes/constants/DatabaseSchemaVersions.class.php
+++ b/classes/constants/DatabaseSchemaVersions.class.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * These are the schema versions used by filesender releases. This is mainly
+ * only needed if custom code is required for a migration, for example, changing
+ * a primary key on a table or migrating data with custom SQL statements.
+ */
+class DatabaseSchemaVersions extends Enum {
+    const VERSION_MIN = 0;
+    const VERSION_21  = 0;
+
+    // the last version should also be the same as _CURRENT
+    const VERSION_22       = 22;
+    const VERSION_CURRENT  = 22;
+    
+    
+}

--- a/classes/data/Authentication.class.php
+++ b/classes/data/Authentication.class.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if(!defined('FILESENDER_BASE')) die('Missing environment');
+
+/**
+ * Represents an user in database
+ */
+class Authentication extends DBObject {
+    
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        'id' => array(
+            'type' => 'uint',
+            'size' => 'big',
+            'primary' => true,
+            'autoinc' => true,
+        ),
+        'saml_user_identification_uid' => array(
+            'type' => 'string',
+            'size' => 255,
+        ),
+        'saml_user_identification_uid_hash' => array(
+            'type' => 'string',
+            'size' => 200,
+            'null' => true
+        ),
+        'created' => array(
+            'type' => 'datetime',
+            'null' => true
+        ),
+        'last_activity' => array(
+            'type' => 'datetime',
+            'null' => true
+        ),
+        
+    );
+    protected static $secondaryIndexMap = array(
+        'saml_user_identification_uid' => array( 
+            'saml_user_identification_uid' => array(),
+            'UNIQUE' => array()
+        ),
+        'saml_user_identification_uid_hash' => array( 
+            'saml_user_identification_uid_hash' => array()
+        )
+    );
+
+
+    
+    /**
+     * Properties
+     */
+    protected $id = null;
+    protected $saml_user_identification_uid = null;
+    protected $saml_user_identification_uid_hash = 0;
+    protected $created = 0;
+    protected $last_activity = 0;
+    
+    
+    /**
+     * Constructor
+     * 
+     * @param integer $id identifier of record to load from database (null if loading not wanted)
+     * @param array $data data to create the record from (if already fetched from database)
+     * 
+     */
+    protected function __construct($id = null, $data = null) {
+        if(!is_null($id)) {
+            // Load from database if id given
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+        }
+        
+        if($data) {
+            $this->fillFromDBData($data);
+        }else{
+            $this->id = $id;
+            $this->created = time();
+        }
+    }
+
+    /**
+     * Create or read the record for this authenticated user
+     *
+     * @param Auth $auth the auth information or the current user will be used
+     *
+     * @return self
+     */
+    public static function ensureAuthIDFromAuthUID( $saml_auth_uid )
+    {
+        $saml_uid = $saml_auth_uid;
+        Logger::info('authentication::ensureID(1) saml_uid ' . $saml_uid );
+
+        $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE saml_user_identification_uid = :samluid');
+        $statement->execute(array(':samluid' => $saml_uid));
+        $data = $statement->fetch();
+        if($data)
+        {
+            $ret = static::createFactory(null,$data);
+            $ret->fillFromDBData($data);
+            Logger::info('authentication::ensureID(2) FOUND AND RETURNING ' . $data['id'] );
+            return $ret->id;
+        }
+        
+        $ret = static::createFactory();
+        $ret->saml_user_identification_uid = $saml_uid;
+        Logger::info('authentication::ensureID(2) NOT FOUND! ' . $saml_uid );
+        $ret->created = time();
+        $ret->last_activity = $ret->created;
+        Logger::info('authentication::ensureID(3) ' . $saml_uid );
+        $ret->updateHash();
+        Logger::info('authentication::ensureID(4) ' . $ret->id );
+        Logger::info('authentication::ensureID(5) ' . $ret->saml_user_identification_uid_hash );
+        $ret->save();
+        return $ret->id;
+    }
+
+    private function updateHash() {
+        $h = password_hash( $this->saml_user_identification_uid, PASSWORD_DEFAULT );
+        $this->saml_user_identification_uid_hash = $h;
+        return $h;
+    }
+    
+    /**
+     * Getter
+     * 
+     * @param string $property property to get
+     * 
+     * @throws PropertyAccessException
+     * 
+     * @return property value
+     */
+    public function __get($property) {
+        if(in_array($property, array(
+            'id', 'saml_user_identification_uid', 'saml_user_identification_uid_hash', 'created','last_activity'
+        ))) return $this->$property;
+
+        throw new PropertyAccessException($this, $property);
+    }
+    
+    /**
+     * Setter
+     * 
+     * @param string $property property to get
+     * @param mixed $value value to set property to
+     * 
+     * @throws BadVoucherException
+     * @throws BadStatusException
+     * @throws BadExpireException
+     * @throws PropertyAccessException
+     */
+    public function __set($property, $value) {
+        if($property == 'saml_user_identification_uid_hash') {
+            $this->saml_user_identification_uid_hash = $value;
+        } else {
+            throw new PropertyAccessException($this, $property);
+        }
+    }
+}

--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -47,9 +47,10 @@ class ClientLog extends DBObject {
             'primary' => true,
             'autoinc' => true
         ),
-        'user_id' => array(
-            'type' => 'string',
-            'size' => 190
+        'userid' => array(
+            'type' => 'uint',
+            'size' => 'big',
+            'null' => true
         ),
         'created' => array(
             'type' => 'datetime'
@@ -70,12 +71,12 @@ class ClientLog extends DBObject {
     }
     
     protected static $secondaryIndexMap = array(
-        'user_id' => array( 
-            'user_id' => array()
+        'userid' => array( 
+            'userid' => array()
         ),
-        'created_and_user_id' => array( 
+        'created_and_userid' => array( 
             'created' => array(),
-            'user_id' => array()
+            'userid' => array()
         )
     );
 
@@ -83,7 +84,7 @@ class ClientLog extends DBObject {
      * Properties
      */
     protected $id = null;
-    protected $user_id = null;
+    protected $userid = null;
     protected $created = 0;
     protected $message = null;
     
@@ -119,7 +120,7 @@ class ClientLog extends DBObject {
     public static function fromUser($user) {
         if($user instanceof User) $user = $user->id;
 
-        return self::all('user_id = :user_id ORDER BY id ASC', array(':user_id' => $user));
+        return self::all('userid = :userid ORDER BY id ASC', array(':userid' => $user));
     }
     
     /**
@@ -132,7 +133,7 @@ class ClientLog extends DBObject {
      */
     public static function create(User $user, $message) {
         $log = new self();
-        $log->user_id = $user->id;
+        $log->userid = $user->id;
         $log->message = $message;
         $log->created = time();
         
@@ -198,11 +199,11 @@ class ClientLog extends DBObject {
      */
     public function __get($property) {
         if(in_array($property, array(
-            'id', 'user_id', 'message', 'created'
+            'id', 'userid', 'message', 'created'
         ))) return $this->$property;
         
         if($property == 'user' || $property == 'owner')
-            return User::fromId($this->user_id);
+            return User::fromId($this->userid);
         
         throw new PropertyAccessException($this, $property);
     }

--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -102,6 +102,34 @@ class File extends DBObject
         )
     );
 
+
+    public static function getViewMap() {
+        $a = array();
+        $filesbywhodef = array();
+        foreach(array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype,'upload_start')
+                        . DBView::columnDefinition_age($dbtype,'upload_end')
+                                . '  from ' . self::getDBTable();
+            $filesbywhodef[$dbtype] = 'select t.id as transferid,name,upload_end,f.id as fileid,mime_type,size,'
+                                    . ' t.* from '.self::getDBTable().' f, '
+                                                       . '(select t.id as id,t.userid as userid,u.authid as authid,a.saml_user_identification_uid as user_id,'
+                                                       . 't.made_available,t.expires,t.created FROM '
+                                                       . call_user_func('Transfer::getDBTable').' t, '
+                                                       . call_user_func('User::getDBTable').' u, '
+                                                       . call_user_func('Authentication::getDBTable')
+                                                        .' a where t.userid = u.id and u.authid = a.id )'
+                                                      .  ' t '
+                                                       . ' where f.transfer_id = t.id order by t.id';
+        }
+        
+        
+        return array( strtolower(self::getDBTable()) . 'view' => $a, 'filesbywhoview' => $filesbywhodef
+        );
+    }
+    
+    
+
     /**
      * Properties
      */

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -47,9 +47,9 @@ class Guest extends DBObject {
             'primary' => true,
             'autoinc' => true
         ),
-        'user_id' => array(
-            'type' => 'string',
-            'size' => 255
+        'userid' => array(
+            'type' => 'uint',
+            'size' => 'big',
         ),
         'user_email' => array(
             'type' => 'string',
@@ -130,15 +130,15 @@ class Guest extends DBObject {
      */
     const AVAILABLE = "status = 'available' ORDER BY created DESC";
     const EXPIRED = "expires < :date ORDER BY expires ASC";
-    const FROM_USER = "user_id = :user_id AND expires > :date ORDER BY created DESC";
-    const FROM_USER_AVAILABLE = "user_id = :user_id AND expires > :date AND status = 'available' ORDER BY created DESC";
+    const FROM_USER = "userid = :userid AND expires > :date ORDER BY created DESC";
+    const FROM_USER_AVAILABLE = "userid = :userid AND expires > :date AND status = 'available' ORDER BY created DESC";
     
     /**
      * Properties
      */
     protected $id = null;
-    protected $user_id = null;
     protected $user_email = null;
+    protected $userid = null;
     protected $token = null;
     protected $email = null;
     protected $transfer_count = 0;
@@ -228,7 +228,7 @@ class Guest extends DBObject {
                 throw new BadEmailException($from);
         }
         
-        $guest->user_id = Auth::user()->id;
+        $guest->userid = Auth::user()->id;
         $guest->__set('user_email', $from);
         $guest->__set('email', $recipient); // Throws
         
@@ -301,7 +301,7 @@ class Guest extends DBObject {
     public static function fromUser($user) {
         if($user instanceof User) $user = $user->id;
         
-        return self::all(self::FROM_USER, array(':user_id' => $user, ':date' => date('Y-m-d')));
+        return self::all(self::FROM_USER, array(':userid' => $user, ':date' => date('Y-m-d')));
     }
 
     /**
@@ -314,7 +314,7 @@ class Guest extends DBObject {
     public static function fromUserAvailable($user) {
         if($user instanceof User) $user = $user->id;
         
-        return self::all(self::FROM_USER_AVAILABLE, array(':user_id' => $user, ':date' => date('Y-m-d')));
+        return self::all(self::FROM_USER_AVAILABLE, array(':userid' => $user, ':date' => date('Y-m-d')));
     }
     
     /**
@@ -544,12 +544,12 @@ class Guest extends DBObject {
      */
     public function __get($property) {
         if(in_array($property, array(
-            'id', 'user_id', 'user_email', 'token', 'email', 'transfer_count',
-            'subject', 'message', 'options', 'transfer_options', 'status', 'created', 'expires', 'last_activity'
+            'id', 'user_email', 'token', 'email', 'transfer_count',
+            'subject', 'message', 'options', 'transfer_options', 'status', 'created', 'expires', 'last_activity', 'userid'
         ))) return $this->$property;
         
         if($property == 'user' || $property == 'owner') {
-            $user = User::fromId($this->user_id);
+            $user = User::fromId($this->userid);
             $user->email_addresses = $this->user_email;
             return $user;
         }

--- a/classes/data/Metadata.class.php
+++ b/classes/data/Metadata.class.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if(!defined('FILESENDER_BASE')) die('Missing environment');
+
+/**
+ * Represents an user in database
+ */
+class Metadata extends DBObject {
+    
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        'id' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'primary' => true,
+            'autoinc' => true,
+        ),
+        'schemaversion' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+        ),
+        'created' => array(
+            'type' => 'datetime'
+        ),
+        'message' => array(
+            'type' => 'text'
+        )
+    );
+
+
+    
+    /**
+     * Properties
+     */
+    protected $id = null;
+    protected $schemaversion = null;
+    protected $created = 0;
+    protected $message = '';
+    
+    
+    /**
+     * Constructor
+     * 
+     * @param integer $id identifier of record to load from database (null if loading not wanted)
+     * @param array $data data to create the record from (if already fetched from database)
+     * 
+     */
+    protected function __construct($id = null, $data = null) {
+        if(!is_null($id)) {
+            // Load from database if id given
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+        }
+        
+        if($data) {
+            $this->fillFromDBData($data);
+        }else{
+            $this->id = $id;
+            $this->created = time();
+        }
+    }
+
+    public static function getLatestUsedSchemaVersion() {
+
+        try {
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' order by schemaversion desc limit 1');
+            $statement->execute(array());
+            $data = $statement->fetch();
+            if($data) {
+                return $data['schemaversion'];
+            }
+            return DatabaseSchemaVersions::VERSION_MIN;
+        } catch(Exception $e) {
+            echo $e;
+            return DatabaseSchemaVersions::VERSION_MIN;
+        }
+    }
+
+    public static function add( $message ) {
+        $ret = new self();
+
+        $ret->schemaversion = DatabaseSchemaVersions::VERSION_CURRENT;
+        $ret->created = time();
+        $ret->message = $message;
+
+        $ret->save();
+        return $ret;
+    }
+    
+    /**
+     * Create a new record
+     * 
+     * @param string $id record id, mandatory
+     * 
+     * @return record
+     */
+    public static function create($id) {
+        return self::fromId($id);
+    }
+    
+    
+    
+    /**
+     * Getter
+     * 
+     * @param string $property property to get
+     * 
+     * @throws PropertyAccessException
+     * 
+     * @return property value
+     */
+    public function __get($property) {
+        if(in_array($property, array(
+            'id', 'schemaversion', 'created', 'message'
+        ))) return $this->$property;
+        
+        throw new PropertyAccessException($this, $property);
+    }
+    
+    /**
+     * Setter
+     * 
+     * @param string $property property to get
+     * @param mixed $value value to set property to
+     * 
+     * @throws BadVoucherException
+     * @throws BadStatusException
+     * @throws BadExpireException
+     * @throws PropertyAccessException
+     */
+    public function __set($property, $value) {
+        if($property == 'message') {
+            $this->message = $value;
+        } else {
+            throw new PropertyAccessException($this, $property);
+        }
+    }
+}

--- a/classes/exceptions/BadExceptions.class.php
+++ b/classes/exceptions/BadExceptions.class.php
@@ -154,3 +154,21 @@ class BadURLException extends DetailedException {
         );
     }
 }
+
+
+/**
+ * Bad authid exception
+ */
+class BadAuthIDException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param string $url
+     */
+    public function __construct($aid) {
+        parent::__construct(
+            'bad_url_code', // Message to give to the user
+            array('aid' => $aid) // Details to log
+        );
+    }
+}

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -48,7 +48,7 @@ class RestEndpointGuest extends RestEndpoint {
     public static function cast(Guest $guest) {
         return array(
             'id' => $guest->id,
-            'user_id' => $guest->user_id,
+            'userid' => $guest->userid,
             'user_email' => $guest->user_email,
             'email' => $guest->email,
             'token' => $guest->token,

--- a/classes/utils/Database.class.php
+++ b/classes/utils/Database.class.php
@@ -164,6 +164,11 @@ class Database {
         
         return call_user_func($class.'::createView', $table, $viewname, $definitionsql);
     }
+    public static function dropView($table, $viewname) {
+        $class = self::getDelegationClass();
+        
+        return call_user_func($class.'::dropView', $table, $viewname);
+    }
 
     /**
      * Get selected database delegation class

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -94,7 +94,7 @@ $default = array(
     
     'encryption_enabled' => true,
     'encryption_min_password_length' => 0,
-    'encryption_generated_password_length' => 0,
+    'encryption_generated_password_length' => 30,
     'encryption_generated_password_encoding' => 'base64',
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -40,6 +40,8 @@ if( $testingMode ) {
     Mail::TESTING_SET_DO_NOT_SEND_EMAIL();
 }
 
+
+
 // Log some daily statistics first
 $storage_usage = Storage::getUsage();
 if(!is_null($storage_usage)) {


### PR DESCRIPTION
In filesender 2.1 and previous versions, the database schema scattered
user_id strings into multiple tables. The user_id strings originated
from the saml auth system as the user identifier. That information
was (potentially) a long string and by it's nature could obviously
contain information that identified a user on the system. The
UserPreferences table placed the user_id into the 'id' column which
was the primary key of the table. RI was not explicit in the schema
for these user_id and userpreferences.id columns.

The new schema moves to using big numbers (8 bytes for example) to
identify the user and stores the saml user_id into a new
authentications table. Because we still want to link a user to the
auth system the new userpreferences table has an authid which
references the auth.id auto increment primary key column. This design
allows more flexibility over how long the link to SAML user id is
maintained while allowing the transfers and other data to remain
valid. Using numeric keys and references also greatly helps speed and
can be efficiently undone with joins using views.

Transfers, Guests, and ClientLogs are also updated to now link to the
userpreferences.id column as the "userid" instead of directly storing
information taken from the saml session.

Part of this update moves to add RI to the system. ClientLogs.userid
is captured as explicitly referencing userpreferences.id and likewise
with Transfers and Guests.

I have tested the migration to the new database schmea with small
sized mariadb and postgresql databases and also migrated the
filesender-2.0beta1 dataset in postgresql and checked that things look
valid after migration in these three cases.

The userauthview view is useful to join with when you want to get the
user_id (saml user id string) field back from the userid numeric data.

For example, finding transfers and inspecting subsets with the following
```
select f.id as fid,transfer_id,f.name,t.userid,a.user_id from files f, transfers t, userauthview a
where t.id = transfer_id and a.id = t.userid
and ((transfer_id > 300 and transfer_id < 350) or (transfer_id > 20000 and transfer_id < 20100));
```
And looking at guests and the user_id saml auth string that invited
the guest with
```
select g.id,userid,g.email,g.subject,a.user_id from guests g, userauthview a where a.id = g.userid
and email like 'guest19%@localhost.localdomain';
```
In the old schema these are, respectively:
```
select f.id as fid,transfer_id,f.name,t.user_id from files f, transfers t
where t.id = transfer_id
and ((transfer_id > 300 and transfer_id < 350) or (transfer_id > 20000 and transfer_id < 20100));

select id,user_id,email,subject from guests
where email like 'guest19%@localhost.localdomain';
```