### PR TITLE
php72 but use the vendor phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: required
 language: php
 php:
-  - 7.0
+  - 7.2
 services:
   - postgresql
   - mariadb
@@ -77,7 +77,7 @@ after_failure:
 - sudo cat /var/log/apache2/access.log
 - find ./log -type f -exec cat {} +
 script:
-- phpunit --configuration ./unittests/config_tests_filesender.xml --testsuite=$TESTSUITE
+- ./vendor/bin/phpunit --configuration ./unittests/config_tests_filesender.xml --testsuite=$TESTSUITE
 notifications:
   email: false
 ##

--- a/travis/scripts/simplesamlphp-setup.sh
+++ b/travis/scripts/simplesamlphp-setup.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -ev
 
-wget https://simplesamlphp.org/res/downloads/simplesamlphp-1.14.2.tar.gz --no-check-certificate
+VER=1.17.1
+wget https://github.com/simplesamlphp/simplesamlphp/releases/download/v$VER/simplesamlphp-$VER.tar.gz --no-check-certificate
 
-SHA_DOWNLOAD_HASH=$(sha256sum simplesamlphp-1.14.2.tar.gz)
-SHA_CHECK_HASH='19b849065cdc8b96d74570b2ef91a08e72d0a4c0d9c30fa9526163ff6684c83e  simplesamlphp-1.14.2.tar.gz'
+SHA_DOWNLOAD_HASH=$(sha256sum simplesamlphp-$VER.tar.gz | cut -d ' ' -f 1)
+SHA_CHECK_HASH='d1a6e415828e8c257f9808a5b70d5f738f95af2633cdbae5cf8629571d33a803'
 
 
 if [ "$SHA_DOWNLOAD_HASH" != "$SHA_CHECK_HASH" ]; then
@@ -16,8 +17,8 @@ else
     echo "Hashes matched"
 fi
 
-tar xvzf simplesamlphp-1.14.2.tar.gz
-ln -s simplesamlphp-1.14.2/ simplesaml
+tar xvzf simplesamlphp-$VER.tar.gz
+ln -s simplesamlphp-$VER/ simplesaml
 # Copy standard configuration files to the right places:
 cd simplesaml
 cp -r config-templates/*.php config/


### PR DESCRIPTION
This moves the CI to php 7.2.

Because selenium doesn't like the very latest phpunit that is used by php 7.2 by default I have also moved to using the phpunit that is installed from composer in the vendor directory to ensure compatibility.

There was an issue with the very old simplesamlphp being used so I have updated that to the latest and made moves to allow the version to be updated again in the future.