### PR TITLE
config: complain early if the admin settings are not going to work

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -286,7 +286,11 @@ class Config
                 }
                 break;
         }
-        
+
+        $crypt_padding_size = self::get('upload_crypted_chunk_padding_size');
+        if ((self::get('upload_chunk_size')+$crypt_padding_size) != self::get('upload_crypted_chunk_size')) {
+            throw new ConfigBadParameterException('You must set upload_crypted_chunk_size to upload_chunk_size + '.$crypt_padding_size.'.');
+        }
         
         // verify classes are happy
         Guest::validateConfig();

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -96,6 +96,7 @@ $default = array(
     'encryption_min_password_length' => 0,
     'encryption_generated_password_length' => 30,
     'encryption_generated_password_encoding' => 'base64',
+    'upload_crypted_chunk_padding_size' => 16 + 16, // CONST the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used


### PR DESCRIPTION
If the upload_chunk_size and upload_crypted_chunk_size are not set correctly then bad things can happen. This checks that those settings are correct early and faults to avoid finding issues later.

This relates to https://github.com/filesender/filesender/issues/397.