### PR TITLE
upload: abstract out the pause and resume functions

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -517,3 +517,5 @@ $lang['terasender_failed_after_many_retries'] = 'Uploading a chunk of the file f
 $lang['upload_progressing_again'] = 'Upload progressing again';
 $lang['reconnect_and_continue'] = 'Reconnect and Continue';
 $lang['retry_attempt_x'] = 'Retry attempt {x}';
+$lang['terasender_no_workers_have_started'] = 'Uploading a chunk of the file failed because workers could not be started. Are you still connected to the Internet?';
+


### PR DESCRIPTION
When an upload has failed and all the automatic resume attempts have been used then pause the upload to avoid more errors from occurring.

This also abstracts out the pause() and resume() functions so that the many sites that want to perform that can do so without needing to explicitly attend to timers, user interface elements etc that might need to be updated.
