### PR TITLE
docs: update to mention php 7.2 and where min versions are at in the docs.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,15 +24,15 @@ about the project [please visit our homepage](http://filesender.org).
 
 ### Which version should you choose
 
-Version 2.2 has been released in August 2018 and is the recommended
+Version 2.5 has been released in December 2018 and is the recommended
 choice.
 
 Following the 2.0 release there will be subsequent releases in the
 pattern 2.1, 2.2, 2.30 etc. Each of these releases will build on
-version 2.0 adding bugfixes and features. It is planend that you can
+version 2.0 adding bugfixes and features. It is planned that you can
 migrate from 2.0 upwards in the 2.x series.
 
-The previos production release is [1.6.1, released on December 30th
+The previous production release is [1.6.1, released on December 30th
 2015](https://downloads.filesender.org/filesender-1.6.1.tar.gz). 
 
 ### Documentation
@@ -84,6 +84,8 @@ A snapshot of features for the latest 1.6(.x) release is located at [Features](v
 ### Requirements
 
 Some storage, either MariaDB or PostgreSQL for database, either Apache
-or nginx for web server and SimpleSamlPhp.
+or nginx for web server, PHP and SimpleSamlPhp. Please see the
+[installation](v2.0/install/) page for minimum version requirements
+and advice.
 
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,7 +139,7 @@ https://github.com/filesender/filesender/issues/100
 
 ### Travis CI
 
-For FileSender 2.0 we should consider PHP 5.6 to be the minimum
+For FileSender 2.0 we should consider PHP 7.2 to be the minimum
 version. This will mean the CI can be moved to that version and use
 the more recent Ubuntu operating system to run the CI. This is
 starting to become a problem as travis CI has moved to more recent

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -31,8 +31,8 @@ you can report issues with and update the documentation.
 
 ### Dependencies
 
-* Apache (or nginx) and PHP from your distribution.
-* A PostgreSQL or MySQL database.
+* Apache (or nginx) and PHP (version 7.2 or 7.0).
+* A PostgreSQL or MariaDB database (10.0 or above, 10.2 or later recommended).
 * A big filesystem (or cloud backed).
 * [SimpleSamlPhp](https://simplesamlphp.org/download) 1.15.4 or newer.
 


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/466 which was mentioning if php 7.2 was ok.