### PR TITLE
Fix Undefined variable: menupage

### DIFF
--- a/templates/menu.php
+++ b/templates/menu.php
@@ -54,7 +54,7 @@ $pagemenuitem = function($page) {
                     echo '<li><a href="'.Utilities::sanitizeOutput($url).'" id="topmenu_logoff">'.Lang::tr('logoff').'</a></li>';
             }else if (!Auth::isGuest()){
                 if(Config::get('auth_sp_embedded')) {
-                    $menupage('logon');
+                    $pagemenuitem('logon');
                 }else{
                     echo '<li><a href="'.Utilities::sanitizeOutput(AuthSP::logonURL()).'" id="topmenu_logon">'.Lang::tr('logon').'</a></li>';
                 }


### PR DESCRIPTION
If `auth_sp_embedded` is set all rendered pages will be broken (`menupage` doesn't seem to exist anymore, whatever it did). This PR fixes an undef var leading to fatal error:

```
AH01071: Got error 'PHP message: PHP Notice:
  Undefined variable: menupage in /opt/filesender/templates/menu.php on line 56
PHP message: PHP Fatal error:  Uncaught Error: Function name must be a string in /opt/filesender/templates/menu.php:56
Stack trace:
  thrown in /opt/filesender/templates/menu.php on line 56
```
