### PR TITLE
Fix var classes overrided during migration

### DIFF
--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -418,8 +418,8 @@ try {
                                  call_user_func($class.'::getDataMap'));
                     // First, ensure the dbid column exists using the same mechanism that would
                     // normally create it
-                    $classes = array('User','Guest','ClientLog','Transfer');
-                    foreach($classes as $class) {
+                    $classesToMigrate = array('User','Guest','ClientLog','Transfer');
+                    foreach($classesToMigrate as $class) {
                         $datamap = call_user_func($class.'::getDataMap');
                         $table   = call_user_func($class.'::getDBTable');
                         if( $class == 'User' ) {


### PR DESCRIPTION
Var classes created line 88 is overrided during database migration version 22 line 420 , which prevents the creation of 3 views including auditlogsview which is essential for the cron.