### PR TITLE
osx: always show zip64 warning on download page

### DIFF
--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -133,9 +133,8 @@ $(function() {
         return false;
     });
     
-    var needszip64extractor = parseInt($('[data-transfer-size]').attr('data-transfer-size')) > 2 * 1024 * 1024 * 1024;
     var macos = navigator.platform.match(/Mac/);
-    if( !needszip64extractor || !macos )
+    if( !macos )
         $('.mac_archive_message').hide();
 
     // only worry the user with this banner if any files are encrypted


### PR DESCRIPTION
This is a band aid until https://github.com/filesender/filesender/issues/325 is completed.