### PR TITLE
ui: bring out statistics from admin page

### DIFF
--- a/classes/constants/GUIPages.class.php
+++ b/classes/constants/GUIPages.class.php
@@ -40,6 +40,7 @@ class GUIPages extends Enum
     const UPLOAD          = 'upload';
     const TRANSFERS       = 'transfers';
     const GUESTS          = 'guests';
+    const STATISTICS      = 'statistics';
     const ADMIN           = 'admin';
     const LOGON           = 'logon';
     const USER            = 'user';

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -332,6 +332,10 @@ class GUI
                     if (Auth::canViewAggregateStatistics()) {
                         self::$allowed_pages[] = 'aggregate_statistics';
                     }
+
+                    if (Auth::canViewStatistics()) {
+                        self::$allowed_pages[] = 'statistics';
+                    }
                     
                     // Is user page enabled ?
                     if (Config::get('user_page')) {

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -518,4 +518,5 @@ $lang['upload_progressing_again'] = 'Upload progressing again';
 $lang['reconnect_and_continue'] = 'Reconnect and Continue';
 $lang['retry_attempt_x'] = 'Retry attempt {x}';
 $lang['terasender_no_workers_have_started'] = 'Uploading a chunk of the file failed because workers could not be started. Are you still connected to the Internet?';
+$lang['statistics_page'] = 'Statistics';
 

--- a/templates/about_page.php
+++ b/templates/about_page.php
@@ -1,10 +1,5 @@
 <?php
-
-$pagemenuitem = function($page) {
-    if(!GUI::isUserAllowedToAccessPage($page)) return;
-    $class = ($page == GUI::currentPage()) ? 'current' : '';
-    echo '<div><a class="'.$class.'" href="?s='.$page.'">'.Lang::tr($page.'_page_link').'</a></div>';
-};
+      include_once "pagemenuitem.php"
 ?>
 
 <div class="box">
@@ -15,7 +10,7 @@ $pagemenuitem = function($page) {
 
     <?php 
     if (AggregateStatistic::enabled()) {
-        $pagemenuitem('aggregate_statistics');
+        pagelink('aggregate_statistics');
     }
     ?>
 </div>

--- a/templates/admin_page.php
+++ b/templates/admin_page.php
@@ -1,12 +1,12 @@
 <div class="box">
     <?php
     
-    $sections = array('statistics', 'transfers', 'guests', 'users' );
+    $sections = array('transfers', 'guests', 'users' );
     
     if(Config::get('config_overrides'))
         $sections[] = 'config';
     
-    $section = 'statistics';
+    $section = 'transfers';
     if(array_key_exists('as', $_REQUEST))
         $section = $_REQUEST['as'];
     

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -1,12 +1,8 @@
 <?php
 
-$maybe_display_aggregate_statistics_menu = false;
+include_once "pagemenuitem.php";
 
-$pagemenuitem = function($page) {
-    if(!GUI::isUserAllowedToAccessPage($page)) return;
-    $class = ($page == GUI::currentPage()) ? 'current' : '';
-    echo '<li><a class="'.$class.'" id="topmenu_'.$page.'" href="?s='.$page.'">'.Lang::tr($page.'_page').'</a></li>';
-};
+$maybe_display_aggregate_statistics_menu = false;
 
 ?>
 
@@ -19,20 +15,22 @@ $pagemenuitem = function($page) {
             <?php
             
             if(!Auth::isGuest()) {
-                $pagemenuitem('upload');
+                pagemenuitem('upload');
                 
-                $pagemenuitem('guests');
+                pagemenuitem('guests');
                 
-                $pagemenuitem('transfers');
+                pagemenuitem('transfers');
                 
                 if(Config::get('user_page'))
-                    $pagemenuitem('user');
+                    pagemenuitem('user');
                 
-                $pagemenuitem('admin');
+                pagemenuitem('statistics');
+                
+                pagemenuitem('admin');
 
                 if( $maybe_display_aggregate_statistics_menu ) {
                     if (AggregateStatistic::enabled()) {
-                        $pagemenuitem('aggregate_statistics');
+                        pagemenuitem('aggregate_statistics');
                     }
                 }
                     
@@ -45,9 +43,9 @@ $pagemenuitem = function($page) {
     <div class="rightmenu">
         <ul>
         <?php
-            $pagemenuitem('help');
-            $pagemenuitem('about');
-            $pagemenuitem('privacy');
+            pagemenuitem('help');
+            pagemenuitem('about');
+            pagemenuitem('privacy');
 
             if (Auth::isAuthenticated() && Auth::isSP()) {
                 $url = AuthSP::logoffURL();
@@ -55,7 +53,7 @@ $pagemenuitem = function($page) {
                     echo '<li><a href="'.Utilities::sanitizeOutput($url).'" id="topmenu_logoff">'.Lang::tr('logoff').'</a></li>';
             }else if (!Auth::isGuest()){
                 if(Config::get('auth_sp_embedded')) {
-                    $pagemenuitem('logon');
+                    pagemenuitem('logon');
                 }else{
                     echo '<li><a href="'.Utilities::sanitizeOutput(AuthSP::logonURL()).'" id="topmenu_logon">'.Lang::tr('logon').'</a></li>';
                 }

--- a/templates/pagemenuitem.php
+++ b/templates/pagemenuitem.php
@@ -1,0 +1,16 @@
+<?php
+
+
+function pagelink($page) {
+    if(!GUI::isUserAllowedToAccessPage($page)) return;
+    $class = ($page == GUI::currentPage()) ? 'current' : '';
+    
+    echo '<div><a class="'.$class.'" href="?s='.$page.'">'.Lang::tr($page.'_page_link').'</a></div>';
+}
+
+function pagemenuitem($page) {
+    if(!GUI::isUserAllowedToAccessPage($page)) return;
+    $class = ($page == GUI::currentPage()) ? 'current' : '';
+    echo '<li><a class="'.$class.'" id="topmenu_'.$page.'" href="?s='.$page.'">'.Lang::tr($page.'_page').'</a></li>';
+}
+

--- a/templates/statistics_page.php
+++ b/templates/statistics_page.php
@@ -1,5 +1,17 @@
+<?php
+      include_once "pagemenuitem.php"
+?>
+
+<div class="box">
 <h2>{tr:admin_statistics_section}</h2>
 
+<?php
+if (AggregateStatistic::enabled()) {
+    echo "<h3>{tr:aggregate_statistics}</h3>";
+    pagelink('aggregate_statistics');
+}
+?>
+    
 <h3>{tr:global_statistics}</h3>
 
 <table class="global_statistics">
@@ -217,3 +229,4 @@ echo '</table>';
 
 
 <script type="text/javascript" src="{path:js/admin_statistics.js}"></script>
+</div>


### PR DESCRIPTION
The statistics page is now a top level menu item. It has a $config['can_view_statistics'] config.php setting which has the same format as the 'admin' config. The stats page can also be enabled for a user through SAML with the auth_sp_saml_can_view_statistics_entitlement config setting and the other saml attribute that are used to define admin rights through SAML attributes (ie,            auth_sp_saml_entitlement_attribute, auth_sp_additional_attributes).

The statistics page also includes a link to the aggregate statistics section if that feature is enabled.

