### PR TITLE
crypto: add new AES-256-GCM encryption modes

### DIFF
--- a/classes/constants/CryptoAppConstants.class.php
+++ b/classes/constants/CryptoAppConstants.class.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * These constants should match the values in www/js/crypter/crypto_app.js
+ * See that file for definitions and documentation.
+ */
+
+class CryptoAppConstants extends Enum
+{
+    const crypto_random_password_octets = 32;
+    
+    // crypto_key_version_constants
+    const v2019_gcm_importKey_deriveKey = 3;
+    const v2019_gcm_digest_importKey    = 2;
+    const v2018_importKey_deriveKey     = 1;
+    const v2017_digest_importKey        = 0;
+
+    // crypto_password_version_constants
+    const v2018_text_password = 1;
+    const v2019_generated_password_that_is_full_256bit = 2;
+    
+}
+
+

--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -241,8 +241,18 @@ class File extends DBObject
         if ($lastChunkPadding == 0) {
             $lastChunkPadding = 16;
         }
-            
-        return $this->size + ($chunksMinusOne * $echunkdiff) + $lastChunkPadding + 16;
+
+        switch( $this->transfer->key_version ) {
+            case CryptoAppConstants::v2018_importKey_deriveKey:
+            case CryptoAppConstants::v2017_digest_importKey:
+                return $this->size + ($chunksMinusOne * $echunkdiff) + $lastChunkPadding + 16;
+            case CryptoAppConstants::v2019_gcm_importKey_deriveKey:
+            case CryptoAppConstants::v2019_gcm_digest_importKey:
+                return $this->size + (($chunksMinusOne+1) * $echunkdiff);
+            default:
+        }
+        // fall through is an error
+        throw new BadCryptoKeyVersionException( $this->transfer->key_version );
     }
 
     /**

--- a/classes/exceptions/BadExceptions.class.php
+++ b/classes/exceptions/BadExceptions.class.php
@@ -189,3 +189,22 @@ class BadAuthIDException extends DetailedException
         );
     }
 }
+
+/**
+ * Bad crypto key version
+ */
+class BadCryptoKeyVersionException extends DetailedException
+{
+    /**
+     * Constructor
+     *
+     * @param string $url
+     */
+    public function __construct($v)
+    {
+        parent::__construct(
+            'bad_crypto_key_version_code', // Message to give to the user
+            array('version' => $v)         // Details to log
+        );
+    }
+}

--- a/www/js/admin_testing.js
+++ b/www/js/admin_testing.js
@@ -86,9 +86,10 @@ $(function() {
             salt:              '123456789',
             password_hash_iterations: cfg.encryption_password_hash_iterations_new_files
         };
-        
+
+        var chunkid = 0;
         var t0 = performance.now();            
-        crypto.encryptBlob( data, encryption_details, function(dataenc) {
+        crypto.encryptBlob( data, chunkid, encryption_details, function(dataenc) {
             var t1 = performance.now();
 
             var l = cryptoperftable.find('.tpl').clone().removeClass('tpl').addClass('benchmark');

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -374,7 +374,8 @@ window.filesender.client = {
                 return uxhr;
             }
         };
-        
+
+        var chunkid = Math.floor(offset / window.filesender.config.upload_chunk_size);
         var $this = this;
         if(encrypted){
             var cryptedBlob = null;
@@ -386,6 +387,7 @@ window.filesender.client = {
             blobReader.readArrayBuffer(function(arrayBuffer){
                 window.filesender.crypto_app().encryptBlob(
                     arrayBuffer,
+                    chunkid,
                     encryption_details,
                     function(encrypted_blob) {
                         var result = $this.put(

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -112,10 +112,13 @@ window.filesender.terasender = {
         if(!file) return null; // Nothing to do
         
         if(!file.endpoint) file.endpoint = this.transfer.authenticatedEndpoint(filesender.config.terasender_upload_endpoint.replace('{file_id}', file.id), file);
+
+        var chunkid = Math.floor(file.uploaded / filesender.config.upload_chunk_size);
         
 	if (typeof file.fine_progress_done === 'undefined') file.fine_progress_done=file.uploaded; //missing from file
         var job = {
             chunk: {
+                id: chunkid,
                 start: file.uploaded,
                 end: Math.min(file.uploaded + filesender.config.upload_chunk_size, file.size) //MD last chunk was too big
             },

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -178,6 +178,7 @@ var terasender_worker = {
 			blobReader.readArrayBuffer(function(arrayBuffer){
 			    window.filesender.crypto_app().encryptBlob(
                                 arrayBuffer,
+                                job.chunk.id,
                                 job.encryption_details,
                                 function (encrypted_blob) {
 				    xhr.setRequestHeader('X-Filesender-Encrypted', '1');

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -859,7 +859,8 @@ filesender.ui.startUpload = function() {
         // as the password is 256 bits of entropy hashing is not needed
         this.transfer.encryption_password_hash_iterations = 1;
     }
-    
+
+
     this.transfer.onprogress = filesender.ui.files.progress;
 
     // if the server wants the aup to be checked then we pass that information


### PR DESCRIPTION
This adds two new key version modes for AES-256-GCM encryption. These mirror the existing AES-256-CBC modes but use GCM (see https://en.wikipedia.org/wiki/Galois/Counter_Mode) for more details than could easily be described here. The implementation uses a design proposed by a cryptographer where the IV is derived using a combination of entropy and a chunk counter to avoid the possibility of IV reuse across chunks.

This has been tested as working across Firefox, Chrome, and Safari. Tests were performed also uploading in one browser and downloading in the others across these choices. These modes do not work in Edge or IE. 

Some more documentation will follow for the encryption_key_version_new_files settings 2 and 3 which enable these new modes using digest_importKey and importKey_deriveKey respectively. The main difference in modes 2 and 3 is the explicit use of PBKDF2 in version 3 in key derivation for user supplied passphrases. If you have the choice, always use mode 3 over mode 2.
