### PR TITLE
Fix to cron.php - Added missing new properties to __get() from StatLog.class.php

### DIFF
--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -358,6 +358,9 @@ class StatLog extends DBObject
             'size',
             'time_taken',
             'additional_attributes',
+            'browser',
+            'os',
+            'is_encrypted',
         ))) {
             return $this->$property;
         }

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -130,6 +130,9 @@ class StatLog extends DBObject
     protected $size = null;
     protected $time_taken = 0;
     protected $additional_attributes = null;
+    protected $browser = 0;
+    protected $os = 0;
+    protected $is_encrypted = 0;
     
     
     /**


### PR DESCRIPTION
This should fix cron.php crashing with error no_such_property #557 