### PR TITLE
fixed the browser/os stats display in admin_statistics_section.php (FS > 2.5)

### DIFF
--- a/classes/data/constants/DBConstantBrowserType.class.php
+++ b/classes/data/constants/DBConstantBrowserType.class.php
@@ -84,27 +84,27 @@ class DBConstantBrowserType extends DBConstant
     static function currentBrowserToEnum()
     {
         $b = $_SERVER['HTTP_USER_AGENT'];
-        if( preg_match( '/Firefox/', $b )) {
+        if( preg_match( '/Firefox/i', $b )) {
             $v = self::T_FIREFOX;
-        } elseif ( preg_match( '/edge/', $b )) {
+        } elseif ( preg_match( '/edge/i', $b )) {
             $v = self::T_EDGE;
-        } elseif ( preg_match( '/MSIE/', $b )) {
+        } elseif ( preg_match( '/MSIE/i', $b )) {
             $v = self::T_IE;
-        } elseif ( preg_match( '/Trident/', $b )) {
+        } elseif ( preg_match( '/Trident/i', $b )) {
             $v = self::T_IE;
-        } elseif ( preg_match( '/Vivaldi/', $b )) {
+        } elseif ( preg_match( '/Vivaldi/i', $b )) {
             $v = self::T_VIVALDI;
-        } elseif ( preg_match( '/Opera/', $b )) {
+        } elseif ( preg_match( '/Opera/i', $b )) {
             $v = self::T_OPERA;
-        } elseif ( preg_match( '/OPR/', $b )) {
+        } elseif ( preg_match( '/OPR/i', $b )) {
             $v = self::T_OPERA;
-        } elseif ( preg_match( '/Chrome/', $b )) {
+        } elseif ( preg_match( '/Chrome/i', $b )) {
             $v = self::T_CHROME;
-        } elseif ( preg_match( '/CriOS/', $b )) {
+        } elseif ( preg_match( '/CriOS/i', $b )) {
             $v = self::T_CHROME;
-        } elseif ( preg_match( '/Safari/', $b )) {
+        } elseif ( preg_match( '/Safari/i', $b )) {
             $v = self::T_SAFARI;
-        } elseif ( preg_match( '/Outlook/', $b )) {
+        } elseif ( preg_match( '/Outlook/i', $b )) {
             $v = self::T_OUTLOOK;
         } else {
             $v = self::T_UNKNOWN;

--- a/classes/data/constants/DBConstantOperatingSystem.class.php
+++ b/classes/data/constants/DBConstantOperatingSystem.class.php
@@ -108,31 +108,31 @@ class DBConstantOperatingSystem extends DBConstant
     static function currentUserOperatingSystemEnum()
     {
         $b = $_SERVER['HTTP_USER_AGENT'];
-        if( preg_match( '/iPad/', $b )) {
+        if( preg_match( '/iPad/i', $b )) {
             $v = self::T_IPAD;
-        } elseif ( preg_match( '/iPod/', $b )) {
+        } elseif ( preg_match( '/iPod/i', $b )) {
             $v = self::T_IPOD;
-        } elseif ( preg_match( '/iPhone/', $b )) {
+        } elseif ( preg_match( '/iPhone/i', $b )) {
             $v = self::T_IPHONE;
-        } elseif ( preg_match( '/imac/', $b )) {
+        } elseif ( preg_match( '/imac/i', $b )) {
             $v = self::T_MAC;
-        } elseif ( preg_match( '/Mac.*OS/', $b )) {
+        } elseif ( preg_match( '/Mac.*OS/i', $b )) {
             $v = self::T_OSX;
-        } elseif ( preg_match( '/android/', $b )) {
+        } elseif ( preg_match( '/android/i', $b )) {
             $v = self::T_ANDROID;
-        } elseif ( preg_match( '/linux/', $b )) {
+        } elseif ( preg_match( '/linux/i', $b )) {
             $v = self::T_LINUX;
-        } elseif ( preg_match( '/Nokia/', $b )) {
+        } elseif ( preg_match( '/Nokia/i', $b )) {
             $v = self::T_NOKIA;
-        } elseif ( preg_match( '/(Win|win)/', $b )) {
+        } elseif ( preg_match( '/Win/i', $b )) {
             $v = self::T_WINOTHER;
-            if ( preg_match( '/NT 10.0\)/', $b )) {
+            if ( preg_match( '/NT 10.0/i', $b )) {
                 $v = self::T_WIN10;
-            } elseif ( preg_match( '/NT 6.3\)/', $b )) {
+            } elseif ( preg_match( '/NT 6.3/i', $b )) {
                 $v = self::T_WIN81;
-            } elseif ( preg_match( '/NT 6.2\)/', $b )) {
+            } elseif ( preg_match( '/NT 6.2/i', $b )) {
                 $v = self::T_WIN80;
-            } elseif ( preg_match( '/NT 6.1\)/', $b )) {
+            } elseif ( preg_match( '/NT 6.1/i', $b )) {
                 $v = self::T_WIN70;
             }
         } else {

--- a/templates/admin_statistics_section.php
+++ b/templates/admin_statistics_section.php
@@ -160,19 +160,35 @@ echo '<thead><tr><th>Browser</th><th>OS</th><th>Encrypted</th><th>Average Speed<
 foreach($result as $row) {
     echo '<tr>';
     if (empty($row['browser_name'])) {
-        echo '<td colspan="2">';
-        if ((empty($row['browser'])) && (empty($row['os'])))  {
-            echo 'Unknown<br>Unknown<br>';
+        echo '<td>';
+        if ((empty($row['browser'])))  {
+            echo 'Unknown';
         } else {
-            echo $row['browser'].'<br>'.$row['os'].'<br>';
+            echo $row['browser'];
         }
-        echo $row['additional_attributes'];
+        echo '</td>';
+        echo '<td>';
+        if (empty($row['os']))  {
+            echo 'Unknown';
+        } else {
+            echo $row['os'];
+        }
+        echo '</td>';
+        echo '<td>';
+        if ($row['additional_attributes'] === '{"encryption":true}')  {
+            echo is_encrypted_to_html(1);
+        } 
+        elseif ($row['additional_attributes'] === '{"encryption":false}') {
+            echo is_encrypted_to_html(0);
+        } else {
+            echo $row['additional_attributes'];
+        }
         echo '</td>';
     } else {
         echo '<td>'.browser_name_to_html($row['browser_name']).'</td>';
         echo '<td>'.os_name_to_html($row['os_name']).'</td>';
+        echo '<td>'.is_encrypted_to_html($row['is_encrypted']).'</td>';
     }
-    echo '<td>'.is_encrypted_to_html($row['is_encrypted']).'</td>';
     echo '<td>'.($row['speed']>0?(Utilities::formatBytes($row['speed']).'/s'):'&nbsp;').'</td>';
     echo '<td>'.($row['gspeed']>0?(Utilities::formatBytes($row['gspeed']).'/s'):'&nbsp;').'</td>';
     echo '<td>'.($row['minsize']>0?Utilities::formatBytes($row['minsize']):'&nbsp;').'</td>';

--- a/templates/admin_statistics_section.php
+++ b/templates/admin_statistics_section.php
@@ -159,14 +159,18 @@ echo '<table class="list storage_usage_blocks">';
 echo '<thead><tr><th>Browser</th><th>OS</th><th>Encrypted</th><th>Average Speed</th><th>Average Speed of &gt;1GB</th><th>Min Size</th><th>Average Size</th><th>Max Size</th><th>Transfered</th><th>File Transfers</th><th>Average Transfers per Day</th></tr></thead>';
 foreach($result as $row) {
     echo '<tr>';
-    if ($row['browser_name'] != 'Unknown' && $row['os_name'] != 'Unknown') {
-	echo '<td>'.browser_name_to_html($row['browser_name']).'</td>';
-	echo '<td>'.os_name_to_html($row['os_name']).'</td>';
+    if (empty($row['browser_name'])) {
+        echo '<td colspan="2">';
+        if ((empty($row['browser'])) && (empty($row['os'])))  {
+            echo 'Unknown<br>Unknown<br>';
+        } else {
+            echo $row['browser'].'<br>'.$row['os'].'<br>';
+        }
+        echo $row['additional_attributes'];
+        echo '</td>';
     } else {
-	echo '<td colspan="2">';
-	echo $row['browser'].'<br>'.$row['os'].'<br>';
-	echo $row['additional_attributes'];
-	echo '</td>';
+        echo '<td>'.browser_name_to_html($row['browser_name']).'</td>';
+        echo '<td>'.os_name_to_html($row['os_name']).'</td>';
     }
     echo '<td>'.is_encrypted_to_html($row['is_encrypted']).'</td>';
     echo '<td>'.($row['speed']>0?(Utilities::formatBytes($row['speed']).'/s'):'&nbsp;').'</td>';


### PR DESCRIPTION
Fixed the  browser/os/encryption stats display, somehow...
OS detection doesn't seem to work?

-------------------------------------------------------
Older stats (pre 2.6) are displayed like before with commit f24ab04 
```
Unknown
Unknown
{"encryption":true}
```

-------------------------------------------------------

Older stats (pre 2.6) are displayed like newer stats (>= 2.6) with commit 26b2b60 .
![image](https://user-images.githubusercontent.com/49909162/60437070-d4c99780-9c0d-11e9-818d-12de77fb9c6b.png)

