### PR TITLE
dbconstant validator active and will die if invalid data given

### DIFF
--- a/classes/data/constants/DBConstantPasswordEncoding.class.php
+++ b/classes/data/constants/DBConstantPasswordEncoding.class.php
@@ -62,11 +62,11 @@ class DBConstantPasswordEncoding extends DBConstant
 
     static function validateCGIParamOrDIE( $v )
     {
-//        if (!preg_match('`^[a-z_]{1,40}$`', $v)) {
+	if (!preg_match('`^[a-z_0-9]{1,40}$`', $v)) {
             Logger::error('xxx invalid data given to validateCGIParamOrDIE v ' . $v );
-//            exit(1);
-//        }
-        self::lookup($v);
+            exit(1);
+	} 
+	self::lookup($v);
         return $v;
     }
 


### PR DESCRIPTION
Main change is the last part of the file where the regex is enabled again and the error message only displayed on invalid data. Also the function will die on invalid now too.
I'm not sure why this was non unix formatting, that is why it is a small file replace.