### PR TITLE
guests: can_only_send_to_me default=1 and available=0

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -534,6 +534,22 @@ class Guest extends DBObject
             return true;
         });
     }
+
+    /**
+     * Get options that are not available for user setting
+     *
+     * @return array
+     */
+    public static function forcedOptions()
+    {
+        return array_filter(self::allOptions(), function ($o) {
+            if (!$o['available']) {
+                return true;
+            }
+        });
+    }
+
+    
     
     /**
      * Get option value

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -201,6 +201,16 @@ class RestEndpointGuest extends RestEndpoint
                 }
             }
         }
+
+        // options that are available => false and default => value should be forced
+        // to being the default rather than anything the user has tried to send
+        // as they are not available for users to change.
+        foreach (Guest::forcedOptions() as $name => $dfn) {
+            if (in_array('default', $dfn)) {
+                $guest_options[$name] = $dfn['default'];
+            }
+        }
+        
         $guest->options = $guest_options;
         
         // Set to-be-created transfers options based on provided ones and defaults

--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -1,3 +1,21 @@
+<?php
+
+$new_guests_can_only_send_to_creator = false;
+
+
+Guest::forcedOptions();
+foreach (Guest::allOptions() as $name => $dfn) {
+    if( $name == 'can_only_send_to_me' ) {
+        if (in_array('available', $dfn) && !$dfn['available']) {
+            if (in_array('default', $dfn)) {
+                $new_guests_can_only_send_to_creator = $dfn['default'];
+            }
+        }
+    }
+}
+ 
+
+?>
 <div class="box">
     <div id="send_voucher" class="box">
         <div class="disclamer">
@@ -53,7 +71,13 @@
                     </div>
                     
                     <?php
-                        $displayoption = function($name, $cfg, $transfer = false) {
+                        $displayoption = function($name, $cfg, $transfer = false) use ($new_guests_can_only_send_to_creator)
+                        {
+                            // don't show the option for get_a_link if they can't use it.
+                            if($name == 'get_a_link' && $new_guests_can_only_send_to_creator ) {
+                                return;
+                            }
+                        
                             $default = $cfg['default'];
                             if(Auth::isSP()) {
                                 if($transfer) {


### PR DESCRIPTION
When you set can_only_send_to_me as a default=1 and available=0 so the user can not change it then you should disable get_a_link stuff (two are exclusive). With this update you can force can_only_send_to_me and the guest will have no option otherwise and the form is prepopulated as expected.

This relates to https://github.com/filesender/filesender/issues/460.