### PR TITLE
GCM: we can relax the IV counter. New chunk max size checks

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -521,6 +521,11 @@ class RestEndpointTransfer extends RestEndpoint
                         if( $sz > $v ) {
                             throw new TransferMaximumEncryptedFileSizeExceededException($sz, $v);
                         }
+                        $numchunks = ceil($sz / Config::get('upload_chunk_size'));
+                        $v = Config::get('crypto_gcm_max_chunk_count');
+                        if( $numchunks > $v ) {
+                            throw new TransferMaximumEncryptedFileSizeExceededException($sz, $v);
+                        }
                     }
                     
                     

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -276,6 +276,9 @@ class Config
             throw new ConfigBadParameterException('Generated password length must be equal or greater than encryption_min_password_length');
         }
 
+        // If the admin has very small chunks then they will have a smaller max file size.
+        self::$parameters['crypto_gcm_max_file_size'] = 4294967296 * self::$parameters['upload_chunk_size'];
+
 
         $relay_to = Config::get('relay_unknown_feedbacks');
         switch($relay_to) {

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -278,7 +278,9 @@ class Config
 
         // If the admin has very small chunks then they will have a smaller max file size.
         self::$parameters['crypto_gcm_max_file_size'] = 4294967296 * self::$parameters['upload_chunk_size'];
-
+        self::$parameters['crypto_gcm_max_chunk_size']  = 4294967295 * 16;
+        self::$parameters['crypto_gcm_max_chunk_count'] = 4294967295;
+        
 
         $relay_to = Config::get('relay_unknown_feedbacks');
         switch($relay_to) {

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -102,8 +102,9 @@ $default = array(
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used
     'crypto_hash_name' => "SHA-256", // The hash used to convert password to hashencryption_enabled
 
-    'crypto_gcm_max_file_size'  => 4294967296 * 5 * 1024 * 1024, // 4294967296 times 5 MB or roughly 16384 tb.
-    'crypto_gcm_max_chunk_size' => 4294967295 * 16,              // 2^32-1 AES blocks of 16 bytes.
+    'crypto_gcm_max_file_size'   => 4294967296 * 5 * 1024 * 1024, // 4294967296 times 5 MB or roughly 16384 tb.
+    'crypto_gcm_max_chunk_size'  => 4294967295 * 16,              // 2^32-1 AES blocks of 16 bytes.
+    'crypto_gcm_max_chunk_count' => 4294967295,                   // 2^32-1
 
     'terasender_enabled' => true,
     'terasender_disableable' => true,

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -102,7 +102,8 @@ $default = array(
     'crypto_crypt_name' => "AES-CBC", // The encryption algorithm used
     'crypto_hash_name' => "SHA-256", // The hash used to convert password to hashencryption_enabled
 
-    'crypto_gcm_max_file_size' => 68719476720, // 16 * (2^32 - 1)   or roughly a little under 64gb.
+    'crypto_gcm_max_file_size'  => 4294967296 * 5 * 1024 * 1024, // 4294967296 times 5 MB or roughly 16384 tb.
+    'crypto_gcm_max_chunk_size' => 4294967295 * 16,              // 2^32-1 AES blocks of 16 bytes.
 
     'terasender_enabled' => true,
     'terasender_disableable' => true,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -94,6 +94,7 @@ window.filesender.config = {
     encryption_password_hash_iterations_new_files: '<?php echo Config::get('encryption_password_hash_iterations_new_files') ?>',
     crypto_gcm_max_file_size: '<?php echo Config::get('crypto_gcm_max_file_size') ?>',
     crypto_gcm_max_chunk_size: '<?php echo Config::get('crypto_gcm_max_chunk_size') ?>',
+    crypto_gcm_max_chunk_count: '<?php echo Config::get('crypto_gcm_max_chunk_count') ?>',
 
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -93,6 +93,7 @@ window.filesender.config = {
     encryption_random_password_version_new_files: '<?php echo Config::get('encryption_random_password_version_new_files') ?>',
     encryption_password_hash_iterations_new_files: '<?php echo Config::get('encryption_password_hash_iterations_new_files') ?>',
     crypto_gcm_max_file_size: '<?php echo Config::get('crypto_gcm_max_file_size') ?>',
+    crypto_gcm_max_chunk_size: '<?php echo Config::get('crypto_gcm_max_chunk_size') ?>',
 
     upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -388,7 +388,14 @@ window.filesender.crypto_app = function () {
                     return callbackError({message: 'maximum_encrypted_file_size_exceeded',
                                           details: {}});
                 }
-                
+
+                //
+                // Not too many chunks.
+                //
+                if( chunkid > window.filesender.config.crypto_gcm_max_chunk_count ) {
+                    return callbackError({message: 'maximum_encrypted_file_size_exceeded',
+                                          details: {}});
+                }
             }
 
             


### PR DESCRIPTION
It was found that we can move to using the filesender chunkid directly in the formation of the IV.