### PR TITLE
make reports_show_ip effective on the transfer audit log

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -223,13 +223,18 @@ class RestEndpointTransfer extends RestEndpoint
                 // ... to be returned, aggregate it
                 return array_values(array_map(function ($log) {
                     $author = $log->author;
+
+                    $ip = '';
+                    if( Config::get('reports_show_ip_addr')) {
+                        $ip = $log->ip;
+                    }
                     
                     // Build action author data
                     $author_data = array(
                         'type' => $log->author_type,
                         'id' => $log->author_id,
                         'identity' => $author ? (string)$author->identity : null,
-                        'ip' => $log->ip
+                        'ip' => $ip
                     );
                     if ($log->author_type == 'Recipient') {
                         $author_data['email'] = $log->author->email;

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -136,7 +136,7 @@ $default = array(
     'report_bounces' => 'asap',
     'report_bounces_asap_then_daily_range' => 15 * 60,
 
-    'reports_show_ip_addr' => true,
+    'reports_show_ip_addr' => false,
 
     'statlog_lifetime' => 0,
     'statlog_log_user_organization' => false,


### PR DESCRIPTION
Also, to the default setting for reports_show_ip_addr is now false.