### PR TITLE
ci: catch attempts to use the database we are not planning to use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,10 @@ before_script:
 - sudo cat /etc/apache2/sites-enabled/000-default.conf
 - sudo service apache2 restart
 #- curl -k https://localhost/filesender/info.php || sudo cat /var/log/apache2/*.log
+# stop the database we are not planning to use
+# to catch bad configurations that might use the wrong database by mistake
+- sh -c "if [ '$DB' = 'pgsql' ]; then sudo service mysql stop  ; fi "
+- sh -c "if [ '$DB' = 'mysql' ]; then sudo service postgresql stop  ; fi "
 after_failure:
 - sudo cat /var/log/apache2/error.log
 - sudo cat /var/log/apache2/access.log


### PR DESCRIPTION
This should be implicit anyway because we only setup the database we are planning to use. But also we save some RAM for the test run by stopping one of them.