### PR TITLE
make convertTableResultsToObjects static

### DIFF
--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -329,7 +329,7 @@ class DBObject
      *
      * @return array of objects or page object
      */
-    public function convertTableResultsToObjects( $records, $run = null )
+    public static function convertTableResultsToObjects( $records, $run = null )
     {
         // Look for primary key(s) name(s)
         $pk = array();


### PR DESCRIPTION
make convertTableResultsToObjects static to avoid Deprecated: Non-static method DBObject::convertTableResultsToObjects() should not be called statically