### PR TITLE
security: clean up the policy, add docs

### DIFF
--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -301,10 +301,8 @@ class RestServer
             
             Logger::debug('Got data to send back');
 
-            //
-            // Security that applies to all REST requests
-            //
-            header('X-Frame-Options: sameorigin', false);
+            // Security that applies to all page requests
+            Security::addHTTPHeaders();
 
             //
             // Output data

--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2019, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+
+
+/**
+ * Utility functions for security
+ */
+class Security
+{
+
+    /**
+     *  
+     * Apache or NGINX may have been configured to already have
+     * some security headers enabled. This method can add some
+     * more defaults or update things if it can to ensure a site
+     * policy.
+     */
+    public static function addHTTPHeaders()
+    {
+        $v = Config::get('header_x_frame_options');
+        if( $v != 'sameorigin' && $v != 'deny' && $v != 'none' ) {
+            throw new ConfigBadParameterException('The setting header_x_frame_options should be one of the valid values.');
+        }
+        if( $v != 'none' ) {
+            header( 'X-Frame-Options: ' . $v, false );
+        }
+        
+    }
+}

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -26,6 +26,7 @@ A note about colours;
 * [site_url](#site_url)
 * [site_logouturl](#site_logouturl)
 * [reports_show_ip_addr](#reports_show_ip_addr)
+* [header_x_frame_options](#header_x_frame_options)
 
 ## Backend storage
 
@@ -309,6 +310,17 @@ A note about colours;
 * __default:__ true
 * __available:__ since version 2.0
 * __comment:__ If you want to hide IP addresses from reports set it to false
+
+
+### header_x_frame_options
+
+* __description:__ How to handle the X-Frame-Options HTTP header
+* __mandatory:__ no
+* __type:__ string
+* __default:__ sameorigin
+* __available:__ since version 2.7
+* __comment:__ Default should be ok. Can be 'deny' to disallow frames if you do not use them or 'none' to disable the feature (not recommended). Note that this setting will not override a setting that is already in place in your web server. This setting is mainly here as a second catch and for sites that can not configure their web server to install a site wide nominated value for X-Frame-Options.
+
 
 
 

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -266,6 +266,23 @@ information](../faq/#simplesamlphp-for-local-users-for-small-scale-setup-or-test
 if you would prefer to setup some username and passwords for local
 authentication for development and testing.
 
+# Step 5 - Web Server Security
+
+By default the configuration and setup for Apache and NGINX both use
+X-Frame-Options sameorigin and the configuration for FileSender itself
+will try to add that policy to pages if there is no existing policy in
+place. You can change the later by setting the header_x_frame_options
+config.php key to either sameorigin, deny, or none. Values that are not
+listed in the documentation for header_x_frame_options will cause a
+site halt until the configuration is restored to a valid value.
+
+If you are not running FileSender inside another web application you
+might like to set X-Frame-Options to deny in both your web server and
+the header_x_frame_options filesender config.php setting. This will
+inform the browser to fail to load any part of your site in a frame
+which will help strengthen your site against clickjacking.
+
+
 # Step 5-apache - Configure Apache
 
 A default configuration file for apache is shipped with FileSender in the

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -207,7 +207,7 @@ $default = array(
     'aggregate_statlog_lifetime' => false,
     'aggregate_statlog_send_report_days' => 0,
     'aggregate_statlog_send_report_email_address' => '',
-
+    
     'transfer_options_not_available_to_export_to_client' => array('get_a_link'
                                                                 , 'email_me_copies','email_me_on_expire'
                                                                 , 'email_upload_complete', 'email_download_complete'
@@ -216,6 +216,8 @@ $default = array(
                                                                 , 'add_me_to_recipients', 'redirect_url_on_complete'
     ),
 
+    'header_x_frame_options' => 'sameorigin',
+    
     
     // see crypto_app.js for constants in the range crypto_key_version_constants
     // Generally higher is newer + better.

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -37,10 +37,9 @@
 require_once('../includes/init.php');
 
 header('Content-Type: text/javascript; charset=UTF-8');
-//
 // Security that applies to all page requests
-//
-header('X-Frame-Options: sameorigin', false);
+Security::addHTTPHeaders();
+
 
 $banned = Config::get('ban_extension');
 $extension_whitelist_regex = Config::get('extension_whitelist_regex');

--- a/www/index.php
+++ b/www/index.php
@@ -38,10 +38,8 @@ try {
     try { // At that point we can render exceptions using nice html
         Auth::isAuthenticated(); // Preload auth state
 
-        //
         // Security that applies to all page requests
-        //
-        header('X-Frame-Options: sameorigin', false);
+        Security::addHTTPHeaders();
         
         Template::display('!!header');
         


### PR DESCRIPTION
Instead of setting the header all over the place, use a new Security class to set that policy in code in one place. That uses a new config.php setting to provide the default choice and there are docs for that new setting. This should make it clean to issue a 'none' value and disable it in the web server configuration for sites which do not wish to use the default sameorigin policy or wish to tighten it up to a 'deny'.