### PR TITLE
info about adding samesite param to cookies

### DIFF
--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -1,8 +1,9 @@
 Alias /simplesaml /opt/filesender/simplesaml/www
 <Directory "/opt/filesender/simplesaml/www">
         Header always append X-Frame-Options SAMEORIGIN
-        Options -Indexes
+        Header always edit Set-Cookie (.*) "$1; SameSite=Strict"
 
+        Otions -Indexes
 	Options None
 	AllowOverride None
 	Require all granted
@@ -11,6 +12,8 @@ Alias /simplesaml /opt/filesender/simplesaml/www
 Alias /filesender /opt/filesender/filesender/www
 <Directory "/opt/filesender/filesender/">
         Header always append X-Frame-Options SAMEORIGIN
+        Header always edit Set-Cookie (.*) "$1; SameSite=Strict"
+        
 	Options SymLinksIfOwnerMatch
         Options -Indexes
 	AllowOverride None

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -380,6 +380,14 @@ the header_x_frame_options filesender config.php setting. This will
 inform the browser to fail to load any part of your site in a frame
 which will help strengthen your site against clickjacking.
 
+You may also like to edit cookies at the web server level to set
+"SameSite=Strict" as part of each cookie. Setting the
+[SameSite](https://www.owasp.org/index.php/SameSite) parameter has
+been added to the apache template shown below. This will prevent the
+SimpleSAML authentication cookies being sent to the site from cross
+site requests.
+
+
 
 # Step 5-apache - Configure Apache
 


### PR DESCRIPTION
The goal of this is to try to limit browsers sending the simplesaml cookie from other sites to a filesender instance. Such as might happen with a third party site trying to use a logged in session to do things without explicit user consent. If the saml cookie is not sent then the user will be seen as not authenticated and requests to perform data modification will be blocked at that level. This relies on a modern browser being used which will respect the samesite selection, of which many browsers do these days.

php 7.3 supports adding this at the code level. It is a bit of a nasty kludge to do it in a php 7.x and 7.3 compliant way, and also in lower level libraries as well as filesender itself. In the shorter term using the apache config to blanket things is a simpler solution.