### PR TITLE
Logging, new securityIssue() call for potential security logs to be made with

### DIFF
--- a/classes/utils/FileSendercsrfProtectorLogger.class.php
+++ b/classes/utils/FileSendercsrfProtectorLogger.class.php
@@ -46,7 +46,7 @@ class FileSendercsrfProtectorLogger implements LoggerInterface {
             $context['message'] = $message;
             $context = json_encode($context) .PHP_EOL;
 
-            Logger::warn( 'OWASP CSRF protector log message: ' . $context );
+            Logger::securityIssue( 'OWASP CSRF protector log message: ' . $context );
         }
 }
 

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -244,6 +244,16 @@ class Logger
     }
 
     /**
+     * Log security issue
+     *
+     * @param string $message
+     */
+    public static function securityIssue($message)
+    {
+        self::log(LogLevels::ERROR, 'SECURITY ' . $message);
+    }
+    
+    /**
      * Log warn
      *
      * @param string $message


### PR DESCRIPTION
A call site generally knows if it is recording something relating to security so a new Logger method to articulate that can be helpful. At the moment the call just adds some metadata to the message but it could in the future redirect these from simple ERROR to some SECURITY log file.