### PR TITLE
db: set user creation time in new db schema

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -223,6 +223,7 @@ class User extends DBObject {
             $data = array();
             $data['authid'] = $authid;
             $ret = static::createFactory(null,$data);
+            $ret->created = time();
             $ret->authid = $authid;
             $ret->insert();
             return $ret;


### PR DESCRIPTION
It seems the creation time was not set unless it was forced in the from authid method.