### PR TITLE
dbpsql make update script idempotent on bool columns

### DIFF
--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -383,8 +383,9 @@ class DatabasePgsql
                     $non_respected[] = 'default';
                 }
             } elseif (is_bool($definition['default'])) {
-                if ((bool)$column_dfn['column_default'] != $definition['default']) {
-                    $logger($column.' default is not '.($definition['default'] ? '1' : '0'));
+                $expected = $definition['default'] ? 'true' : 'false';
+                if ((bool)$column_dfn['column_default'] != $expected) {
+                    $logger($column.' default is not '.$expected);
                     $non_respected[] = 'default';
                 }
             } elseif ($column_dfn['column_default'] != $definition['default']
@@ -531,7 +532,7 @@ class DatabasePgsql
                 if (is_null($definition['default'])) {
                     DBI::exec('ALTER TABLE '.$table.' ALTER COLUMN '.$column.' SET DEFAULT NULL');
                 } elseif (is_bool($definition['default'])) {
-                    DBI::exec('ALTER TABLE '.$table.' ALTER COLUMN '.$column.' SET DEFAULT '.($definition['default'] ? '1' : '0'));
+                    DBI::exec('ALTER TABLE '.$table.' ALTER COLUMN '.$column.' SET DEFAULT '.($definition['default'] ? 'true' : 'false'));
                 } else {
                     $s = DBI::prepare('ALTER TABLE '.$table.' ALTER COLUMN '.$column.' SET DEFAULT :default');
                     $s->execute(array(':default' => $definition['default']));


### PR DESCRIPTION
This will allow the update script to treat the default value for boolean columns properly and not try to update it when an update is not needed. Specifically if a column was already boolean and the right value we do not try to reset the default. The code to reset the default was also using 1/0 which pgsql doesn't like and would fail on. 

So now you should be able to run update.php two or more times without triggering an issue.

The initial refresh of boolean handling in the postgresql class didn't catch this issue.
Initial update is at https://github.com/filesender/filesender/commit/230c4085279277db2958989e25843c9b38157b32#diff-e827e779c944a7e88324da63750161d2L639
