### PR TITLE
Consistently use Utilities::http_build_query

### DIFF
--- a/classes/auth/AuthSPFake.class.php
+++ b/classes/auth/AuthSPFake.class.php
@@ -166,7 +166,7 @@ class AuthSPFake
             if (!$landing_page) {
                 $landing_page = 'upload';
             }
-            $target = Config::get('site_url').'index.php?s='.$landing_page;
+            $target = Utilities::http_build_query(array('s' => $landing_page));
         }
         
         return Config::get('site_url').'#logon-'.urlencode($target);

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -201,7 +201,7 @@ class AuthSPSaml
             if (!$landing_page) {
                 $landing_page = 'upload';
             }
-            $target = Config::get('site_url').'index.php?s='.$landing_page;
+            $target = Utilities::http_build_query(array('s' => $landing_page));
         }
         
         $url = Utilities::http_build_query(array(

--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -187,7 +187,7 @@ class AuthSPShibboleth
             if (!$landing_page) {
                 $landing_page = 'upload';
             }
-            $target = Config::get('site_url').'index.php?s='.$landing_page;
+            $target = Utilities::http_build_query(array('s' => $landing_page));
         }
         
         return str_replace('{target}', urlencode($target), self::$config['login_url']);

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -628,7 +628,10 @@ class Guest extends DBObject
         
         
         if ($property == 'upload_link') {
-            return Config::get('site_url').'?s=upload&vid='.$this->token;
+            return Utilities::http_build_query(
+                array( 's'   => 'upload',
+                       'vid' => $this->token )
+            );
         }
         
         if ($property == 'transfers') {

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -804,7 +804,7 @@ class Transfer extends DBObject
         }
         
         if ($property == 'link') {
-            $tr_url = Config::get('site_url').'index.php?s=transfers#transfer_'.$this->id;
+            $tr_url = Utilities::http_build_query(array('s' => 'transfers#transfer_'.$this->id));
             $auth_url = AuthSP::logonURL($tr_url);
             
             if (!preg_match('`^https?://[^/]+`', $auth_url)) {


### PR DESCRIPTION
when building self-referential URLs with query strings, as used by other [Templates](https://github.com/filesender/filesender/blob/filesender-2.4/templates/download_page.php#L25-L34) or Classes, e.g. [Recipient.class.php](https://github.com/filesender/filesender/blob/filesender-2.4/classes/data/Recipient.class.php#L292) or [TranslatableEmail.class.php](https://github.com/filesender/filesender/blob/filesender-2.4/classes/data/TranslatableEmail.class.php#L382).

Actually I'm interested in replacing calls to `Utilities::http_build_query()` with another function that makes the generated URLs site-configurable beyond the `site_url` (e.g. in order to support "clean URLs"), but let's make the existing code more consistent first.