### PR TITLE
ci test that key_version is stored per transfer by using many key_versions in ci

### DIFF
--- a/travis/filesender-config.php
+++ b/travis/filesender-config.php
@@ -326,5 +326,8 @@ $config['sauce_access_key'] = getenv('sauce_access_key');     // String, Sauce L
 $config['ban_extension'] = 'exe,bat';
 $config['user_page'] = array();
 
+$config['encryption_key_version_new_files'] = 0;
+
+
 $config['PUT_PERFORM_TESTSUITE'] = '';
 

--- a/unittests/selenium/SeleniumTest.php
+++ b/unittests/selenium/SeleniumTest.php
@@ -242,6 +242,13 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
         sleep(2);
     }
 
+    protected function setKeyVersionNewFiles($v = 0)
+    {
+        $this->changeConfigValue('encryption_key_version_new_files', $v);
+        $this->refresh();
+        sleep(2);
+    }
+    
     public function changeConfigValue($type, $value) {
         TestSuiteSupport::changeConfigValue($type, $value);
     }

--- a/unittests/selenium/tests/EncryptionTest.php
+++ b/unittests/selenium/tests/EncryptionTest.php
@@ -4,14 +4,11 @@ require_once 'unittests/selenium/SeleniumTest.php';
 
 class EncryptionTest extends SeleniumTest {
 
-    /**
-     * Method testEncryptionTest 
-     * @test 
-     */
-    public function testEncryptionTest() {
+    private function uploadEncrypted() {
         extract($this->getKeyBindings());
 
         $this->setupAuthenticated();
+
 
         if (!$this->isCheckBoxSelected('[name="get_a_link"]')) {
             $this->clickCheckbox('[name="get_a_link"]');
@@ -69,12 +66,10 @@ class EncryptionTest extends SeleniumTest {
 
         return array($test1_file_data);
     }
-    
+
     /**
-     * Method testEncryptionTest 
-     * @test 
      */
-    public function testDecryptionTest() {
+    private function downloadEncrypted() {
         extract($this->getKeyBindings());
 
         $this->setupAuthenticated();
@@ -127,5 +122,32 @@ class EncryptionTest extends SeleniumTest {
         
         
     }
+    
+    /**
+     * Method testEncryptionTest 
+     * @test 
+     */
+    public function testEncryptionKeyVerZeroTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 0 );        
+        $this->uploadEncrypted();
+    }
+
+    /**
+     * Method testDecryptionTest 
+     * @test 
+     */
+    public function testDecryptionKeyVerZeroTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 0 );        
+        $this->downloadEncrypted();
+    }
+    public function testDecryptionKeyVerZeroOneTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 1 );        
+        $this->downloadEncrypted();
+    }
+
+    
 
 }

--- a/unittests/selenium/tests/EncryptionTest.php
+++ b/unittests/selenium/tests/EncryptionTest.php
@@ -125,6 +125,7 @@ class EncryptionTest extends SeleniumTest {
     
     /**
      * Method testEncryptionTest 
+     * upload a file using key_version = 0
      * @test 
      */
     public function testEncryptionKeyVerZeroTest() {
@@ -148,6 +149,27 @@ class EncryptionTest extends SeleniumTest {
         $this->downloadEncrypted();
     }
 
+
+    /**
+     * Method testEncryptionTest 
+     * upload a file using key_version = 1
+     * @test 
+     */
+    public function testEncryptionKeyVerOneTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 1 );        
+        $this->uploadEncrypted();
+    }
+    public function testDecryptionKeyVerOneTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 0 );        
+        $this->downloadEncrypted();
+    }
+    public function testDecryptionKeyVerOneOneTest() {
+        extract($this->getKeyBindings());
+        $this->setKeyVersionNewFiles( 1 );        
+        $this->downloadEncrypted();
+    }
     
 
 }


### PR DESCRIPTION
This is to help assure that the encryption_key_version_new_files config setting can be changed while allowing transfers that already exist on the server to still be downloaded and decrypted. Much of this has been tested manually, but having it here will help avoid regression.