### PR TITLE
2019/march/expanded not available list

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1020,8 +1020,8 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __description:__ Options that can be exposed to the client when available=false. For example, if you want to force the get_a_link option it will be default=true and available=false (available to be changed, not unavailable as a used option). You might like to leave this option unset so that it can change as filesender evolves to allow mandatory options to be exposed to the browser.
 * __mandatory:__ no 
 * __recommend_leaving_at_default:__ true
-* __type:__ comma sep list of strings
-* __default:__ get_a_link
+* __type:__ array of strings
+* __default:__ see ConfigDefaults.php
 * __available:__ since version 2.6
 * __comment:__ 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -202,8 +202,15 @@ $default = array(
     'aggregate_statlog_send_report_days' => 0,
     'aggregate_statlog_send_report_email_address' => '',
 
-    'transfer_options_not_available_to_export_to_client' => 'get_a_link',
+    'transfer_options_not_available_to_export_to_client' => array('get_a_link'
+                                                                , 'email_me_copies','email_me_on_expire'
+                                                                , 'email_upload_complete', 'email_download_complete'
+                                                                , 'email_daily_statistics', 'email_report_on_closing'
+                                                                , 'enable_recipient_email_download_complete'
+                                                                , 'add_me_to_recipients', 'redirect_url_on_complete'
+    ),
 
+    
     // see crypto_app.js for constants in the range crypto_key_version_constants
     // Generally higher is newer + better.
     'encryption_key_version_new_files' => 1,

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -297,7 +297,7 @@ if(Auth::isGuest()) {
 
                     <div class="hidden_options">
                         <?php foreach(Transfer::forcedOptions() as $name => $cfg) {
-                            $allowed = explode(',', Config::get("transfer_options_not_available_to_export_to_client"));
+                            $allowed = (array)Config::get("transfer_options_not_available_to_export_to_client");
                             if( in_array($name,$allowed)) {
                                 $displayoption($name, $cfg, Auth::isGuest(),true);
                             }

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -161,32 +161,33 @@ if(Auth::isGuest()) {
                         <label class="invalid" id="message_can_not_contain_urls" style="display:none;">{tr:message_can_not_contain_urls}</label>                        
                         <textarea id="message" name="message" rows="4"></textarea>
                     </div>
-                        <?php if(Config::get('encryption_enabled')) { ?>
-                            <div class="fieldcontainer" id="encrypt_checkbox" data-related-to="encryption">
-                                <input id="encryption" name="encryption" type="checkbox">
-                                <label for="encryption" style="cursor: pointer;">{tr:file_encryption}</label>
-                            </div>
-                            <div class="fieldcontainer" id="encryption_password_container">  
-                                <label for="encryption_password" style="cursor: pointer;">{tr:file_encryption_password} : </label>
-                                <input id="encryption_password" name="encryption_password" type="password" autocomplete="new-password" readonly />
-                            </div>
-                            <div class="fieldcontainer" id="encryption_password_container_too_short_message">
-                                {tr:file_encryption_password_too_short}
-                            </div>
-                            <div class="fieldcontainer" id="encryption_password_container_generate">
-                                <a id='encryption_generate_password' href="#">{tr:file_encryption_generate_password}</a>
-                            </div>
-                            <div class="fieldcontainer" id="encryption_password_show_container">  
-                                <input id="encryption_show_password" name="encryption_show_password" type="checkbox">  
-                                <label for="encryption_show_password" style="cursor: pointer;">{tr:file_encryption_show_password}</label>
-                            </div>
-                            <div class="fieldcontainer" id="encryption_description_container">
-                                {tr:file_encryption_description}
-                            </div>
-                            <div class="fieldcontainer" id="encryption_description_disabled_container">
-                                {tr:file_encryption_description_disabled}
-                            </div>
-                        <?php } ?>
+                    <?php } ?> <!-- closing if($allow_recipients) -->
+                    
+                    <?php if(Config::get('encryption_enabled')) {  ?>
+                        <div class="fieldcontainer" id="encrypt_checkbox" data-related-to="encryption">
+                            <input id="encryption" name="encryption" type="checkbox">
+                            <label for="encryption" style="cursor: pointer;">{tr:file_encryption}</label>
+                        </div>
+                        <div class="fieldcontainer" id="encryption_password_container">  
+                            <label for="encryption_password" style="cursor: pointer;">{tr:file_encryption_password} : </label>
+                            <input id="encryption_password" name="encryption_password" type="password" autocomplete="new-password" readonly />
+                        </div>
+                        <div class="fieldcontainer" id="encryption_password_container_too_short_message">
+                            {tr:file_encryption_password_too_short}
+                        </div>
+                        <div class="fieldcontainer" id="encryption_password_container_generate">
+                            <a id='encryption_generate_password' href="#">{tr:file_encryption_generate_password}</a>
+                        </div>
+                        <div class="fieldcontainer" id="encryption_password_show_container">  
+                            <input id="encryption_show_password" name="encryption_show_password" type="checkbox">  
+                            <label for="encryption_show_password" style="cursor: pointer;">{tr:file_encryption_show_password}</label>
+                        </div>
+                        <div class="fieldcontainer" id="encryption_description_container">
+                            {tr:file_encryption_description}
+                        </div>
+                        <div class="fieldcontainer" id="encryption_description_disabled_container">
+                            {tr:file_encryption_description_disabled}
+                        </div>
                     <?php } ?>
                     
                     <div>


### PR DESCRIPTION
This expands the list of available=false options that can be passed client side. 

Also, for some reason the encryption option was nested in the php code in a way that made it unavailable when you force the get_a_link option.

The update relates to https://github.com/filesender/filesender/issues/439.