### PR TITLE
my profile: turn on the language selector by default

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -157,7 +157,7 @@ $default = array(
 
 
     //'user_page' => false,
-    'user_page' => array('auth_secret'=>true,'id'=>true,'created'=>true),
+    'user_page' => array('lang'=>true,'auth_secret'=>true,'id'=>true,'created'=>true),
 
     // Logging
     'log_facilities' => array(


### PR DESCRIPTION
This fixes the second bug in https://github.com/filesender/filesender/issues/477 where the language selector is not shown by default.
