### PR TITLE
tar: calculate the content-length and set header

### DIFF
--- a/classes/utils/Archiver.class.php
+++ b/classes/utils/Archiver.class.php
@@ -90,6 +90,47 @@ class Archiver
     }
 
 
+    /**
+     * This is a bit sneaky, we create a temporary tarball to include
+     * all the byte offsets and padding but do not actually read/write
+     * the real storage contents, only record the metadata in the archive.
+     *
+     * Then we know the size will be metadata only archive size + number of bytes
+     * in the content for all the files.
+     */
+    public function getTarSize($filename,$opts) {
+
+        // work out the content length
+        $tfn = tempnam( Filesystem::getTempDirectory(), 'szf');
+        $outstream = fopen($tfn,'w');
+        $opt['send_http_headers'] = false;
+        $contentsz = 0;
+        $archive = new \Barracuda\ArchiveStream\TarArchive(null,$opts,$filename,$outstream);
+        
+        // collect info for each file
+        foreach ($this->files as $k => $data) {
+            $file = $data['data'];
+            $fileopts = array();
+            $transfer = $file->transfer;
+            if( !$archivedName ) {
+                $archivedName = $this->getArchivedFileName( $file );
+            }
+
+            $contentsz += $file->size;
+	    $archive->init_file_stream_transfer($archivedName, $file->size, $fileopts);
+	    $archive->complete_file_stream();        
+            
+        }
+
+        $archive->finish();        
+
+        fflush($tfn);
+        $ret = $contentsz + filesize($tfn);
+        fclose($tfn);
+        unlink($tfn);
+        
+        return $ret;
+    }
     
     /**
      * Creates an archive in the format set in the constructor 
@@ -117,11 +158,18 @@ class Archiver
                 $filename = null;
             }
 
-            $outstream = fopen('php://output','w');
             $opts = array();
             $opts['send_http_headers'] = $withHeaders;
-            $opts['content_type'] = 'application/tar';
-            $archive = new \Barracuda\ArchiveStream\TarArchive($filename . '.tar',$opts,$filename,$outstream);
+            $opts['content_type'] = 'application/x-tar';
+            
+            // work out the content length
+            $sz = $this->getTarSize($filename,$opts);
+            header("Content-Length: $sz");
+            $opt['send_http_headers'] = true;
+
+            // do the work for real now and stream things over to the client
+            $outstream = fopen('php://output','w');
+            $archive = new \Barracuda\ArchiveStream\TarArchive($filename . ".tar",$opts,$filename,$outstream);
 
             // send each file
             foreach ($this->files as $k => $data) {

--- a/classes/utils/Filesystem.class.php
+++ b/classes/utils/Filesystem.class.php
@@ -117,4 +117,9 @@ class Filesystem
             throw new StorageFilesystemCannotDeleteException($file_path, $file);
         }
     }
+
+    public static function getTempDirectory()
+    {
+        return Config::get('tmp_path');
+    }
 }

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -110,7 +110,9 @@ $default = array(
 
     'testing_terasender_worker_uploadRequestChange_function_name' => '',
 
+    'tmp_path' => FILESENDER_BASE.'/tmp/',
 
+    
     // There are not so many options here, so they are listed
     // to make it easy for users to know what values might be interesting
     'storage_type' => 'filesystem',


### PR DESCRIPTION
The content-length can be calculated using a shallow pass over the data, building an archive without needing to read/write the contents of the files from storage. Using the same API gives the advantages that the padding and other metadata included in the tar is going to be the same as what is generated using a non shallow (real) copy of the data when we stream the real archive to the user.

Note that if you have something like the following running for a tree that includes www/download.php then the size information will be lost in transit. 
```
<Directory "/opt/filesender">
<IfModule mod_deflate.c>
SetOutputFilter DEFLATE
</IfModule>
```

If you are going to on the fly compress like that then maybe use something like the below to override for just download.php. There are likely more elegant ways to disable it.

```
<Files "download.php">
  SetOutputFilter INCLUDES
</Files>
```