### PR TITLE
Fix crash during cron on mariadb < 10.3.1

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -385,12 +385,11 @@ class AuditLog extends DBObject {
         // already been removed from the system
         DBI::exec(
             ""
-           ."delete from ".self::getDBTable()." where id in ("
-           ."   select al.id from ".self::getViewName()." al"
+           ."delete au from ".self::getDBTable()." as au"
+           ."   join ".self::getViewName()." al on al.id = au.id"
            ."   left outer join ".Guest::getDBTable()." g"
-           ."      on g.id = target_id_as_number "
-           ."   where target_type = 'Guest' and g.id is null"
-           ." )"
+           ."   on g.id = al.target_id_as_number "
+           ."   where al.target_type = 'Guest' and g.id is null"
         );
         
         // if there is a sunset lifetime for the auditlog 


### PR DESCRIPTION
Until mariaDb 10.3.1 (or on Mysql) you can't reference the table being deleted or updated. Because of that the function called by the cron AuditLog::cleanup is crashing. We can workaround that by using a join.