### PR TITLE
Update download template

### DIFF
--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -44,8 +44,8 @@
     ?>
     
     <div class="disclamer">
-        {tr:download_disclamer}
         <?php if(!$isEncrypted) { ?>
+            {tr:download_disclamer}
             {tr:download_disclamer_nocrypto_message}
         <?php } ?>
         <?php if($isEncrypted) { ?>


### PR DESCRIPTION
disable "You can download all files at once as a single compressed archive (.zip) file." when transfer is encrypted as you can not download a zip of it.