### PR TITLE
uploading: catch terasender startup fails, xhr timeout, better net stall reporting

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -107,6 +107,8 @@ $default = array(
     'terasender_start_mode' => 'multiple',
     'terasender_worker_count' => 6,
     'terasender_worker_max_chunk_retries' => 20,    
+    'terasender_worker_xhr_timeout' => 20000, // in ms
+    'terasender_worker_start_must_complete_within_ms' => 20000, // in ms
     'stalling_detection' => false,
 
     'testing_terasender_worker_uploadRequestChange_function_name' => '',
@@ -190,7 +192,7 @@ $default = array(
     'clientlogs_stashsize' => 10,
     'clientlogs_lifetime' => 10,
 
-    'automatic_resume_number_of_retries' =>  10,
+    'automatic_resume_number_of_retries' =>  20,
     'automatic_resume_delay_to_resume'   => 360,
 
     'guests_expired_lifetime' => 0,

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1463,6 +1463,10 @@ table.paginator a {
     background: #1cff1c;
 }
 
+.paused {
+    background: #6c666c;
+}
+
 .middle {
     background: #ffff1c;
 }

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -100,7 +100,10 @@ window.filesender.config = {
     terasender_worker_file: 'lib/terasender/terasender_worker.js',
     terasender_upload_endpoint: '<?php echo Config::get('site_url') ?>rest.php/file/{file_id}/chunk/{offset}',
     terasender_worker_max_chunk_retries: <?php echo Config::get('terasender_worker_max_chunk_retries')  ?>,
-    
+    terasender_worker_xhr_timeout: <?php  echo Config::get('terasender_worker_xhr_timeout') ?>,
+    terasender_worker_start_must_complete_within_ms: <?php  echo Config::get('terasender_worker_start_must_complete_within_ms') ?>,
+
+
     stalling_detection: <?php echo value_to_TF(Config::get('stalling_detection')); ?>,
 
     max_legacy_file_size: <?php echo Config::get('max_legacy_file_size') ?>,

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -1211,6 +1211,7 @@ window.filesender.transfer = function() {
         
         filesender.ui.log('Data sending failed, retrying from last known offsets');
         
+        this.status = 'running';
         if (this.canUseTerasender()) {
             filesender.terasender.retry();
         } else {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -253,11 +253,13 @@ filesender.ui.files = {
                 crust_indicator.removeClass('good');
                 crust_indicator.removeClass('middle');
                 crust_indicator.removeClass('slow');
+                crust_indicator.removeClass('paused');
                 crust_indicator.addClass('bad');
             } else {
                 crust_indicator.removeClass('middle');
                 crust_indicator.removeClass('slow');
                 crust_indicator.removeClass('bad');
+                crust_indicator.removeClass('paused');
                 crust_indicator.addClass('good');
             }
             
@@ -311,18 +313,43 @@ filesender.ui.files = {
                 crust_indicator.removeClass('middle');
                 crust_indicator.removeClass('slow');
                 crust_indicator.removeClass('bad');
+                crust_indicator.removeClass('paused');
                 crust_indicator.addClass('good');
+            }
+        }
+    },
+
+    pause_crust_meter: function( file ) {
+        var imax = 1;
+        if( filesender.config.terasender_enabled ) {
+            imax = filesender.config.terasender_worker_count;
+        }
+
+        for( var i = 0; i < imax; i++ ) {
+            var crust_indicator = filesender.ui.nodes.files.list.find('[data-cid="' + file.cid + '"] .crust' + i);
+            if( crust_indicator ) {
+                crust_indicator.find('.crustage').text( '' );
+                crust_indicator.find('.crustbytes').text( '' );
+                crust_indicator.removeClass('middle');
+                crust_indicator.removeClass('slow');
+                crust_indicator.removeClass('bad');
+                crust_indicator.removeClass('good');
+                crust_indicator.addClass('paused');
             }
         }
     },
     
     update_crust_meter: function( file ) {
+//        console.log("update_crust_meter(top) status " +  filesender.ui.transfer.status );
         if (!filesender.config.upload_display_per_file_stats) {
             return;
         }
         
         if (filesender.ui.transfer.status != 'running') {
             this.clear_crust_meter( file );
+            if (filesender.ui.transfer.status == 'paused') {
+                this.pause_crust_meter( file );
+            }
             return;
         }
 
@@ -657,6 +684,7 @@ filesender.ui.retryingErrorHandler = function(error,callback) {
 
     filesender.ui.automatic_resume_retries++;
     if( filesender.ui.automatic_resume_retries > filesender.config.automatic_resume_number_of_retries ) {
+        console.log("The user has run out of automatic retries so we are going to report this as a fatal error");
         filesender.ui.errorOriginal( error, callback );
         return;
     }
@@ -807,7 +835,10 @@ filesender.ui.startUpload = function() {
             filesender.ui.reload();
         });
     };
-    
+
+    if( filesender.config.automatic_resume_number_of_retries ) {
+        errorHandler = filesender.ui.retryingErrorHandler;
+    }
     this.transfer.onerror = errorHandler;
 
     

--- a/www/lib/terasender/terasender_worker.js
+++ b/www/lib/terasender/terasender_worker.js
@@ -117,6 +117,7 @@ var terasender_worker = {
         xhr.ontimeout = function() {
             worker.timeout();
         };
+        xhr.timeout = window.filesender.config.terasender_worker_xhr_timeout;
         
         var url = file.endpoint.replace('{offset}', this.job.chunk.start);
         xhr.open('PUT', url, true); // Open a request to the upload endpoint


### PR DESCRIPTION
This is targeted at the specific case when the network drops out during an upload https://github.com/filesender/filesender/issues/217. In this case the server may drop the connection and the client must rebuild the connection automatically. The catch is that sometimes creating web workers will also fail due to network IO issues (the network went away after all). So this adds detection for failed web worker startup and flags that as a failure after a period of time. 

I have found that in testing using terasender_worker_xhr_timeout at around 3 seconds a number of automatic resumes occurs before the actual upload starts again. I'm not sure why the web workers keep failing to start, but it does pick up again, maybe after 4-5 attempts and 20 seconds after reenabling wifi.

This also adds support for explicitly setting the xhr timeout for TeraSender. Having some control over that might be better than silently waiting forever. 

The terasender progress meters now also move to a "paused" grey state when things are not humming along and resume back to green when the web workers are up and running again.
