### PR TITLE
mail: do not double encode the right side of the URL

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -824,6 +824,10 @@ class Transfer extends DBObject
         
         if ($property == 'link') {
             $tr_url = Utilities::http_build_query(array('s' => 'transfers#transfer_'.$this->id));
+            // Utilities::http_build_query() has URL encoded $tr_url 
+            // AuthSP::logonURL() will URL encode what is given to it,
+            // so we must decode the string first to avoid a double encoding.
+            $tr_url = urldecode( $tr_url );
             $auth_url = AuthSP::logonURL($tr_url);
             
             if (!preg_match('`^https?://[^/]+`', $auth_url)) {


### PR DESCRIPTION
This addresses the double encoded link highlighed in issue https://github.com/filesender/filesender/issues/465. Mail messages should now contain links that will direct you to the right place.