### PR TITLE
AEAD: only generate and store one for GCM modes where it is useful

### DIFF
--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -177,11 +177,20 @@ window.filesender.crypto_app = function () {
          */
         generateAEAD: function( file ) {
             var $this = this;
-            return {
-                chunkcount: Math.ceil( file.size / window.filesender.config.upload_chunk_size ),
-                chunksize: window.filesender.config.upload_chunk_size,
-                iv: file.iv
-            };
+
+            var key_version = window.filesender.config.encryption_key_version_new_files;
+            
+            // AES-GCM modes can make use of AEAD
+            if( key_version == $this.crypto_key_version_constants.v2019_gcm_digest_importKey ||
+                key_version == $this.crypto_key_version_constants.v2019_gcm_importKey_deriveKey )
+            {
+                return {
+                    chunkcount: Math.ceil( file.size / window.filesender.config.upload_chunk_size ),
+                    chunksize: window.filesender.config.upload_chunk_size,
+                    iv: file.iv
+                };
+            }
+            return null;
         },
         /**
          * This uses direct printing to produce a canonical string representation
@@ -196,6 +205,10 @@ window.filesender.crypto_app = function () {
          * as new fields are added in the future.
          */
         encodeAEAD: function( aead ) {
+            if( !aead ) {
+                return '';
+            }
+            
             var $this = this;
 
             var ret = "{";

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -1133,8 +1133,10 @@ window.filesender.transfer = function() {
 
             // Setup AEAD if we can use it
             for (var i = 0; i < this.files.length; i++) {
-                this.files[i].aead = crypter.encodeAEAD(
-                    crypter.generateAEAD( this.files[i] ));
+                var aead = crypter.generateAEAD( this.files[i] );
+                if( aead ) {
+                    this.files[i].aead = crypter.encodeAEAD( aead );
+                }
             }
             
         }


### PR DESCRIPTION
There isn't much point to making and storing the AEAD for the AES-CBC cipher modes.