### PR TITLE
db statlog: move is-encrypted to being a real column

### DIFF
--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -85,6 +85,10 @@ class StatLog extends DBObject
             'type' => 'uint',
             'size' => 'medium',
             'null' => true
+        ),
+        'is_encrypted' => array(
+            'type' => 'bool',
+            'default' => false
         )
     );
 
@@ -104,7 +108,6 @@ class StatLog extends DBObject
         foreach (array('mysql','pgsql') as $dbtype) {
             $a[$dbtype] = 'select *'
                         . DBView::columnDefinition_age($dbtype, 'created')
-                        . DBView::columnDefinition_is_encrypted()
                         . DBView::columnDefinition_dbconstant( DBConstantBrowserType::getDBTable(),
                                                                'browser',
                                                                'browser_name' )
@@ -191,7 +194,8 @@ class StatLog extends DBObject
         $log->target_type = get_class($target);
         $log->browser = DBConstantBrowserType::currentBrowserToEnum();
         $log->os = DBConstantOperatingSystem::currentUserOperatingSystemEnum();
-        
+        $is_encrypted = false;
+
         // Add metadata depending on target
         switch ($log->target_type) {
             case File::getClassName():
@@ -199,7 +203,8 @@ class StatLog extends DBObject
                 
                 if ($event == LogEventTypes::FILE_UPLOADED) {
                     $log->time_taken = $target->upload_time;
-                    $log->additional_attributes = array('encryption'=>$target->transfer->options['encryption']);
+                    $is_encrypted = $target->transfer->options['encryption'];
+                    $log->additional_attributes = array('encryption'=>$is_encrypted);
                 }
                 break;
             
@@ -219,6 +224,8 @@ class StatLog extends DBObject
                 $log->size = 0;
                 break;
         }
+
+        $log->is_encrypted = $is_encrypted;
         
         // Add user aditionnal attributes if enabled
         if (Config::get('statlog_log_user_additional_attributes')) {

--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -636,7 +636,7 @@ class DatabasePgsql
             if (is_null($default)) {
                 $sql .= 'NULL';
             } elseif (is_bool($default)) {
-                $sql .= $default ? '1' : '0';
+                $sql .= $default ? 'true' : 'false';
             } elseif (is_numeric($default) && in_array($definition['type'], array('int', 'uint'))) {
                 $sql .= $default;
             } else {


### PR DESCRIPTION
It isn't a really great design to take a boolean value and put it into additional_attributes only to try to pick it out again in the SQL query and group by it. We might as well store it as a bool in the database and avoid the unneeded to string and LIKE loops.
