### PR TITLE
i18n: when adding a locale you must update this too

### DIFF
--- a/language/locale.php
+++ b/language/locale.php
@@ -36,9 +36,11 @@
 
 
 $locales  =  array(
-    'cs' => 'cs_CZ',
+    'cs'    => 'cs_CZ',
     'cs-cz' => 'cs_CZ',
-    'de' => 'de_DE',
+    'da'    => 'da_DK',
+    'da_DK' => 'da_DK',
+    'de'    => 'de_DE',
     'de-de' => 'de_DE',
     'en-au' => array('name' => 'English (AU)', 'path' => 'en_AU'),
     'en-us' => array('name' => 'English (US)', 'path' => 'en_AU'),

--- a/scripts/language/import-langs-directory.sh
+++ b/scripts/language/import-langs-directory.sh
@@ -25,6 +25,8 @@ function importfile {
 
 }
 
+# note that you need to update languages/locale.php to have 
+# the new entries in it when you update the below
 importfile cs_CZ FileSender_2.0_Czech.php
 importfile da_DK FileSender_2.0_Danish.php
 importfile nl_NL FileSender_2.0_Dutch.php


### PR DESCRIPTION
I added a comment to the import-all script as that is likely to be the first place that is updated when a new locale is added and that is likely to be a relatively rare event.
