### PR TITLE
create some hidden options to set not available options in the client javascript.

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -618,6 +618,21 @@ class Transfer extends DBObject
             return true;
         });
     }
+
+
+    /**
+     * Get options that are not available for user setting
+     *
+     * @return array
+     */
+    public static function forcedOptions()
+    {
+        return array_filter(self::allOptions(), function ($o) {
+            if (!$o['available']) {
+                return true;
+            }
+        });
+    }
     
     /**
      * Get specific available option

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -108,6 +108,8 @@ A note about colours;
 * [encryption_generated_password_length](#encryption_generated_password_length)
 * [automatic_resume_number_of_retries](#automatic_resume_number_of_retries)
 * [automatic_resume_delay_to_resume](#automatic_resume_delay_to_resume)
+* [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)
+
 
 ## Graphs
 
@@ -1012,6 +1014,18 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __available:__ since version 2.1
 * __comment:__ 
 
+
+### transfer_options_not_available_to_export_to_client
+* __description:__ Options that can be exposed to the client when available=false. For example, if you want to force the get_a_link option it will be default=true and available=false (available to be changed, not unavailable as a used option). You might like to leave this option unset so that it can change as filesender evolves to allow mandatory options to be exposed to the browser.
+* __mandatory:__ no 
+* __recommend_leaving_at_default:__ true
+* __type:__ comma sep list of strings
+* __default:__ get_a_link
+* __available:__ since version 2.6
+* __comment:__ 
+
+
+* [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -201,6 +201,7 @@ $default = array(
     'aggregate_statlog_send_report_days' => 0,
     'aggregate_statlog_send_report_email_address' => '',
 
+    'transfer_options_not_available_to_export_to_client' => 'get_a_link',
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -190,13 +190,15 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                 </td>
                 <td class="box">
                     <?php
-                        $displayoption = function($name, $cfg, $disable = false) {
+                        $displayoption = function($name, $cfg, $disable = false, $forcedOption = false) {
                             $text = in_array($name, array(TransferOptions::REDIRECT_URL_ON_COMPLETE));
                             
                             $default = $cfg['default'];
-                            if(Auth::isSP() && !$text)
-                                $default = Auth::user()->defaultTransferOptionState($name);
-
+                            if( !$forcedOption ) {
+                                if(Auth::isSP() && !$text)
+                                    $default = Auth::user()->defaultTransferOptionState($name);
+                            }
+                            
                             $checked = $default ? 'checked="checked"' : '';
                             $disabled = $disable ? 'disabled="disabled"' : '';
                             $extraDivAttrs = '';
@@ -247,6 +249,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                         
                         <?php foreach(Transfer::availableOptions(false) as $name => $cfg) $displayoption($name, $cfg, Auth::isGuest()) ?>
                     </div>
+
                     
                     <?php if(count(Transfer::availableOptions(true)) || (Config::get('terasender_enabled') && Config::get('terasender_advanced'))) { ?>
                     <div class="fieldcontainer">
@@ -265,8 +268,20 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
                         </div>
                         <?php } ?>
                         <?php if (Config::get('terasender_enabled') && Config::get('terasender_disableable')) $displayoption('disable_terasender', array('default'=>false), false); ?>
+
+
                     </div>
                     <?php } /* End of advanced settings div. */ ?>
+
+                    <div class="hidden_options">
+                        <?php foreach(Transfer::forcedOptions() as $name => $cfg) {
+                            $allowed = explode(',', Config::get("transfer_options_not_available_to_export_to_client"));
+                            if( in_array($name,$allowed)) {
+                                $displayoption($name, $cfg, Auth::isGuest(),true);
+                            }
+                        } ?>
+                    </div>
+                    
                 </td>
             </tr>
         </table>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -779,6 +779,10 @@ table.list .date {
     display: none;
 }
 
+#upload_form .hidden_options {
+    display: none;
+}
+
 #upload_form .aup {
     padding: 1em;
 }

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -969,6 +969,10 @@ $(function() {
         var i = $(this);
         filesender.ui.nodes.options[i.attr('name')] = i;
     });
+    form.find('.basic_options [data-option] input, .hidden_options [data-option] input').each(function() {
+        var i = $(this);
+        filesender.ui.nodes.options[i.attr('name')] = i;
+    });
 
     
 
@@ -1109,6 +1113,10 @@ $(function() {
     // Bind advanced options display toggle
     form.find('.toggle_advanced_options').on('click', function() {
         $('.advanced_options').slideToggle();
+        return false;
+    });
+    form.find('.toggle_hidden_options').on('click', function() {
+        $('.hidden_options').slideToggle();
         return false;
     });
     


### PR DESCRIPTION
This is an alternate way to handle what https://github.com/filesender/filesender/pull/441 is doing.

The idea of this PR is to put the available=false options into hidden form elements. The code can then get those options just as it gets the shown options. The goal is to avoid having javascript code that does form.optionx is set or config.transfer_options_optionx is set because the later is communicated to the client in the hidden field which creates form.optionx. 

Yes, the client can then reverse this or mangle the javascript to show these hidden options but the server should recheck them to make sure nothing funny is going on. This issue is present no matter how these available=false options are sent. For get_a_link they must be sent to the browser as the javascript code has to operate differently when the option is set (available=false && default=true).
