### PR TITLE
enable the language selector even when the lang is null

### DIFF
--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -68,6 +68,11 @@
             if(array_key_exists($id, $page)) {
                 if(!$page[$id]) continue;
                 $value = Auth::user()->$id;
+                if( $id == 'lang' ) {
+                    if( !$value ) {
+                        $value = Lang::getBaseCode();
+                    }
+                }
                 if($value) $displayed[] = array(
                     'id' => $id,
                     'mode' => $page[$id],


### PR DESCRIPTION
This fixes the first bug in https://github.com/filesender/filesender/issues/477 where the language selector is not shown when the user does not already have an explicit selection in the database. Chicken and egg really as you are unlikely to get a selection set unless you can see this selector in the first place.
