### PR TITLE
GCM: AEAD version 1 to ensure whole file and iv

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -102,6 +102,20 @@ class File extends DBObject
             'type' => 'string',
             'size' => 24,
             'null' => true
+        ),
+        // For encrypted files and encryption algorithms that
+        // support AEAD this is the string that the client sent
+        // and is needed during decryption.
+        //
+        // This is base64 encoded by the client because we, as the server,
+        // can not really use it for much. After a base64 decoude it should
+        // be a JSON object which uses the aeadversion field to version itself.
+        // Note that it is encoded manually into JSON on the client side
+        // so that it is a canonical representation
+        'aead' => array(
+            'type' => 'string',
+            'size' => 512,
+            'null' => true
         )
     );
 
@@ -155,6 +169,7 @@ class File extends DBObject
     protected $upload_end = 0;
     protected $sha1 = null;
     protected $iv = '';
+    protected $aead = null;
    
     /**
      * Related objects cache
@@ -472,7 +487,7 @@ class File extends DBObject
     {
         if (in_array($property, array(
             'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1'
-          , 'storage_class_name', 'iv'
+          , 'storage_class_name', 'iv', 'aead'
         ))) {
             return $this->$property;
         }
@@ -564,6 +579,8 @@ class File extends DBObject
             $this->storage_class_name = (string)$value;
         } elseif ($property == 'iv') {
             $this->iv = $value;
+        } elseif ($property == 'aead') {
+            $this->aead = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -996,7 +996,7 @@ class Transfer extends DBObject
      *
      * @return File
      */
-    public function addFile($path, $size, $mime_type = null, $iv = null )
+    public function addFile($path, $size, $mime_type = null, $iv = null, $aead = null )
     {
         if (is_null($this->filesCache)) {
             $this->filesCache = File::fromTransfer($this);
@@ -1018,6 +1018,7 @@ class Transfer extends DBObject
         // Create and save new file
         $file = File::create($this, $path, $size, $mime_type);
         $file->iv = $iv;
+        $file->aead = $aead;
         $file->save();
  
         // Update local cache

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -625,7 +625,8 @@ class RestEndpointTransfer extends RestEndpoint
                     throw new FileExtensionNotAllowedException($ext);
                 }
 
-                $file = $transfer->addFile($filedata->name, $filedata->size, $filedata->mime_type, $filedata->iv );
+                $file = $transfer->addFile($filedata->name, $filedata->size, $filedata->mime_type,
+                                           $filedata->iv, $filedata->aead );
                 $files_cids[$file->id] = $filedata->cid;
             }
             

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -529,3 +529,6 @@ $lang['system_active_setting'] = 'This setting is active on your system';
 
 $lang['decryption_verification_failed_unexpected_ivchunkid'] = 'Decryption of data failed';
 $lang['decryption_verification_failed_bad_ivchunkid'] = 'Decryption of data failed';
+$lang['decryption_verification_failed_bad_fixed_iv'] = 'Part of the IV for the encrypted file does not match what it should be. This is unlikely and suggests that something may have changed from the data that was being sent to the server.';
+$lang['decryption_verification_failed_bad_aead'] = 'Some encrypted files are protected with AEAD which allows FileSender to check the integrity of the file. It was found that the AEAD data does not match the expected value for this file so decryption was halted for your protection.';
+

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -101,6 +101,7 @@
              data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
              data-client-entropy="<?php echo $transfer->client_entropy; ?>"
              data-fileiv="<?php echo $file->iv; ?>"
+             data-fileaead="<?php echo $file->aead; ?>"
         >
             
             <span class="select clickable fa fa-2x fa-square-o" title="{tr:select_for_archive_download}"></span>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -306,6 +306,7 @@
                              data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
                              data-client-entropy="<?php echo $transfer->client_entropy; ?>"
                              data-fileiv="<?php echo $file->iv; ?>"
+                             data-fileaead="<?php echo $file->aead; ?>"
                         >
                             <?php echo Template::sanitizeOutput($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo count($file->downloads) ?> {tr:downloads}
                             
@@ -323,6 +324,7 @@
                                         data-password-hash-iterations="<?php echo $transfer->password_hash_iterations; ?>"
                                         data-client-entropy="<?php echo $transfer->client_entropy; ?>"
                                         data-fileiv="<?php echo $file->iv; ?>"
+                                        data-fileaead="<?php echo $file->aead; ?>"
                                       
                                 ></span>
                                         

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -280,12 +280,21 @@ window.filesender.client = {
             
         var files = [];
         for (var i = 0; i < transfer.files.length; i++) {
+            //
+            // Do not btoa an empty string, if there is nothing to send
+            // then just send nothing.
+            //
+            var aead = '';
+            if( transfer.files[i].aead ) {
+                aead = btoa(transfer.files[i].aead);
+            }
             files.push({
                 name: transfer.files[i].name,
                 size: transfer.files[i].size,
                 mime_type: transfer.files[i].mime_type,
                 cid: transfer.files[i].cid,
-                iv: transfer.files[i].iv
+                iv: transfer.files[i].iv,
+                aead: aead 
             });
         }
 

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -98,8 +98,11 @@ $(function() {
                 var password_encoding = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-encoding');
                 var password_hash_iterations = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-hash-iterations');
                 var client_entropy = $($this).find("[data-id='" + ids[0] + "']").attr('data-client-entropy');
-                var fileiv = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileiv');
-
+                var fileiv   = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileiv');
+                var fileaead = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileaead');
+                if( fileaead.length ) {
+                    fileaead = atob(fileaead);
+                }
                 window.filesender.crypto_app().decryptDownload( filesender.config.base_path
                                                                 + 'download.php?token=' + token
                                                                 + '&files_ids=' + ids.join(','),
@@ -108,6 +111,7 @@ $(function() {
                                                                 password_hash_iterations,
                                                                 client_entropy,
                                                                 window.filesender.crypto_app().decodeCryptoFileIV(fileiv),
+                                                                fileaead,
                                                                 progress);
             }else{
                 var notify = false;

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -116,7 +116,8 @@ window.filesender.terasender = {
         var chunkid = Math.floor(file.uploaded / filesender.config.upload_chunk_size);
         var encryption_details = this.transfer.getEncryptionMetadata();
         if( this.transfer.encryption ) {
-            encryption_details['fileiv'] = window.filesender.crypto_app().decodeCryptoFileIV(file.iv);
+            encryption_details['fileiv']   = window.filesender.crypto_app().decodeCryptoFileIV(file.iv);
+            encryption_details['fileaead'] = file.aead;
         }
         
 	if (typeof file.fine_progress_done === 'undefined') file.fine_progress_done=file.uploaded; //missing from file
@@ -134,7 +135,8 @@ window.filesender.terasender = {
                 size: file.size,
                 blob: file.blob,
                 endpoint: file.endpoint,
-                iv: file.iv
+                iv: file.iv,
+                aead: file.aead
             },
             security_token: this.security_token,
             csrfptoken: filesender.client.getCSRFToken()

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -1118,11 +1118,25 @@ window.filesender.transfer = function() {
             }
         }
 
-        // Generate IV for each crypted file.
+        // No AEAD unless we explicitly set some below for encrypted files.
+        for (var i = 0; i < this.files.length; i++) {
+            this.files[i].aead = '';
+        }
+        
         if( this.encryption ) {
+            var crypter = window.filesender.crypto_app();
+            
+            // Generate IV for each crypted file.
             for (var i = 0; i < this.files.length; i++) {
-                this.files[i].iv = window.filesender.crypto_app().generateCryptoFileIV();
+                this.files[i].iv = crypter.generateCryptoFileIV();
             }
+
+            // Setup AEAD if we can use it
+            for (var i = 0; i < this.files.length; i++) {
+                this.files[i].aead = crypter.encodeAEAD(
+                    crypter.generateAEAD( this.files[i] ));
+            }
+            
         }
         
         if (this.size > filesender.config.max_transfer_size) {

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -376,6 +376,10 @@ $(function() {
         var password_hash_iterations = $(this).attr('data-password-hash-iterations');
         var client_entropy = $(this).attr('data-client-entropy');
         var fileiv = $(this).attr('data-fileiv');
+        var fileaead = $(this).attr('data-fileaead');
+        if( fileaead.length ) {
+            fileaead = atob(fileaead);
+        }
         
         if (typeof id == 'string'){
             id = [id];
@@ -386,7 +390,8 @@ $(function() {
             password_version, password_encoding,
             password_hash_iterations,
             client_entropy,
-            window.filesender.crypto_app().decodeCryptoFileIV(fileiv)
+            window.filesender.crypto_app().decodeCryptoFileIV(fileiv),
+            fileaead
         );
 
         return false;


### PR DESCRIPTION
This introduces the use of AEAD for GCM mode encrypted files.

https://en.wikipedia.org/wiki/Authenticated_encryption#Authenticated_encryption_with_associated_data_(AEAD)

AEAD is used to ensure that the chunk size has not changed and that exactly the number of filesender chunks that should be received are received. The random 96 bits of the encryption IV for a file are also stored in AEAD and asserted to be the same as the 96 bits of entropy of a fileiv on decrypt.

As the filesender chunk size and number of chunks are in AEAD the client ensures that the chunk size has not changed after encryption and that the server has sent exactly the correct number of filesender chunks to the client. Changing the filesender chunk size (the value of upload_chunk_size in config.php) is unlikely to happen on a production server as that would lead to many other potential issues but it is also checked to have not changed after a file was encrypted explicitly in GCM encrypted files to ensure consistency.

NOTE: GCM encrypted files do not allow upload_chunk_size to vary.

Some implementation notes:

As a convenience the AEAD is base64 encoded by the client to be stored on the server. Generation of the AEAD and validation of the AEAD against the encrypted data both happen on the client. This allows the JSON object to be sent through form fields by the server for example.

The encoding to string of the javascript aead object is handled by encodeAEAD() which manually writes JSON to ensure that whitespace and field ordering is explicit because this string representation of the AEAD is what is bound to the encrypted data. The aeadversion field is used to allow more data in the AEAD string in the future while being backwards compatible.