### PR TITLE
guests: improved interaction of get_a_link and send_to_me

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -505,3 +505,5 @@ $lang['you_can_report_exception_by_email'] = 'You can report this error by email
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['archive_tar_download'] = 'Download as single (.tar) file';
 $lang['invalid_file_name'] = 'Invalid file name';
+$lang['turning_on_guests_get_a_link_disables_can_only_send_to_me'] = 'Allowing guests to get a link means that can only send to me has been disabled';
+

--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -6,6 +6,7 @@ $new_guests_can_only_send_to_creator = false;
 Guest::forcedOptions();
 foreach (Guest::allOptions() as $name => $dfn) {
     if( $name == 'can_only_send_to_me' ) {
+        $new_guests_can_only_send_to_creator_default = $dfn['default'];
         if (in_array('available', $dfn) && !$dfn['available']) {
             if (in_array('default', $dfn)) {
                 $new_guests_can_only_send_to_creator = $dfn['default'];
@@ -65,16 +66,20 @@ foreach (Guest::allOptions() as $name => $dfn) {
 
                 <td class="box">
                     <div class="fieldcontainer">
+
                         <label for="expires" id="datepicker_label" class="mandatory">{tr:expiry_date}:</label>
                         
                         <input id="expires" name="expires" type="text" autocomplete="off"
                                title="<?php echo Lang::trWithConfigOverride('dp_date_format_hint')->r(array('max' => Config::get('max_guest_days_valid'))) ?>"
                                data-epoch="<?php echo Transfer::getDefaultExpire() ?>"
                         />
+
                     </div>
                     
                     <?php
-                        $displayoption = function($name, $cfg, $transfer = false) use ($new_guests_can_only_send_to_creator)
+                    $displayoption = function($name, $cfg, $transfer = false)
+                    use ( $new_guests_can_only_send_to_creator,
+                          $new_guests_can_only_send_to_creator_default )
                         {
                             // don't show the option for get_a_link if they can't use it.
                             if($name == 'get_a_link' && $new_guests_can_only_send_to_creator ) {
@@ -89,6 +94,9 @@ foreach (Guest::allOptions() as $name => $dfn) {
                                     $default = Auth::user()->defaultGuestOptionState($name);
                                 }
                             }
+                            if( $name == 'get_a_link' && $new_guests_can_only_send_to_creator_default ) {
+                                $default = false;
+                            }
                             $checked = $default ? 'checked="checked"' : '';
                             $extraDivAttrs = '';
                             $hidden = '';
@@ -100,14 +108,19 @@ foreach (Guest::allOptions() as $name => $dfn) {
                                 echo '</div>';
                                 
                             } else {
-                                echo '<div class="fieldcontainer" '. $extraDivAttrs .'>';
+                                $lockClassLabel = '';
+                                $lockClass = '';
+                                if($name == 'get_a_link' || $name == 'can_only_send_to_me') {
+                                    $lockClass = 'get_a_link_lock';
+                                }
+                                echo '<div class="fieldcontainer '.$lockClass.'" '. $extraDivAttrs .'>';
                                 echo '  <input id="'.$name.'" name="'.$name.'" type="checkbox" '.$checked.' />';
-                                echo '  <label for="'.$name.'">'.Lang::tr($name).'</label>';
+                                echo '  <label for="'.$name.'" class="'.$lockClassLabel.'">'.Lang::tr($name).'</label>';
                                 echo '</div>';
                             }
                         };
                     ?>
-                    
+
                     <div class="guest_options options_box">
                         <h3>{tr:guest_options}</h3>
                         

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1523,3 +1523,6 @@ div.not_displayed {
 	z-index: -1;
 }
 
+.get_a_link_lock {
+    background: #eeeeff;
+}

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -336,6 +336,7 @@ $(function() {
         if( checked ) {
             onlyToMe.prop('checked', false );
             onlyToMe.prop('disabled', true);
+            filesender.ui.notify('info',lang.tr('turning_on_guests_get_a_link_disables_can_only_send_to_me'));
         } else {
             onlyToMe.prop('disabled', false);
         }
@@ -344,6 +345,9 @@ $(function() {
         get_a_link_updates();
     });
     get_a_link_updates();
+
+    
+    
     
     // Bind advanced options display toggle
     send_voucher.find('.toggle_advanced_options').on('click', function() {


### PR DESCRIPTION
This updates a bad interaction when the config.php shown below is used. In this case can_only_send_to_me will be checked in the interface and get_a_link will be unchecked by default.  There is now a notification if you subsequently select get_a_link letting you know that can_only_send_to_me has been changed to false and disabled. A subtle background colour is used to link these two options on the page as well. It is possible that a different user interface element such as a single selection drop down or list should be used to handle this setting making the choice explicit and not offering combinations that do not make sense.

```
$config['guest_options'] = array(
        'can_only_send_to_me' => array(
            'available' => true,
            'advanced' => false,
            'default' => true
        ),
```


This relates to https://github.com/filesender/filesender/issues/591.