### PR TITLE
db: delay creating fks to the end of script

### DIFF
--- a/classes/exceptions/DBIExceptions.class.php
+++ b/classes/exceptions/DBIExceptions.class.php
@@ -105,3 +105,19 @@ class DBIBackendExplicitHandlerUnimplementedException extends DetailedException 
         );
     }
 }
+
+// duplicate object
+class DBIDuplicateException extends DetailedException {
+    /**
+     * Constructor
+     * 
+     * @param string $message error message
+     */
+    public function __construct($message, $details = null) {
+        parent::__construct(
+            'duplicate_object', // Message to give to the user
+            array($message, $details) // Details to log
+        );
+    }
+}
+

--- a/classes/utils/DBI.class.php
+++ b/classes/utils/DBI.class.php
@@ -221,6 +221,14 @@ class DBI {
                 
             return $r;
         } catch(Exception $e) {
+            $dbtype = Config::get('db_type');
+            $code = $e->getCode();
+            if( $dbtype == 'pgsql' ) {
+                // print_r($e,false);
+                if( $code == 42710 ) {
+                    throw new DBIDuplicateException($e->getMessage(), array('name' => $name, 'args' => $args));
+                }
+            }
             throw new DBIUsageException($e->getMessage(), array('name' => $name, 'args' => $args));
         }
     }


### PR DESCRIPTION
Sometimes things interact in 'interesting' ways. For example adding a not null constraint to a column might not work if there is an FOREIGN KEY (fk) in use. This might be the case during a database migration from an older database where a column is created in a slightly different way (allowing null) so that data can be migrated into the database updating that new column before it is set to not null.

Keeping the fks at the end of the script allows this shuffle on those columns to happen before an attempt is made to lock down the fk constraint. I think this particular migration worked for later mariaab (nulls -> no nulls) but certainly causes an issue with mariadb 10.0 as seen in https://github.com/filesender/filesender/issues/394#issuecomment-416116520

Giving the fks a name allows the use of if not exists for mariadb to stop the creation of duplicates on subsequent runs. That doesn't seem available on pgsql so I added the propagation of the duplicate object exception to allow the execution to continue when the fk already exists on pgsql. Thus, running the database.php script 10 times doesn't result in more than one copy of each fk in the database.
