### PR TITLE
GCM updates: IV stored per file, more checks

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -94,6 +94,14 @@ class File extends DBObject
             'size' => 60,
             'null' => true,
             'default' => 'StorageFilesystem'
+        ),
+        // The IV used to encrypt the file.
+        // This is 24 bytes long to allow for storage
+        // of a 128bit array in base64 format
+        'iv' => array(
+            'type' => 'string',
+            'size' => 24,
+            'null' => true
         )
     );
 
@@ -146,6 +154,7 @@ class File extends DBObject
     protected $upload_start = 0;
     protected $upload_end = 0;
     protected $sha1 = null;
+    protected $iv = '';
    
     /**
      * Related objects cache
@@ -462,7 +471,8 @@ class File extends DBObject
     public function __get($property)
     {
         if (in_array($property, array(
-            'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1', 'storage_class_name'
+            'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1'
+          , 'storage_class_name', 'iv'
         ))) {
             return $this->$property;
         }
@@ -552,6 +562,8 @@ class File extends DBObject
             $this->sha1 = (string)$value;
         } elseif ($property == 'storage_class_name') {
             $this->storage_class_name = (string)$value;
+        } elseif ($property == 'iv') {
+            $this->iv = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -511,6 +511,19 @@ class RestEndpointTransfer extends RestEndpoint
                     if ($v && $sz > $v) {
                         throw new TransferMaximumEncryptedFileSizeExceededException($sz, $v);
                     }
+
+                    $key_version = Config::get('encryption_key_version_new_files');
+        
+                    if( $key_version == CryptoAppConstants::v2019_gcm_importKey_deriveKey ||
+                        $key_version == CryptoAppConstants::v2019_gcm_digest_importKey )
+                    {
+                        $v = Config::get('crypto_gcm_max_file_size');
+                        if( $sz > $v ) {
+                            throw new TransferMaximumEncryptedFileSizeExceededException($sz, $v);
+                        }
+                    }
+                    
+                    
                 }
             }
 
@@ -579,6 +592,9 @@ class RestEndpointTransfer extends RestEndpoint
             if ($data->encryption_password_hash_iterations) {
                 $transfer->password_hash_iterations = $data->encryption_password_hash_iterations;
             }
+            if ($data->encryption_client_entropy) {
+                $transfer->client_entropy = $data->encryption_client_entropy;
+            }
             if (Utilities::isTrue($data->encryption)) {
                 // reading the salt will ensure it is made
                 $dummy1 = $transfer->salt;
@@ -608,8 +624,8 @@ class RestEndpointTransfer extends RestEndpoint
                 if (!is_null($banned_exts) && in_array($ext, $banned_exts)) {
                     throw new FileExtensionNotAllowedException($ext);
                 }
-                
-                $file = $transfer->addFile($filedata->name, $filedata->size, $filedata->mime_type);
+
+                $file = $transfer->addFile($filedata->name, $filedata->size, $filedata->mime_type, $filedata->iv );
                 $files_cids[$file->id] = $filedata->cid;
             }
             

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -102,6 +102,8 @@ $default = array(
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used
     'crypto_hash_name' => "SHA-256", // The hash used to convert password to hashencryption_enabled
 
+    'crypto_gcm_max_file_size' => 68719476720, // 16 * (2^32 - 1)   or roughly a little under 64gb.
+
     'terasender_enabled' => true,
     'terasender_disableable' => true,
     'terasender_start_mode' => 'multiple',

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -526,3 +526,6 @@ $lang['calculate'] = 'Calculate';
 $lang['iterations'] = 'Iterations';
 $lang['time_to_complete_ms'] = 'Time to complete (ms)';
 $lang['system_active_setting'] = 'This setting is active on your system';
+
+$lang['decryption_verification_failed_unexpected_ivchunkid'] = 'Decryption of data failed';
+$lang['decryption_verification_failed_bad_ivchunkid'] = 'Decryption of data failed';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -99,6 +99,8 @@
              data-password-version="<?php echo $transfer->password_version; ?>"
              data-password-encoding="<?php echo $transfer->password_encoding_string; ?>"
              data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
+             data-client-entropy="<?php echo $transfer->client_entropy; ?>"
+             data-fileiv="<?php echo $file->iv; ?>"
         >
             
             <span class="select clickable fa fa-2x fa-square-o" title="{tr:select_for_archive_download}"></span>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -112,6 +112,7 @@
             data-password-version="<?php echo $transfer->password_version; ?>"
             data-password-encoding="<?php echo $transfer->password_encoding_string; ?>"
             data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
+            data-client-entropy="<?php echo $transfer->client_entropy; ?>"
         >
             <td class="expand">
                 <span class="clickable fa fa-plus-circle fa-lg" title="{tr:show_details}"></span>
@@ -303,6 +304,8 @@
                              data-password-version="<?php echo $transfer->password_version; ?>"
                              data-password-encoding="<?php echo $transfer->password_encoding_string; ?>"
                              data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
+                             data-client-entropy="<?php echo $transfer->client_entropy; ?>"
+                             data-fileiv="<?php echo $file->iv; ?>"
                         >
                             <?php echo Template::sanitizeOutput($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo count($file->downloads) ?> {tr:downloads}
                             
@@ -318,6 +321,8 @@
                                         data-password-version="<?php echo $transfer->password_version; ?>"
                                         data-password-encoding="<?php echo $transfer->password_encoding_string; ?>"
                                         data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
+                                        data-client-entropy="<?php echo $transfer->client_entropy; ?>"
+                                        data-fileiv="<?php echo $file->iv; ?>"
                                       
                                 ></span>
                                         

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -92,6 +92,7 @@ window.filesender.config = {
     encryption_key_version_new_files: '<?php echo Config::get('encryption_key_version_new_files') ?>',
     encryption_random_password_version_new_files: '<?php echo Config::get('encryption_random_password_version_new_files') ?>',
     encryption_password_hash_iterations_new_files: '<?php echo Config::get('encryption_password_hash_iterations_new_files') ?>',
+    crypto_gcm_max_file_size: '<?php echo Config::get('crypto_gcm_max_file_size') ?>',
 
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -284,9 +284,11 @@ window.filesender.client = {
                 name: transfer.files[i].name,
                 size: transfer.files[i].size,
                 mime_type: transfer.files[i].mime_type,
-                cid: transfer.files[i].cid
+                cid: transfer.files[i].cid,
+                iv: transfer.files[i].iv
             });
         }
+
         return this.post(transfer.authenticatedEndpoint('/transfer'), {
             from: transfer.from,
             encryption: transfer.encryption,
@@ -294,6 +296,7 @@ window.filesender.client = {
             encryption_password_encoding: transfer.encryption_password_encoding,
             encryption_password_version:  transfer.encryption_password_version,
             encryption_password_hash_iterations: transfer.encryption_password_hash_iterations,
+            encryption_client_entropy: transfer.encryption_client_entropy,
             files: files,
             recipients: transfer.recipients,
             subject: transfer.subject,

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -97,6 +97,8 @@ $(function() {
                 var password_version  = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-version');
                 var password_encoding = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-encoding');
                 var password_hash_iterations = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-hash-iterations');
+                var client_entropy = $($this).find("[data-id='" + ids[0] + "']").attr('data-client-entropy');
+                var fileiv = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileiv');
 
                 window.filesender.crypto_app().decryptDownload( filesender.config.base_path
                                                                 + 'download.php?token=' + token
@@ -104,6 +106,8 @@ $(function() {
                                                                 mime, filename, key_version, salt,
                                                                 password_version, password_encoding,
                                                                 password_hash_iterations,
+                                                                client_entropy,
+                                                                window.filesender.crypto_app().decodeCryptoFileIV(fileiv),
                                                                 progress);
             }else{
                 var notify = false;

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -114,6 +114,10 @@ window.filesender.terasender = {
         if(!file.endpoint) file.endpoint = this.transfer.authenticatedEndpoint(filesender.config.terasender_upload_endpoint.replace('{file_id}', file.id), file);
 
         var chunkid = Math.floor(file.uploaded / filesender.config.upload_chunk_size);
+        var encryption_details = this.transfer.getEncryptionMetadata();
+        if( this.transfer.encryption ) {
+            encryption_details['fileiv'] = window.filesender.crypto_app().decodeCryptoFileIV(file.iv);
+        }
         
 	if (typeof file.fine_progress_done === 'undefined') file.fine_progress_done=file.uploaded; //missing from file
         var job = {
@@ -123,13 +127,14 @@ window.filesender.terasender = {
                 end: Math.min(file.uploaded + filesender.config.upload_chunk_size, file.size) //MD last chunk was too big
             },
 	    encryption: this.transfer.encryption,
-	    encryption_details: this.transfer.getEncryptionMetadata(),
+	    encryption_details: encryption_details,
             file: {
                 id: file.id,
                 name: file.name,
                 size: file.size,
                 blob: file.blob,
-                endpoint: file.endpoint
+                endpoint: file.endpoint,
+                iv: file.iv
             },
             security_token: this.security_token,
             csrfptoken: filesender.client.getCSRFToken()

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -183,7 +183,8 @@ var terasender_worker = {
                                 function (encrypted_blob) {
 				    xhr.setRequestHeader('X-Filesender-Encrypted', '1');
 				    xhr.send(encrypted_blob);
-				});
+				},
+                                function (e) { $this.error(e); } );
 			});
 		} else {
 			xhr.send(blob);

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -171,6 +171,7 @@ window.filesender.transfer = function() {
     this.encryption_key_version = 0;
     this.encryption_salt = '';
     this.encryption_password_hash_iterations = filesender.config.encryption_password_hash_iterations_new_files;
+    this.encryption_client_entropy = '';
     this.disable_terasender = 0;
     this.pause_time = 0;
     this.pause_length = 0;
@@ -243,7 +244,8 @@ window.filesender.transfer = function() {
             password_version:  this.encryption_password_version,
             key_version:       this.encryption_key_version,
             salt:              this.encryption_salt,
-            password_hash_iterations: this.encryption_password_hash_iterations
+            password_hash_iterations: this.encryption_password_hash_iterations,
+            client_entropy:    this.encryption_client_entropy
         };
     };
 
@@ -273,8 +275,31 @@ window.filesender.transfer = function() {
                 errorhandler({message: 'maximum_encrypted_file_size_exceeded', details: {size: file.size, max: v  }});
                 return false;
             }
+            if( !this.checkIsValidFileSize( file, errorhandler )) {
+                return false;
+            }
+            
         }
         okHandler(true);
+        return true;
+    };
+
+    /**
+     * Check file size for encryption limits
+     *
+     * @return true if things are ok
+     */
+    this.checkIsValidFileSize = function( file, errorhandler ) {
+
+        if( this.encryption )
+        {
+            if( !window.filesender.crypto_app().isFileSizeValidForEncryption( file.size ))
+            {
+                errorhandler({message: 'maximum_encrypted_file_size_exceeded',
+                              details: {filename: file.name, size: file.size}});
+                return false;
+            }
+        }
         return true;
     };
     
@@ -342,6 +367,9 @@ window.filesender.transfer = function() {
             errorhandler({message: 'empty_file'});
             return false;
         }
+        if( !this.checkIsValidFileSize( file, errorhandler )) {
+            return false;
+        }
         
         if (typeof filesender.config.ban_extension == 'string') {
             var banned = filesender.config.ban_extension.replace(/\s+/g, '');
@@ -383,6 +411,7 @@ window.filesender.transfer = function() {
             return false;
         }
 
+        
         var t = this.checkFileAsStillValid(file, function() {}, errorhandler);
         if( t === false )
             return t;
@@ -1083,11 +1112,23 @@ window.filesender.transfer = function() {
         if (this.files.length > filesender.config.max_transfer_files) {
             return errorhandler({message: 'transfer_too_many_files', details: {max: filesender.config.max_transfer_files}});
         }
+        for (var i = 0; i < this.files.length; i++) {
+            if( !this.checkIsValidFileSize( this.files[i], errorhandler )) {
+                return false;
+            }
+        }
+
+        // Generate IV for each crypted file.
+        if( this.encryption ) {
+            for (var i = 0; i < this.files.length; i++) {
+                this.files[i].iv = window.filesender.crypto_app().generateCryptoFileIV();
+            }
+        }
         
         if (this.size > filesender.config.max_transfer_size) {
             return errorhandler({message: 'transfer_maximum_size_exceeded', details: {size: file.size, max: filesender.config.max_transfer_size}});
         }
-        
+         
         var today = Math.floor((new Date()).getTime() / (24 * 3600 * 1000));
         var minexpires = today - 1;
         var maxexpires = today + filesender.config.max_transfer_days_valid + 1;
@@ -1100,6 +1141,10 @@ window.filesender.transfer = function() {
         filesender.ui.log('Creating transfer');
         
         this.time = (new Date()).getTime();
+
+        if( this.encryption ) {
+            this.encryption_client_entropy = window.filesender.crypto_app().generateClientEntropy();
+        }
         
         var transfer = this;
         filesender.client.postTransfer(this, function(path, data) {

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -374,7 +374,9 @@ $(function() {
         var password_version  = $(this).attr('data-password-version');
         var password_encoding = $(this).attr('data-password-encoding');
         var password_hash_iterations = $(this).attr('data-password-hash-iterations');
-
+        var client_entropy = $(this).attr('data-client-entropy');
+        var fileiv = $(this).attr('data-fileiv');
+        
         if (typeof id == 'string'){
             id = [id];
         }
@@ -382,7 +384,9 @@ $(function() {
             filesender.config.base_path + 'download.php?files_ids=' + id.join(','),
             mime, filename, key_version, salt,
             password_version, password_encoding,
-            password_hash_iterations
+            password_hash_iterations,
+            client_entropy,
+            window.filesender.crypto_app().decodeCryptoFileIV(fileiv)
         );
 
         return false;


### PR DESCRIPTION
A random IV is now created client side and stored in the database for
each uploaded file (the fileiv). That IV is 12 octets long for GCM
mode and 16 octets (unused) for CBC.

The fileiv is now used to set the first 12 octets of the IV for a file
during upload for GCM files.

For GCM: The fileiv is verified against the IV for each filesender chunk during
decode to ensure that it is the same for the IV for each filesender
chunk for the file.

The chunkid is extracted from the IV for each filesender chunk to
verify that it has the correct value (it is for this filesender chunk).

When the FileSender chunkid is encoded and decoded to an encryption IV
it is now expaned to cater for the FileSender upload_chunk_size and
contracted back during a decode. The exact value setting of the
chunkid needs to be more relative to the AES chunk size when used in
an IV than the filesender chunk number.

An explicit check that a file does not exceed the maximum size for GCM
is done in many places both on the client and server side. This uses the
internal constant crypto_gcm_max_file_size set in ConfigDefaults.php.

A client_entropy pool of 32 octets is now also uploaded from the
client to the server at transfer creation time in perparation for
future use.
