### PR TITLE
hide the scrollbar in the auditlog dialog as the page itself allows scrolling

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -386,6 +386,7 @@ $(function() {
     var auditlogs = function(transfer_id, filter) {
         filesender.client.getTransferAuditlog(transfer_id, function(log) {
             var popup = filesender.ui.wideInfoPopup(lang.tr('auditlog'));
+            popup.css('overflow','hidden');
             
             if(!log || !log.length) {
                 $('<p />').text(lang.tr('no_auditlog')).appendTo(popup);

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -78,7 +78,7 @@ window.filesender.ui = {
             }
         }
         
-        var d = $('<div />').appendTo('body').attr({title: title});
+        var d = $("<div  />").appendTo('body').attr({title: title});
         
         var handle = function(lid) {
             return function() {
@@ -220,7 +220,7 @@ window.filesender.ui = {
         return this.popup(
             title,
             {close: onclose},
-            {width: $('#wrap').width(), minHeight: 'auto', onclose: onclose}
+            {width: $('#wrap').width(), minHeight: 'auto', onclose: onclose }
         ).addClass('wide_info');
     },
     


### PR DESCRIPTION
As reported in https://github.com/filesender/filesender/issues/446 it can be confusing to see this additional scrollbar that will not do anything.