### PR TITLE
server side recheck for aup_checked in case form is mangled by user

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -336,6 +336,17 @@ class RestEndpointTransfer extends RestEndpoint
         }
         
         $user = Auth::user();
+
+        // Did they try to be a wise guy with the aup checkbox?
+        if(Config::get('aup_enabled')) {
+            // Raw data
+            $data = $this->request->input;
+            if( $data->aup_checked != true ) {
+                Logger::warn("nefarious activity suspected: A user with id " . $user->id
+                           . " has sent a request without AUP data checked and is likely doing something bad.");
+                throw new RestBadParameterException('aup_checked');
+            }
+        }
         
         // Check parameters
         if ($id) {

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -285,6 +285,7 @@ window.filesender.client = {
             message: transfer.message,
             lang: transfer.lang,
             expires: transfer.expires,
+            aup_checked: transfer.aup_checked,
             options: transfer.options
         }, callback, opts);
     },

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -179,7 +179,8 @@ window.filesender.transfer = function() {
     this.guest_token = null;
     this.failed_transfer_restart = false;
     this.uploader = null;
-
+    this.aup_checked = false;
+    
     this.watchdog_processes = {};
     
     // Load and analyse stalling detection config

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -742,6 +742,13 @@ filesender.ui.startUpload = function() {
     
     this.transfer.onprogress = filesender.ui.files.progress;
 
+    // if the server wants the aup to be checked then we pass that information
+    // back to the server. If the user has disabled this part of the form then
+    // the server can throw an error.
+    this.transfer.aup_checked = false;
+    if(filesender.ui.nodes.aup.length)
+        this.transfer.aup_checked = filesender.ui.nodes.aup.is(':checked');
+    
     if( filesender.config.upload_display_per_file_stats ) {
         window.setInterval(function() {
             for (var i = 0; i < filesender.ui.transfer.files.length; i++) {


### PR DESCRIPTION
This is to strengthen up the AUP checked policy as noted in https://github.com/filesender/filesender/issues/440.

One can test this by disabling the block on the user_page that creates the form element. 
https://github.com/filesender/filesender/blob/c0f85be2130edabac0308d073937a09cd93fa359/templates/upload_page.php#L289

This is the sort of thing a nasty client/user might like to do in the browser before the javascript can see the form elements. They might think they are smart removing the form elements so they can send a file without needing to check the aup element. This code will detect that attempt because there is no checked aup sent to the server.
