### PR TITLE
Fix escaping quoting

### DIFF
--- a/scripts/language/common.php
+++ b/scripts/language/common.php
@@ -57,8 +57,7 @@ function loadLangDirectory( $code ) {
 
 function squote( $s ) {
 
-    $s = preg_replace( '![^\\\\]\\\\[^\\\\\']!' , '\\\\' , $s );
-    $s = preg_replace( "![^\\\\]\'!", "\\\'", $s );
+    $s = preg_replace("#(?<!\\\\\\\\)((?:\\\\\\\\{2})*)'#", "$1\\'", $s);
     return $s;
 }
 


### PR DESCRIPTION
After editing the french translation on poeditor, i tried to use the import-translation-for-language command, but the function squote is deleting the letter before escaping a single quote.

Example :
 - Export Poeditor : `M\'ajouter aux destinataires`
 - After the actual squote function : `\'ajouter aux destinataires` 

The commit fixes this issue.