### PR TITLE
sql: update the admin stats SQL

### DIFF
--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -75,6 +75,16 @@ class StatLog extends DBObject
         ),
         'created' => array(
             'type' => 'datetime'
+        ),
+        'browser' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'null' => true
+        ),
+        'os' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'null' => true
         )
     );
 
@@ -95,7 +105,14 @@ class StatLog extends DBObject
             $a[$dbtype] = 'select *'
                         . DBView::columnDefinition_age($dbtype, 'created')
                         . DBView::columnDefinition_is_encrypted()
-                        . '  from ' . self::getDBTable();
+                        . DBView::columnDefinition_dbconstant( DBConstantBrowserType::getDBTable(),
+                                                               'browser',
+                                                               'browser_name' )
+                        . DBView::columnDefinition_dbconstant( DBConstantOperatingSystem::getDBTable(),
+                                                               'os',
+                                                               'os_name' )
+                        . '  from ' . self::getDBTable() . ' base';
+            
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a );
     }
@@ -172,6 +189,8 @@ class StatLog extends DBObject
         $log->event = $event;
         $log->created = time();
         $log->target_type = get_class($target);
+        $log->browser = DBConstantBrowserType::currentBrowserToEnum();
+        $log->os = DBConstantOperatingSystem::currentUserOperatingSystemEnum();
         
         // Add metadata depending on target
         switch ($log->target_type) {

--- a/classes/data/constants/DBConstantBrowserType.class.php
+++ b/classes/data/constants/DBConstantBrowserType.class.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ */
+class DBConstantBrowserType extends DBConstant
+{
+    public static function createObject()
+    {
+        return new self();
+    }
+
+    const T_UNKNOWN = 'Unknown';
+    const T_EDGE    = 'Edge';
+    const T_IE      = 'Internet Explorer';
+    const T_FIREFOX = 'Mozilla Firefox';
+    const T_VIVALDI = 'Vivaldi';
+    const T_OPERA   = 'Opera';
+    const T_CHROME  = 'Google Chrome';
+    const T_SAFARI  = 'Apple Safari';
+    const T_OUTLOOK = 'Outlook';
+    
+    protected function getEnum()
+    {
+        return array(
+            self::T_UNKNOWN  => 0,
+            self::T_EDGE     => 1,
+            self::T_IE       => 2,
+            self::T_FIREFOX  => 3,
+            self::T_VIVALDI  => 4,
+            self::T_OPERA    => 5,
+            self::T_CHROME   => 6,
+            self::T_SAFARI   => 7,
+            self::T_OUTLOOK  => 8,
+        );
+    }
+
+    /////////////////////////////
+    //
+    //
+
+    static function validateCGIParamOrDIE( $v )
+    {
+        if (!preg_match('`^[a-z_]{1,40}$`', $v)) {
+            exit(1);
+        }
+        self::lookup($v);
+        return $v;
+    }
+
+    static function currentBrowserToEnum()
+    {
+        $b = $_SERVER['HTTP_USER_AGENT'];
+        if( preg_match( '/Firefox/', $b )) {
+            $v = self::T_FIREFOX;
+        } elseif ( preg_match( '/edge/', $b )) {
+            $v = self::T_EDGE;
+        } elseif ( preg_match( '/MSIE/', $b )) {
+            $v = self::T_IE;
+        } elseif ( preg_match( '/Trident/', $b )) {
+            $v = self::T_IE;
+        } elseif ( preg_match( '/Vivaldi/', $b )) {
+            $v = self::T_VIVALDI;
+        } elseif ( preg_match( '/Opera/', $b )) {
+            $v = self::T_OPERA;
+        } elseif ( preg_match( '/OPR/', $b )) {
+            $v = self::T_OPERA;
+        } elseif ( preg_match( '/Chrome/', $b )) {
+            $v = self::T_CHROME;
+        } elseif ( preg_match( '/CriOS/', $b )) {
+            $v = self::T_CHROME;
+        } elseif ( preg_match( '/Safari/', $b )) {
+            $v = self::T_SAFARI;
+        } elseif ( preg_match( '/Outlook/', $b )) {
+            $v = self::T_OUTLOOK;
+        } else {
+            $v = self::T_UNKNOWN;
+        }
+        return self::lookup($v);
+    }
+    
+    
+}

--- a/classes/data/constants/DBConstantOperatingSystem.class.php
+++ b/classes/data/constants/DBConstantOperatingSystem.class.php
@@ -1,0 +1,150 @@
+<?php
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ */
+class DBConstantOperatingSystem extends DBConstant
+{
+    public static function createObject()
+    {
+        return new self();
+    }
+
+    
+    const T_UNKNOWN  = 'Unknown';
+    const T_IPAD     = 'iPad';
+    const T_IPOD     = 'iPod';
+    const T_IPHONE   = 'iPhone';
+    const T_MAC      = 'Mac';
+    const T_OSX      = 'OSX';
+    const T_ANDROID  = 'Android';
+    const T_LINUX    = 'Linux';
+    const T_NOKIA    = 'Nokia';
+    const T_WIN10    = 'Windows 10';
+    const T_WIN81    = 'Windows 8.1';
+    const T_WIN80    = 'Windows 8.0';
+    const T_WIN70    = 'Windows 7.0';
+    const T_WINOTHER = 'Windows (Other)';
+    const T_FREEBSD  = 'FreeBSD';
+    const T_OPENBSD  = 'OpenBSD';
+    const T_NETBSD   = 'NetBSD';
+    const T_SOLARIS  = 'Solaris';
+    const T_SUNOS    = 'SunOS';
+    const T_OS2      = 'OS2';
+    const T_BEOS     = 'BEOS';
+
+    protected function getEnum()
+    {
+        return array(
+            self::T_UNKNOWN  => 0,
+            self::T_IPAD     => 1,
+            self::T_IPOD     => 2,
+            self::T_IPHONE   => 3,
+            self::T_MAC      => 4,
+            self::T_OSX      => 5,
+            self::T_ANDROID  => 6,
+            self::T_LINUX    => 7,
+            self::T_NOKIA    => 8,
+            self::T_WIN10    => 9,
+            self::T_WIN81    => 10,
+            self::T_WIN80    => 11,
+            self::T_WIN70    => 12,
+            self::T_WINOTHER => 13,
+            self::T_FREEBSD  => 14,
+            self::T_OPENBSD  => 15,
+            self::T_NETBSD   => 16,
+            self::T_SOLARIS  => 17,
+            self::T_OS2      => 18,
+            self::T_BEOS     => 19,
+        );
+    }
+
+    /////////////////////////////
+    //
+    //
+
+    static function validateCGIParamOrDIE( $v )
+    {
+        if (!preg_match('`^[a-z_]{1,40}$`', $v)) {
+            exit(1);
+        }
+        self::lookup($v);
+        return $v;
+    }
+
+    static function currentUserOperatingSystemEnum()
+    {
+        $b = $_SERVER['HTTP_USER_AGENT'];
+        if( preg_match( '/iPad/', $b )) {
+            $v = self::T_IPAD;
+        } elseif ( preg_match( '/iPod/', $b )) {
+            $v = self::T_IPOD;
+        } elseif ( preg_match( '/iPhone/', $b )) {
+            $v = self::T_IPHONE;
+        } elseif ( preg_match( '/imac/', $b )) {
+            $v = self::T_MAC;
+        } elseif ( preg_match( '/Mac.*OS/', $b )) {
+            $v = self::T_OSX;
+        } elseif ( preg_match( '/android/', $b )) {
+            $v = self::T_ANDROID;
+        } elseif ( preg_match( '/linux/', $b )) {
+            $v = self::T_LINUX;
+        } elseif ( preg_match( '/Nokia/', $b )) {
+            $v = self::T_NOKIA;
+        } elseif ( preg_match( '/(Win|win)/', $b )) {
+            $v = self::T_WINOTHER;
+            if ( preg_match( '/NT 10.0)/', $b )) {
+                $v = self::T_WIN10;
+            } elseif ( preg_match( '/NT 6.3)/', $b )) {
+                $v = self::T_WIN81;
+            } elseif ( preg_match( '/NT 6.2)/', $b )) {
+                $v = self::T_WIN80;
+            } elseif ( preg_match( '/NT 6.1)/', $b )) {
+                $v = self::T_WIN70;
+            }
+        } elseif ( preg_match( '/Safari/', $b )) {
+            $v = self::T_SAFARI;
+        } elseif ( preg_match( '/Outlook/', $b )) {
+            $v = self::T_OUTLOOK;
+        } else {
+            $v = self::T_UNKNOWN;
+        }
+
+        return self::lookup($v);
+    }
+    
+    
+}

--- a/classes/data/constants/DBConstantOperatingSystem.class.php
+++ b/classes/data/constants/DBConstantOperatingSystem.class.php
@@ -135,10 +135,6 @@ class DBConstantOperatingSystem extends DBConstant
             } elseif ( preg_match( '/NT 6.1)/', $b )) {
                 $v = self::T_WIN70;
             }
-        } elseif ( preg_match( '/Safari/', $b )) {
-            $v = self::T_SAFARI;
-        } elseif ( preg_match( '/Outlook/', $b )) {
-            $v = self::T_OUTLOOK;
         } else {
             $v = self::T_UNKNOWN;
         }

--- a/classes/utils/DBView.class.php
+++ b/classes/utils/DBView.class.php
@@ -76,4 +76,14 @@ class DBView
             return ', cast( '. $basecolname . ' as unsigned) as ' . $viewcolname;
         }
     }
+
+    public static function columnDefinition_dbconstant( $dbconstantTableName,
+                                                        $baseTableColumn,
+                                                        $baseTableGeneratedColumn,
+                                                        $baseTableName = 'base'
+    ) {
+        return ', (select description from '.$dbconstantTableName
+              .' where '.$dbconstantTableName.'.id = '.$baseTableName.'.'.$baseTableColumn.' limit 1) as ' . $baseTableGeneratedColumn.' ';
+    }
+    
 };

--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -86,8 +86,8 @@ class DatabasePgsql
 
     public static function createView($table, $viewname, $definitionsql)
     {
-        DBI::exec('DROP VIEW IF EXISTS CASCADE'.$viewname);
-        $query = 'CREATE OR REPLACE VIEW '.$viewname.' as '.$definitionsql;
+        DBI::exec('DROP VIEW IF EXISTS '.$viewname.' CASCADE');
+        $query = 'CREATE VIEW '.$viewname.' as '.$definitionsql;
         DBI::exec($query);
     }
     public static function dropView($table, $viewname)

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -292,6 +292,16 @@ function ensureFK()
                     'aggregatestatistics.eventtype refers to dbconstanteventtypes.id',
 	            call_user_func('AggregateStatistic::getDBTable'), 'AggregateStatistic_eventtype', 'eventtype',
 	            call_user_func('DBConstantStatsEvent::getDBTable'), 'id' ));
+    array_push( $fks,
+                new DatabaseForeignKey(
+                    'statlogs.browser refers to dbconstantbrowsertype.id',
+	            call_user_func('StatLog::getDBTable'), 'statlogs_browsertype', 'browser',
+	            call_user_func('DBConstantBrowserType::getDBTable'), 'id' ));
+    array_push( $fks,
+                new DatabaseForeignKey(
+                    'statlogs.os refers to dbconstantoperatingsystem.id',
+	            call_user_func('StatLog::getDBTable'), 'statlogs_operatingsystem', 'os',
+	            call_user_func('DBConstantOperatingSystem::getDBTable'), 'id' ));
 
     
     foreach ( $fks as $fk ) {

--- a/templates/admin_statistics_section.php
+++ b/templates/admin_statistics_section.php
@@ -86,63 +86,49 @@ if(Config::get('show_storage_statistics_in_admin')) {
 
 <?php
 
+function os_name_to_html( $v )
+{
+    if( $v == 'iPad'   )  return '<i class="fa fa-apple"></i> iPad';
+    if( $v == 'iPod'   )  return '<i class="fa fa-apple"></i> iPod';
+    if( $v == 'iPhone' )  return '<i class="fa fa-apple"></i> iPhone';
+    if( $v == 'Mac' )     return '<i class="fa fa-apple"></i> Mac';
+    if( $v == 'OSX' )     return '<i class="fa fa-apple"></i> Mac OSX';
+    if( $v == 'Android' ) return '<i class="fa fa-android"></i> Android';
+    if( $v == 'Linux' )   return '<i class="fa fa-linux"></i> Linux';
+    if( $v == 'Windows 10' )      return '<i class="fa fa-windows"></i> Windows 10';
+    if( $v == 'Windows 8.1' )     return '<i class="fa fa-windows"></i> Windows 8.1';
+    if( $v == 'Windows 8.0' )     return '<i class="fa fa-windows"></i> Windows 8.0';
+    if( $v == 'Windows 7.0' )     return '<i class="fa fa-windows"></i> Windows 7.0';
+    if( $v == 'Windows (Other)' ) return '<i class="fa fa-windows"></i> Windows Other';
+    return $v;
+}
+
+function browser_name_to_html( $v )
+{
+    if( $v == 'Edge' )              return '<i class="fa fa-edge"></i> Edge';
+    if( $v == 'Internet Explorer' ) return '<i class="fa fa-internet-explorer"></i> Internet Explorer';
+    if( $v == 'Mozilla Firefox' )   return '<i class="fa fa-firefox"></i> Mozilla Firefox';
+    if( $v == 'Opera' )             return '<i class="fa fa-opera"></i> Opera';
+    if( $v == 'Google Chrome' )     return '<i class="fa fa-chrome"></i> Google Chrome';
+    if( $v == 'Apple Safari' )      return '<i class="fa fa-safari"></i> Apple Safari';
+    if( $v == 'Outlook'     )       return '<i class="fa "></i> Outlook';
+    return $v;
+}
+
+function is_encrypted_to_html( $v )
+{
+    if( $v == '1' )
+        return '<i class="fa fa-lock"></i>';
+    return '<i class="fa fa-unlock"></i>';
+}
+ 
+
 $createdTS = DBLayer::timeStampToEpoch('created');
 $createdDD = DBLayer::datediff('NOW()','MIN(created)');
 
 $sql=<<<EOF
 SELECT 
     MAX(additional_attributes) as "additional_attributes",
-    CASE
-        WHEN additional_attributes LIKE '%encryption":false%' THEN '<i class="fa fa-unlock"></i>'
-        WHEN additional_attributes LIKE '%encryption":true%' THEN '<i class="fa fa-lock"></i>'
-        ELSE 'Unknown'
-    END AS "encryption",
-    CASE
-        WHEN additional_attributes LIKE '%iPad%' THEN '<i class="fa fa-apple"></i> iPad'
-        WHEN additional_attributes LIKE '%iPod%' THEN '<i class="fa fa-apple"></i> iPod'
-        WHEN additional_attributes LIKE '%iPhone%' THEN '<i class="fa fa-apple"></i> iPhone'
-        WHEN additional_attributes LIKE '%imac%' THEN '<i class="fa fa-apple"></i> Mac'
-        WHEN additional_attributes LIKE '%Mac%OS%' THEN '<i class="fa fa-apple"></i> Mac OS X'
-        WHEN additional_attributes LIKE '%android%' THEN '<i class="fa fa-android"></i> Android'
-        WHEN additional_attributes LIKE '%Ubuntu%' THEN '<i class="fa fa-linux"></i> Ubuntu Linux'
-        WHEN additional_attributes LIKE '%linux%' THEN '<i class="fa fa-linux"></i> Linux'
-        WHEN additional_attributes LIKE '%Nokia%' THEN 'Nokia'
-        WHEN additional_attributes LIKE '%BlackBerry%' THEN 'BlackBerry'
-        WHEN additional_attributes LIKE '%win%' OR
-             additional_attributes LIKE '%Win%' THEN
-            CASE
-                WHEN additional_attributes LIKE '%NT 10.0%' THEN '<i class="fa fa-windows"></i> Windows 10'
-                WHEN additional_attributes LIKE '%NT 6.3%' THEN '<i class="fa fa-windows"></i> Windows 8.1'
-                WHEN additional_attributes LIKE '%NT 6.2%' THEN '<i class="fa fa-windows"></i> Windows 8'
-                WHEN additional_attributes LIKE '%NT 6.1%' THEN '<i class="fa fa-windows"></i> Windows 7'
-                WHEN additional_attributes LIKE '%NT 6.0%' THEN '<i class="fa fa-windows"></i> Windows Vista'
-                WHEN additional_attributes LIKE '%NT 5.1%' THEN '<i class="fa fa-windows"></i> Windows XP'
-                WHEN additional_attributes LIKE '%NT 5.0%' THEN '<i class="fa fa-windows"></i> Windows 2000'
-                ELSE '<i class="fa fa-windows"></i> Windows'
-            END      
-        WHEN additional_attributes LIKE '%FreeBSD%' THEN 'FreeBSD'
-        WHEN additional_attributes LIKE '%OpenBSD%' THEN 'OpenBSD'
-        WHEN additional_attributes LIKE '%NetBSD%' THEN 'NetBSD'
-        WHEN additional_attributes LIKE '%OpenSolaris%' THEN 'OpenSolaris'
-        WHEN additional_attributes LIKE '%SunOS%' THEN 'SunOS'
-        WHEN additional_attributes LIKE '%OS/2%' THEN 'OS/2'
-        WHEN additional_attributes LIKE '%BeOS%' THEN 'BeOS'
-        ELSE 'Unknown'
-    END AS "os",
-    CASE
-        WHEN additional_attributes LIKE '%edge%'THEN '<i class="fa fa-edge"></i> Edge'
-        WHEN additional_attributes LIKE '%MSIE%' OR
-             additional_attributes LIKE '%Trident%' THEN '<i class="fa fa-internet-explorer"></i> Internet Explorer'
-        WHEN additional_attributes LIKE '%Firefox%' THEN '<i class="fa fa-firefox"></i> Mozilla Firefox'
-        WHEN additional_attributes LIKE '%Vivaldi%' THEN '<i class="fa fa-vimeo-square"></i> Vivaldi' 
-        WHEN additional_attributes LIKE '%Opera%' OR
-             additional_attributes LIKE '%OPR%' THEN '<i class="fa fa-opera"></i> Opera' 
-        WHEN additional_attributes LIKE '%Chrome%' OR
-             additional_attributes LIKE '%CriOS%' THEN '<i class="fa fa-chrome"></i> Google Chrome'
-        WHEN additional_attributes LIKE '%Safari%' THEN '<i class="fa fa-safari"></i> Apple Safari'
-        WHEN additional_attributes LIKE '%Outlook%' THEN 'Outlook' 
-        ELSE 'Unknown'
-    END AS "browser",
     AVG(CASE WHEN time_taken > 0 THEN size/time_taken ELSE 0 END) as speed,
     AVG(CASE WHEN time_taken > 0 AND size>1073741824 THEN size/time_taken ELSE NULL END) as gspeed,
     AVG(size) as avgsize,
@@ -151,10 +137,11 @@ SELECT
     SUM(size) as transfered,
     COUNT(ID) as count,
     MIN($createdTS) as firsttransfer,
-    (CASE WHEN $createdDD > 0 THEN COUNT(ID)/$createdDD ELSE NULL END) as countperday
-FROM StatLogs
+    (CASE WHEN $createdDD > 0 THEN COUNT(ID)/$createdDD ELSE NULL END) as countperday,
+    os_name, browser_name, is_encrypted
+FROM statlogsview
 WHERE event='file_uploaded'
-GROUP BY "encryption","os","browser"
+GROUP BY is_encrypted,os_name,browser_name
 ORDER BY COUNT(ID) DESC, maxsize DESC
 EOF;
 
@@ -172,16 +159,16 @@ echo '<table class="list storage_usage_blocks">';
 echo '<thead><tr><th>Browser</th><th>OS</th><th>Encrypted</th><th>Average Speed</th><th>Average Speed of &gt;1GB</th><th>Min Size</th><th>Average Size</th><th>Max Size</th><th>Transfered</th><th>File Transfers</th><th>Average Transfers per Day</th></tr></thead>';
 foreach($result as $row) {
     echo '<tr>';
-    if ($row['browser'] != 'Unknown' && $row['os'] != 'Unknown') {
-	echo '<td>'.$row['browser'].'</td>';
-	echo '<td>'.$row['os'].'</td>';
+    if ($row['browser_name'] != 'Unknown' && $row['os_name'] != 'Unknown') {
+	echo '<td>'.browser_name_to_html($row['browser_name']).'</td>';
+	echo '<td>'.os_name_to_html($row['os_name']).'</td>';
     } else {
 	echo '<td colspan="2">';
 	echo $row['browser'].'<br>'.$row['os'].'<br>';
 	echo $row['additional_attributes'];
 	echo '</td>';
     }
-    echo '<td>'.$row['encryption'].'</td>';
+    echo '<td>'.is_encrypted_to_html($row['is_encrypted']).'</td>';
     echo '<td>'.($row['speed']>0?(Utilities::formatBytes($row['speed']).'/s'):'&nbsp;').'</td>';
     echo '<td>'.($row['gspeed']>0?(Utilities::formatBytes($row['gspeed']).'/s'):'&nbsp;').'</td>';
     echo '<td>'.($row['minsize']>0?Utilities::formatBytes($row['minsize']):'&nbsp;').'</td>';


### PR DESCRIPTION
It was mentioned in https://github.com/filesender/filesender/issues/464 that MySQL has an issue with the old admin stats SQL. This lead me to wonder what grouping by the additional_attributes column really meant when we are already grouping by 3 subselections of additional_attributes using LIKE.

The code update creates two new real columns which reference two new dbconstant tables and a view to return the string version of these numbers for easy access. The updated query no longer mixes HTML fragments into large CASE statements inside the SQL itself. At the least this makes the query much more readable. I may move the is_encrypted to being a real field using this plan soon to fully optimize things.

The admin/statistics page now works for me too, so there was something not happening in there before making the whole thing not return data on some systems and not execute at all on MySQL 5.7.

This update has been run against MySQL Ver 14.14 Distrib 5.7.19 on Ubuntu 16.04.3 LTS. As well as postgresql and mariadb on Fedora.