### PR TITLE
db: allow two user accounts for elevated priv in database.php

### DIFF
--- a/classes/utils/DBI.class.php
+++ b/classes/utils/DBI.class.php
@@ -149,14 +149,26 @@ class DBI
         if (is_null(self::$config)) {
             self::load();
         }
+
+        $username = self::$config['username'];
+        $password = self::$config['password'];
+
+        if( Logger::isUpgradeProcess()) {
+            if ($config['username_admin']) {
+                $username = self::$config['username_admin'];
+            }
+            if ($config['password_admin']) {
+                $password = self::$config['password_admin'];
+            }
+        }
         
         // Try to connect, cast any thrown exception
         try {
             // Connect
             self::$instance = new PDO(
                 self::$config['dsn'],
-                self::$config['username'],
-                self::$config['password'],
+                $username,
+                $password,
                 self::$config['driver_options']
             );
             

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -90,6 +90,14 @@ class Logger
                                 ProcessTypes::UPGRADE )
         );
     }
+
+    public static function isUpgradeProcess()
+    {
+        return in_array(
+            self::$process,
+                         array( ProcessTypes::UPGRADE )
+        );
+    }
     
     /**
      * Setup logging facilities

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -475,24 +475,39 @@ On Debian, run:
 
 	apt-get install -y mariadb-server php7.0-mysql 
 
-Create the filesender database:
+Create the filesender database. It is recommended to create two users for the database,
+one for normal web usage and another with higher abilities to allow the database setup
+and migration script to use.
 
 ```
 mysql -u root -p
 CREATE DATABASE `filesender` DEFAULT CHARACTER SET utf8mb4;
-GRANT USAGE ON *.* TO 'filesender'@'localhost' IDENTIFIED BY '<your password>';
-GRANT CREATE, CREATE VIEW, ALTER, SELECT, INSERT, INDEX, UPDATE, DELETE ON `filesender`.* TO 'filesender'@'localhost';
-GRANT DROP ON `filesender`.* TO 'filesender'@'localhost';
+
+GRANT USAGE ON *.* TO 'filesender'@'localhost'
+      IDENTIFIED BY '__<your password>__';
+GRANT CREATE, CREATE VIEW, ALTER, SELECT, INSERT, INDEX, UPDATE, DELETE
+      ON `filesender`.* TO 'filesender'@'localhost';
+
+GRANT USAGE ON *.* TO 'filesenderadmin'@'localhost'
+      IDENTIFIED BY '__<your admin password>__';
+GRANT CREATE, CREATE VIEW, ALTER, SELECT, INSERT, INDEX, UPDATE, DELETE, DROP, REFERENCES
+      ON `filesender`.* TO 'filesenderadmin'@'localhost';
+
 FLUSH PRIVILEGES;
 exit
 ```
 
-Note that the drop permissions are only needed by the database setup
-and upgrade script (scripts/upgrade/database.php). Unfortunately the
-permission to drop a view is not separate from the normal drop
-permission which also allows a table to be deleted. It is recommended
-to run to following during production to remove this ability to drop
-views (and tables) from the filesender database user.
+Note that the drop and references permissions are only needed by the
+database setup and upgrade script (scripts/upgrade/database.php).
+Unfortunately the permission to drop a view is not separate from the
+normal drop permission which also allows a table to be deleted. If you
+choose to use the same user to run the site and run the database.php
+migration script then it is recommended to run to following during
+production to remove this ability to drop views (and tables) from the
+filesender database user. Remember to allow drop again when you are
+upgrading your FileSender installation by running the upgrade script
+(scripts/upgrade/database.php).
+
 
 ```
 mysql -u root -p
@@ -500,13 +515,7 @@ REVOKE DROP ON `filesender`.* FROM 'filesender'@'localhost';
 FLUSH PRIVILEGES;
 ```
 
-Remember to allow drop again when you are upgrading your FileSender
-installation by running the upgrade script
-(scripts/upgrade/database.php).
 
-In the future two database users might be created so that the admin
-script can enjoy higher privledges to modify the database while the
-regular filesender user can not make these larger changes.
 
 # Step 7 - Configure PHP
 


### PR DESCRIPTION
The database.php script wants DROP and REFERENCES privileges to operate. The former can be used to do some fairly undesirable things and so should be limited in exposure. This PR allows the database.php script to connect using db_username_admin and db_password_admin. This way, the regular web site can operate without elevated privileges and the database.php script can connect with additional powers needed to perform it's work. 

The docs are updated to recommend this new two user setup which will also mean less admin allowing and dropping privs when you run the database.php script.

This relates to https://github.com/filesender/filesender/issues/453.