### PR TITLE
GDPR: Allow a user to leave the system

### DIFF
--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -253,4 +253,35 @@ class RestEndpointUser extends RestEndpoint {
         
         return true;
     }
+
+    /**
+     * Delete (closes) a user
+     * 
+     * Call examples :
+     *  /user/@me : close user which you are logged in as 
+     * 
+     * @param int $id guest id to close or @me. 
+     *                NOTE use of a number is not implemented yet.
+     * 
+     * @return mixed
+     * 
+     * @throws RestAuthenticationRequiredException
+     * @throws RestOwnershipRequiredException
+     */
+    public function delete($id = null) {
+
+        // Check parameters
+        if(!$id) throw new RestMissingParameterException('user_id');
+        if($id != '@me' && !is_numeric($id)) throw new RestBadParameterException('user_id');
+        
+        if(!Auth::isAuthenticated())
+            throw new RestAuthenticationRequiredException();
+        
+        $user = Auth::user();
+
+        
+        // Delete the user (not recoverable)
+        $user->delete();
+    }
+    
 }

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -456,3 +456,7 @@ $lang['privacy_page_clientlogs_lifetime'] = 'If a transfer fails you might be of
 $lang['privacy_page_translatable_emails_lifetime'] = 'Number of days emails sent to a user will be retained';
 $lang['privacy_page_guests_expired_lifetime'] = 'Once a guest has expired they are removed after this many days';
 $lang['privacy_page_auditlog_lifetime'] = 'Days that a log of what actions have happened is retained.';
+
+$lang['delete_my_account'] = 'Delete my account';
+$lang['confirm_delete_my_account'] = 'This will delete your files, guests, and other information from the FileSender installation. Continue?';
+$lang['user_deleted'] = 'You have been removed from the server. Have a nice day!';

--- a/language/en_AU/user_profile_delete_about_description_text.html.php
+++ b/language/en_AU/user_profile_delete_about_description_text.html.php
@@ -1,0 +1,20 @@
+    <p>
+        Your user name and password information is handled outside of
+        FileSender itself. You are free to delete your account on this
+        FileSender installation which will remove all of your files,
+        all the guests that you have invited, and any other debug
+        information you might have sent to the server (failed upload,
+        etc). Deleting your user account with FileSender removes all
+        of this information and FileSender will no longer retain this
+        information. Because FileSender does not have authority over
+        your user name and password, they will remain active until you
+        delete them from your institution.
+    </p>
+    <p>
+        Because the user name and password checking is handled outside
+        of FileSender you may be able to return to the system and
+        login again. If you do this, you will appear as a new user to
+        FileSender and will not be able to recover any of your old
+        files or information because that has been completely deleted
+        from FileSender when you deleted your FileSender account.
+    </p>

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -1,4 +1,16 @@
 <div class="box">
+
+    <h2>Actions</h2>
+
+        {tr:user_profile_delete_about_description_text}
+    
+    <div class="delete_my_account">
+        <a href="#">
+            <span class="fa fa-lg fa-times"></span>
+            {tr:delete_my_account}
+        </a>
+    </div>
+    
     <?php
     
     $readonly = function($info) {

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -119,6 +119,7 @@ window.filesender.config = {
     auditlog_lifetime: <?php $lt = Config::get('auditlog_lifetime'); echo is_null($lt) ? 'null' : $lt ?>,
     
     logon_url: '<?php echo AuthSP::logonURL() ?>',
+    logoff_url: '<?php echo AuthSP::logoffURL() ?>',
 
     upload_display_per_file_stats: '<?php echo Config::get('upload_display_per_file_stats') ?>',
     upload_force_transfer_resume_forget_if_encrypted: '<?php echo Config::get('upload_force_transfer_resume_forget_if_encrypted') ?>',

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -650,5 +650,24 @@ window.filesender.client = {
     
     getUserQuota: function(callback, onerror) {
         this.get('/user/@me/quota', callback, {ignore_authentication_required: true});
-    }
+    },
+
+    /**
+     * Delete a recipient
+     * 
+     * @param userid user to delete (can be '@me')
+     * @param callable callback
+     */
+    deleteUserAccount: function(user, callback, onerror) {
+        var id = user;
+        var opts = {};
+        
+        if(typeof user == 'object')
+            id = user.id;
+        
+        if(onerror) opts.error = onerror;
+        
+        return this.delete('/user/' + id, callback, opts);
+    },
+    
 };

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -653,7 +653,7 @@ window.filesender.client = {
     },
 
     /**
-     * Delete a recipient
+     * Delete a user account
      * 
      * @param userid user to delete (can be '@me')
      * @param callable callback

--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -33,6 +33,23 @@
 $(function() {
     var page = $('.user_page');
     if(!page.length) return;
+
+    $('.delete_my_account a').button().on('click', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        var redirect_url = filesender.config.logoff_url;
+        filesender.ui.confirm(lang.tr('confirm_delete_my_account'), function() {
+            filesender.client.deleteUserAccount('@me', function() {
+                filesender.ui.alert('success',
+                                    lang.tr('user_deleted'),
+                                    function() { filesender.ui.redirect(redirect_url) });
+
+            });
+        });
+        
+        return false;
+    });
     
     page.find(':input').on('change', function() {
         var i = $(this);


### PR DESCRIPTION
This update offers a button on the My profile page which
allows the user to leave the FileSender instance. Doing this will
delete the user files, invited guests, etc from the database and
the file contents from the filesystem.

This is a bit tricky as the user can still come back using the same
SAML auth in many cases. So the distunction between the data the
FileSender is storing (in database etc) and the login information is
described above the remove account button.