### PR TITLE
upload: add a upload directory button where supported.

### DIFF
--- a/classes/data/constants/DBConstantOperatingSystem.class.php
+++ b/classes/data/constants/DBConstantOperatingSystem.class.php
@@ -126,13 +126,13 @@ class DBConstantOperatingSystem extends DBConstant
             $v = self::T_NOKIA;
         } elseif ( preg_match( '/(Win|win)/', $b )) {
             $v = self::T_WINOTHER;
-            if ( preg_match( '/NT 10.0)/', $b )) {
+            if ( preg_match( '/NT 10.0\)/', $b )) {
                 $v = self::T_WIN10;
-            } elseif ( preg_match( '/NT 6.3)/', $b )) {
+            } elseif ( preg_match( '/NT 6.3\)/', $b )) {
                 $v = self::T_WIN81;
-            } elseif ( preg_match( '/NT 6.2)/', $b )) {
+            } elseif ( preg_match( '/NT 6.2\)/', $b )) {
                 $v = self::T_WIN80;
-            } elseif ( preg_match( '/NT 6.1)/', $b )) {
+            } elseif ( preg_match( '/NT 6.1\)/', $b )) {
                 $v = self::T_WIN70;
             }
         } else {

--- a/classes/utils/Browser.class.php
+++ b/classes/utils/Browser.class.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2019, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+
+/**
+ */
+class Browser
+{
+    private static $instance = null;
+    protected $ua = '';
+    protected $isChrome  = false;
+    protected $isFirefox = false;
+    
+    public function __construct()
+    {
+        $ua = array_key_exists('HTTP_USER_AGENT', $_SERVER) ? $_SERVER['HTTP_USER_AGENT'] : '';
+        $this->ua = $ua;
+
+        $this->isChrome  = preg_match('/[Cc]hrome/', $ua );
+        $this->isFirefox = preg_match('/[Ff]irefox/', $ua );
+    }
+    static function instance()
+    {
+        if( !self::$instance )
+            self::$instance = new Browser();
+        
+        return self::$instance;
+    }
+    public function __get($property)
+    {
+        if (in_array($property, array(
+            'isChrome','isFirefox'
+        ))) {
+            return $this->$property;
+        }
+    }
+
+};

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -188,6 +188,7 @@ $default = array(
     'cloud_s3_secret' => 'verySecretKey1',
 
     'disable_directory_upload' => true,
+    'directory_upload_button_enabled' => true,
 
     'clientlogs_stashsize' => 10,
     'clientlogs_lifetime' => 10,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -372,6 +372,7 @@ $lang['see_all'] = 'See all';
 $lang['select_all_for_archive_download'] = 'Select all files to download them as an archive';
 $lang['select_file'] = 'Select your file';
 $lang['select_files'] = 'Select files';
+$lang['select_directory'] = 'Select directory';
 $lang['select_for_archive_download'] = 'Select for archive download';
 $lang['send'] = 'Send';
 $lang['send_client_logs'] = 'Send logs';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -2,6 +2,15 @@
 
 $guest_can_only_send_to_creator = false;
 
+$files_actions_div_extra_class = "div3";
+$upload_directory_button_enabled = false;
+if( !Config::get('disable_directory_upload')
+    && Config::get('directory_upload_button_enabled')
+ && (Browser::instance()->isChrome || Browser::instance()->isFirefox))
+{
+    $upload_directory_button_enabled = true;
+    $files_actions_div_extra_class = "div4";
+}
 
 $formClasses = "upload_form_regular";
 if (Config::get('upload_display_per_file_stats')) {
@@ -83,20 +92,25 @@ if(Auth::isGuest()) {
 
             
             <div class="files_actions">
-                <div>
+                <div class="<?php echo $files_actions_div_extra_class ?>">
                     <a class="clear_all" href="#">
                         {tr:clear_all}
                     </a>
                 </div>
                 
-                <div>
+                <div class="<?php echo $files_actions_div_extra_class ?>">
                     <a class="select_files" href="#">
                         {tr:select_files}
                     </a>
                 </div>
-
+                <?php if ($upload_directory_button_enabled) { ?>
+                <div class="<?php echo $files_actions_div_extra_class ?>">
+                    <input type="file" name="selectdir" id="selectdir" class="selectdir_hidden_input_element" webkitdirectory directory multiple mozdirectory />
+                    <label for="selectdir" class="select_directory  ">{tr:select_directory}</label>                    
+                </div>
+                <?php } ?>
                 
-                <div class="stats">
+                <div class="stats <?php echo $files_actions_div_extra_class ?>">
                     <div class="number_of_files">{tr:number_of_files} : <span class="value"></span></div>
                     <div class="size">{tr:size} : <span class="value"></span></div>
                 </div>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -733,7 +733,13 @@ table.list .date {
 
 #upload_form .files_actions div {
     display: table-cell;
+}
+
+.div3 {
     width: 33%;
+}
+.div4 {
+     width: 25%;
 }
 
 #upload_form .files_actions div a {
@@ -1507,4 +1513,13 @@ div.not_displayed {
     display: none;
 }
 
+
+.selectdir_hidden_input_element {
+	width: 0.1px;
+	height: 0.1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
+	z-index: -1;
+}
 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -963,6 +963,7 @@ $(function() {
             uploadlogtop: form.find('.files_uploadlogtop'),
             uploadlog: form.find('.uploadlog'),
             select: form.find('.files_actions .select_files'),
+            selectdir: form.find('.files_actions .select_directory'),
             clear: form.find('.files_actions .clear_all'),
         },
         recipients: {
@@ -1028,6 +1029,7 @@ $(function() {
         filesender.ui.nodes.files.input.click();
         return false;
     }).button();
+    filesender.ui.nodes.files.selectdir.button();
     
     // Bind file drag drop events
     if(filesender.supports.reader) $('html').on('dragover', function (e) {
@@ -1357,6 +1359,7 @@ $(function() {
         
         // Remove unavailable features
         filesender.ui.nodes.files.select.remove();
+        filesender.ui.nodes.files.selectdir.remove();
         filesender.ui.nodes.files.dragdrop.remove();
         filesender.ui.nodes.buttons.pause.remove();
         


### PR DESCRIPTION
One Firefox and Chrome a select directory option can be added to hint to the user that they are able to upload an entire directory if they like. This is only available if the site allows directory upload (a config.php option). Also the button can be disabled if desired.

If directory upload is enabled the user should be able to drop a directory onto the form. But it might be more friendly and obvious just having a "select directory" button.

This relates to https://github.com/filesender/filesender/issues/372.