### PR TITLE
cron db: move to a subselect for the auditlog cleanup

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -423,11 +423,11 @@ class AuditLog extends DBObject
         // already been removed from the system
         DBI::exec(
             ""
-           ."delete au from ".self::getDBTable()." as au"
-           ."   join ".self::getViewName()." al on al.id = au.id"
+           ."delete from ".self::getDBTable()." where ".self::getDBTable().".id in ("
+           ."   select al.id from ".self::getViewName()." al "
            ."   left outer join ".Guest::getDBTable()." g"
            ."   on g.id = al.target_id_as_number "
-           ."   where al.target_type = 'Guest' and g.id is null"
+           ."   where al.target_type = 'Guest' and g.id is null )"
         );
         
         // if there is a sunset lifetime for the auditlog


### PR DESCRIPTION
This moves joins into a subselect. Tested on mariadb and postgresql locally.