### PR TITLE
allow setting the date_format et al in config.php

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -516,6 +516,15 @@ class Lang
     {
         return self::translate($id);
     }
+
+    public static function trWithConfigOverride($id)
+    {
+        $v = Config::get('tr_' . $id);
+        if( strlen($v)) {
+            return new Translation($v);
+        }
+        return self::tr($id);
+    }
     
     /**
      * Translate email

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -180,14 +180,14 @@ class Utilities
         Lang::setlocale_fromUserLang( LC_TIME );
 
         $lid = $with_time ? 'datetime_format' : 'date_format';
-        $dateFormat = Lang::tr($lid);
+        $dateFormat = Lang::trWithConfigOverride($lid);
         if ($dateFormat == '{date_format}') {
             $dateFormat = '%d/%m/%Y';
         }
         if ($dateFormat == '{datetime_format}') {
             $dateFormat = '%d/%m/%Y %T';
         }
-        
+
         return utf8_encode(strftime($dateFormat, $timestamp));
     }
     

--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -68,7 +68,7 @@ foreach (Guest::allOptions() as $name => $dfn) {
                         <label for="expires" id="datepicker_label" class="mandatory">{tr:expiry_date}:</label>
                         
                         <input id="expires" name="expires" type="text" autocomplete="off"
-                               title="<?php echo Lang::tr('dp_date_format_hint')->r(array('max' => Config::get('max_guest_days_valid'))) ?>"
+                               title="<?php echo Lang::trWithConfigOverride('dp_date_format_hint')->r(array('max' => Config::get('max_guest_days_valid'))) ?>"
                                data-epoch="<?php echo Transfer::getDefaultExpire() ?>"
                         />
                     </div>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -252,7 +252,7 @@ if(Auth::isGuest()) {
                             <label for="expires" id="datepicker_label" class="mandatory">{tr:expiry_date}:</label>
                             
                             <input id="expires" name="expires" type="text" autocomplete="off"
-                                   title="<?php echo Lang::tr('dp_date_format_hint')->r(array('max' => Config::get('max_transfer_days_valid'))) ?>"
+                                   title="<?php echo Lang::trWithConfigOverride('dp_date_format_hint')->r(array('max' => Config::get('max_transfer_days_valid'))) ?>"
                                    data-epoch="<?php echo Transfer::getDefaultExpire() ?>"
                             />
                         </div>

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -145,6 +145,8 @@ window.filesender.config = {
     automatic_resume_delay_to_resume:   <?php echo Config::get('automatic_resume_delay_to_resume') ?>,
 
 
+    tr_dp_date_format:   "<?php echo Config::get('tr_dp_date_format') ?>",
+    tr_dp_date_format_hint:   "<?php echo Config::get('tr_dp_date_format_hint') ?>",
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -284,7 +284,7 @@ $(function() {
         dayNamesMin: lang.tr('dp_day_names_min').values(),
         
         weekHeader: lang.tr('dp_week_header').out(),
-        dateFormat: lang.tr('dp_date_format').out(),
+        dateFormat: lang.trWithConfigOverride('dp_date_format').out(),
         
         firstDay: parseInt(lang.tr('dp_first_day').out()),
         isRTL: lang.tr('dp_is_rtl').out().match(/true/),

--- a/www/js/lang.js
+++ b/www/js/lang.js
@@ -138,6 +138,15 @@ window.filesender.lang = {
     
     tr: function(id) {
         return this.translate(id);
+    },
+
+    trWithConfigOverride: function(id) {
+        s = filesender.config['tr_' + id];
+        if (/\S/.test(s)) {
+            // the config option has somthing in it
+            return new this.translatedString(s, true);
+        }
+        return this.tr(id);
     }
 };
 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1100,7 +1100,7 @@ $(function() {
         dayNamesMin: lang.tr('dp_day_names_min').values(),
         
         weekHeader: lang.tr('dp_week_header').out(),
-        dateFormat: lang.tr('dp_date_format').out(),
+        dateFormat: lang.trWithConfigOverride('dp_date_format').out(),
         
         firstDay: parseInt(lang.tr('dp_first_day').out()),
         isRTL: lang.tr('dp_is_rtl').out().match(/true/),


### PR DESCRIPTION
This makes the date_format, datetime_format and dp_date_format configurable by setting them with a tr_ prefx in config.php. For example, to add day of week to your instance:

```
$config['tr_date_format'] = '%A %d/%m/%Y';
$config['tr_datetime_format'] = '%A %d/%m/%Y %T';
$config['tr_dp_date_format'] = 'DD dd/mm/yy';
```

Overriding these settings in config.php was suggested in https://github.com/filesender/filesender/issues/299.