### PR TITLE
security: start removing the possible use of frames.

### DIFF
--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -304,7 +304,7 @@ class RestServer
             //
             // Security that applies to all REST requests
             //
-            header('X-Frame-Options: deny');
+            header('X-Frame-Options: sameorigin', false);
 
             //
             // Output data

--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -300,9 +300,15 @@ class RestServer
             $data = call_user_func_array(array($handler, $method), $path);
             
             Logger::debug('Got data to send back');
-            
+
+            //
+            // Security that applies to all REST requests
+            //
+            header('X-Frame-Options: deny');
+
+            //
             // Output data
-            
+            //
             if (array_key_exists('callback', $_GET)) {
                 header('Content-Type: text/javascript');
                 $callback = self::sanitizeCallback($_GET['callback']);

--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -1,5 +1,6 @@
 Alias /simplesaml /opt/filesender/simplesaml/www
 <Directory "/opt/filesender/simplesaml/www">
+        Header always append X-Frame-Options DENY
 	Options None
 	AllowOverride None
 	Require all granted
@@ -7,6 +8,7 @@ Alias /simplesaml /opt/filesender/simplesaml/www
 
 Alias /filesender /opt/filesender/filesender/www
 <Directory "/opt/filesender/filesender/">
+        Header always append X-Frame-Options DENY
 	Options SymLinksIfOwnerMatch
 	AllowOverride None
 	Require all granted

--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -1,6 +1,6 @@
 Alias /simplesaml /opt/filesender/simplesaml/www
 <Directory "/opt/filesender/simplesaml/www">
-        Header always append X-Frame-Options DENY
+        Header always append X-Frame-Options SAMEORIGIN
 	Options None
 	AllowOverride None
 	Require all granted
@@ -8,7 +8,7 @@ Alias /simplesaml /opt/filesender/simplesaml/www
 
 Alias /filesender /opt/filesender/filesender/www
 <Directory "/opt/filesender/filesender/">
-        Header always append X-Frame-Options DENY
+        Header always append X-Frame-Options SAMEORIGIN
 	Options SymLinksIfOwnerMatch
 	AllowOverride None
 	Require all granted

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -327,6 +327,7 @@ would be in a file such as /etc/nginx/sites-enabled/filesender.example.com.
 
 ```
 server {
+        add_header X-Frame-Options none always;
         client_body_buffer_size 256k;
         client_max_body_size 32m;
         server_name filesender.domain.tld;

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -327,7 +327,7 @@ would be in a file such as /etc/nginx/sites-enabled/filesender.example.com.
 
 ```
 server {
-        add_header X-Frame-Options none always;
+        add_header X-Frame-Options sameorigin always;
         client_body_buffer_size 256k;
         client_max_body_size 32m;
         server_name filesender.domain.tld;

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -40,7 +40,7 @@ header('Content-Type: text/javascript; charset=UTF-8');
 //
 // Security that applies to all page requests
 //
-header('X-Frame-Options: deny');
+header('X-Frame-Options: sameorigin', false);
 
 $banned = Config::get('ban_extension');
 $extension_whitelist_regex = Config::get('extension_whitelist_regex');

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -37,6 +37,10 @@
 require_once('../includes/init.php');
 
 header('Content-Type: text/javascript; charset=UTF-8');
+//
+// Security that applies to all page requests
+//
+header('X-Frame-Options: deny');
 
 $banned = Config::get('ban_extension');
 $extension_whitelist_regex = Config::get('extension_whitelist_regex');

--- a/www/index.php
+++ b/www/index.php
@@ -41,7 +41,7 @@ try {
         //
         // Security that applies to all page requests
         //
-        header('X-Frame-Options: deny');
+        header('X-Frame-Options: sameorigin', false);
         
         Template::display('!!header');
         

--- a/www/index.php
+++ b/www/index.php
@@ -37,6 +37,11 @@ try {
     
     try { // At that point we can render exceptions using nice html
         Auth::isAuthenticated(); // Preload auth state
+
+        //
+        // Security that applies to all page requests
+        //
+        header('X-Frame-Options: deny');
         
         Template::display('!!header');
         


### PR DESCRIPTION
There is only one area that I can see that uses frames/iframe in filesender. This is to support legacy browsers that do not support the FileReader API. The FileReader is supported on IE10 and many older browsers (https://developer.mozilla.org/en-US/docs/Web/API/FileReader#Browser_compatibility).  This makes the legacy iframe code very unlikely to be useful these days. 

As such I have made the default policy for X-Frame-Options to be deny. The iframe code has not been pruned yet in case it is discovered to be required by some sites and the X-Frame-Options can be adjusted to allow it again. If nobody notices that x-frame is denied then the legacy code can be pruned away.
