### PR TITLE
lang ui: set the menu lang item when the user preference is changed

### DIFF
--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -64,6 +64,17 @@ $(function() {
             filesender.ui.notify('success', lang.tr('preferences_updated'));
         });
     });
+
+    var user_lang = page.find('select[name="user_lang"]');
+    if( user_lang.length ) {
+        user_lang.on('change', function() {
+            var i = $(this);
+            var menu_language_selector = $('#language_selector');
+            if( menu_language_selector ) {
+                menu_language_selector.val( i.val() );
+            }
+        });
+    }
     
     var rc = page.find('span[data-info="remote_config"]');
     if(rc.length) $('<button />').text(lang.tr('get_full_user_remote_config')).button().on('click', function() {


### PR DESCRIPTION
If both the menu language selector and user preferences language selector are shown change the menu language selector as the user changes the preferences selector. Less confusing when they navigate away from the page. 

Note that as the user preference is saved the lang= part of the menu session language selection is not needed for that selector to be accurate when navigating away from the preferences page. eg, change preference to 'de' and then click upload page and the page is rendered in German (as per the set and saved preference) and the menu item is also showing 'de' which is what you have.