### PR TITLE
ui: allow a subdirectory of templates to be selected as the active theme

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -291,7 +291,12 @@ class Config
         if ((self::get('upload_chunk_size')+$crypt_padding_size) != self::get('upload_crypted_chunk_size')) {
             throw new ConfigBadParameterException('You must set upload_crypted_chunk_size to upload_chunk_size + '.$crypt_padding_size.'.');
         }
-        
+
+        $themeName = self::get('theme');
+        if( strlen($themeName) && preg_match('@[./]@',$themeName)) {
+            throw new ConfigBadParameterException('the theme config can not contain / or . characters');
+        }
+            
         // verify classes are happy
         Guest::validateConfig();
         ClientLog::validateConfig();

--- a/classes/utils/Template.class.php
+++ b/classes/utils/Template.class.php
@@ -40,6 +40,15 @@ if (!defined('FILESENDER_BASE')) {
  */
 class Template
 {
+    private static function resolve_addPossibleLocation(&$possibleLocations,$rpath)
+    {
+        $base = FILESENDER_BASE;
+        $themeName = Config::get('theme');
+        if(strlen($themeName)) {
+            array_push( $possibleLocations, $base.$rpath.'/'.$themeName );
+        }
+        array_push( $possibleLocations, $base.$rpath );
+    }
     /**
      * Resolve template id to path
      *
@@ -49,16 +58,22 @@ class Template
      */
     private static function resolve($id)
     {
+        // Create a list of possible locations
+        $possibleLocations = array();
+        self::resolve_addPossibleLocation( $possibleLocations, '/'.'config/templates' );
+        self::resolve_addPossibleLocation( $possibleLocations, '/'.'templates' );
+
         // Look in possible locations
-        foreach (array('config/templates', 'templates') as $location) {
-            $location = FILESENDER_BASE.'/'.$location;
+        foreach ($possibleLocations as $location) {
+
             if (!is_dir($location)) {
                 continue;
             }
             
             // Return if found
-            if (file_exists($location.'/'.$id.'.php')) {
-                return $location.'/'.$id.'.php';
+            $fullPath = $location.'/'.$id.'.php';
+            if (file_exists($fullPath)) {
+                return $fullPath;
             }
         }
         

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -80,6 +80,7 @@ A note about colours;
 
 ## General UI
 
+* [theme](#theme)
 * [autocomplete](#autocomplete)
 * [autocomplete_max_pool](#autocomplete_max_pool)
 * [autocomplete_min_characters](#autocomplete_min_characters)
@@ -696,6 +697,17 @@ User language detection is done in the following order:
 * __comment:__ <span style="background-color:orange">this parameter will get a different name</span>
 
 ## General UI
+
+### theme
+
+* __description:__ This allows you to select a custom theme by creating a subdirectory inside the normal template directory and naming it here.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ ''
+* __available:__ since version 2.8
+* __comment:__ You can not select absolute or relative paths using this parameter. Your theme directory must exist inside the existing template directory.
+
+
 
 ### autocomplete
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -218,6 +218,8 @@ $default = array(
 
     'header_x_frame_options' => 'sameorigin',
     'owasp_csrf_protector_enabled' => false,
+
+    'theme' => '',
     
     
     // see crypto_app.js for constants in the range crypto_key_version_constants


### PR DESCRIPTION
This is a little massage of the core code from https://github.com/filesender/filesender/pull/590. I thought it cleaner to separate out the list of locations and the code that operates a location into two distinct code blocks. There is also a docs entry for the new config and it is explicitly in the defaultconfig (as an empty string).

