### PR TITLE
crypto: cache keys if possible to avoid redundant work

### DIFF
--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -14,6 +14,10 @@ Uint8Array.prototype.equals = function (a) {
     return this.length === a.length && this.every(function(value, index) { return value === a[index]});
 }
 
+if (!('key_cache' in window.filesender)) {
+    window.filesender.key_cache = new Map();
+}
+
 window.filesender.crypto_app = function () {
     return {
         crypto_is_supported: true,
@@ -59,6 +63,7 @@ window.filesender.crypto_app = function () {
             //
             v2019_generated_password_that_is_full_256bit: 2
         },
+        
 
         /**
          * This turns a filesender chunkid into a 4 byte array
@@ -226,9 +231,21 @@ window.filesender.crypto_app = function () {
         generateVector: function () {
             return crypto.getRandomValues(new Uint8Array(16));
         },
+        generateIV: function( chunkid, encryption_details )
+        {
+            var $this = this;
+            var key_version = encryption_details.key_version;
+            
+            var iv = this.generateVector();
+            if( key_version == $this.crypto_key_version_constants.v2019_gcm_importKey_deriveKey )
+            {
+                // IV has a predefined mix of entropy and chunk counter
+                iv = $this.createIVGCM( chunkid, encryption_details );
+            }
+            return iv;
+        },
         generateKey: function (chunkid, encryption_details, callback, callbackError) {
             var $this = this;
-            var iv = this.generateVector();
             var password    = encryption_details.password;
             var key_version = encryption_details.key_version;
             var salt        = encryption_details.salt;
@@ -247,6 +264,23 @@ window.filesender.crypto_app = function () {
                 callbackError(e);
             };
 
+            //
+            // Force the GCM/CBC crypt_name at the top to make this change explicit before
+            // the code that does the key generation is executed. Doing this here makes the
+            // crypto code less cuttered below.
+            //
+            if( key_version == $this.crypto_key_version_constants.v2019_gcm_importKey_deriveKey 
+                || key_version == $this.crypto_key_version_constants.v2019_gcm_digest_importKey )
+            {
+                window.filesender.config.crypto_crypt_name = "AES-GCM";
+                this.crypto_crypt_name = window.filesender.config.crypto_crypt_name;
+            }
+            else
+            {
+                window.filesender.config.crypto_crypt_name = "AES-CBC";
+                this.crypto_crypt_name = window.filesender.config.crypto_crypt_name;
+            }
+            
             
             if( key_version == $this.crypto_key_version_constants.v2018_importKey_deriveKey )
             {
@@ -267,26 +301,19 @@ window.filesender.crypto_app = function () {
                         },
                         dkey,
                         { "name":   'AES-CBC',
-                          "length": 256,
-                          iv:       iv
+                          "length": 256
                         },
                         false,                   // key is not extractable
                         [ "encrypt", "decrypt" ] // features desired
                     ).then(function (key) {
                     
-                        callback(key, iv);
+                        callback(key);
                     }, efunc );
                 }, efunc );
             }
 
             if( key_version == $this.crypto_key_version_constants.v2019_gcm_importKey_deriveKey )
             {
-                window.filesender.config.crypto_crypt_name = "AES-GCM";
-                this.crypto_crypt_name = window.filesender.config.crypto_crypt_name;
-
-                // IV has a predefined mix of entropy and chunk counter
-                iv = $this.createIVGCM( chunkid, encryption_details );
-
                 crypto.subtle.importKey(
                     'raw', 
                     passwordBuffer,
@@ -304,15 +331,12 @@ window.filesender.crypto_app = function () {
                         dkey,
                         { "name":   'AES-GCM',
                           "length": 256
-                          // Note that passing the IV here does nothing as we are not encrypting anything
-                          // tested by passing a random value here that is not the same during a call from
-                          // decryptBlob()
                         },
                         false,                   // key is not extractable
                         [ "encrypt", "decrypt" ] // features desired
                     ).then(function (key) {
                     
-                        callback(key, iv);
+                        callback(key);
                     }, efunc );
                 }, efunc );
 
@@ -325,11 +349,11 @@ window.filesender.crypto_app = function () {
                     passwordBuffer
                 ).then( function (key) {
                     crypto.subtle.importKey("raw", key,
-                                            {name: $this.crypto_crypt_name, iv: iv},
+                                            {name: $this.crypto_crypt_name},
                                             false,
                                             ["encrypt", "decrypt"]
                                            ).then( function (key) {
-                                               callback(key, iv);
+                                               callback(key);
                                            }, function (e) {
                                                // error making a key
                                                window.filesender.ui.log(e);
@@ -344,12 +368,6 @@ window.filesender.crypto_app = function () {
 
             if( key_version == $this.crypto_key_version_constants.v2019_gcm_digest_importKey )
             {
-                window.filesender.config.crypto_crypt_name = "AES-GCM";
-                this.crypto_crypt_name = window.filesender.config.crypto_crypt_name;
-
-                // IV has a predefined mix of entropy and chunk counter
-                iv = $this.createIVGCM( chunkid, encryption_details );
-                
                 crypto.subtle.digest(
                     {name: this.crypto_hash_name},
                     passwordBuffer
@@ -359,7 +377,7 @@ window.filesender.crypto_app = function () {
                                             false,
                                             ["encrypt", "decrypt"]
                                            ).then( function (key) {
-                                               callback(key, iv);
+                                               callback(key);
                                            }, function (e) {
                                                // error making a key
                                                window.filesender.ui.log(e);
@@ -373,6 +391,40 @@ window.filesender.crypto_app = function () {
             
             
         },
+
+
+        /**
+         * This puts a cache between the call to generateKey() only
+         * doing the work if the key has not already been generated.
+         */
+        obtainKey: function (chunkid, encryption_details, callback, callbackError) {
+            var $this = this;
+
+            var keydesc = JSON.stringify(encryption_details);
+            console.log("keygen: keydesc cache size " + window.filesender.key_cache.size );
+            
+            var k = window.filesender.key_cache.get( keydesc );
+            if( k ) {
+                console.log("keygen: reusing existing key");
+                callback( k );
+                return;
+            }
+
+            // there was no key, really generate one and set it in the
+            // cache before calling the passed 'ok' callback.
+            console.log("keygen: generating key for this thread/worker");
+            this.generateKey(chunkid, encryption_details,
+                             function (key) {
+                                 window.filesender.key_cache.set(keydesc, key );
+                                 callback( key );
+                             },
+                             function (e) {
+                                 callbackError(e);
+                             });
+                                     
+        },
+
+        
         encryptBlob: function (value, chunkid, encryption_details, callback, callbackError ) {
             var $this = this;
             var key_version = encryption_details.key_version;
@@ -412,7 +464,9 @@ window.filesender.crypto_app = function () {
             }
 
             
-            this.generateKey(chunkid, encryption_details, function (key, iv) {
+            this.obtainKey(chunkid, encryption_details, function (key) {
+
+                var iv = $this.generateIV( chunkid, encryption_details );
 
                 /*
                  * The algorithm parameters include the algorithm name to use
@@ -461,7 +515,7 @@ window.filesender.crypto_app = function () {
                 );
             },
             function (e) {
-                // error occured during generatekey
+                // error occured during obtainkey
                 window.filesender.ui.log(e);
             });
         },
@@ -530,7 +584,7 @@ window.filesender.crypto_app = function () {
 
             try {
                 var chunkid = 0;
-                this.generateKey(chunkid, encryption_details, function (key) {
+                this.obtainKey(chunkid, encryption_details, function (key) {
 		    var wrongPassword = false;
 		    var decryptLoop = function(i) {
                         
@@ -614,7 +668,7 @@ window.filesender.crypto_app = function () {
 		    decryptLoop(0);
                 },
                 function (e) {
-                    // error occured during generatekey
+                    // error occured during obtainkey
                     window.filesender.ui.log(e);
                 });
             }


### PR DESCRIPTION
This will cache keys where possible to avoid unnecessary recomputation.

Previously generateKey() would be called for every chunk uploaded. This can cause performance issues when large password hash counts (https://www.w3.org/TR/WebCryptoAPI/#pbkdf2-params) are in use as they will be calculated for each chunk uploaded rather than once for an upload or upload-worker thread. Such hash counts may incur a 30 second delay for hash iterations alone. This is a direct trade where a longer time spent in hash iterations makes it more time consuming for an attacker to try to guess a password.

Looking at the filesender-2.10 code one will notice that generateKey() will also generate and reference a new IV for each time it is called (each chunk). That IV handling was expressly overridden in GCM mode because the IV was constructed as a fixed part per file with a counter. Keys were still needlessly regenerated in both CBC and GCM modes.

The code in filesender-2.10 tag in generateKey() would generate an IV and pass that to the key generation function such as deriveKey(). The generateKey() would then pass the IV back to the encrypting code for use during the encryption. Note however that the IV used during key generation was not supplied or reused during decryption https://github.com/filesender/filesender/blob/filesender-2.10/www/js/crypter/crypto_app.js#L533. This is fine as the key generation parameters do not include the IV as shown here https://www.w3.org/TR/WebCryptoAPI/#dfn-AesKeyGenParams and in the parent class https://www.w3.org/TR/WebCryptoAPI/#dfn-Algorithm. The parameter provision for AES is only the length in bits of the key and the algorithm name. So the WebCrypto API was ignoring the passed IV at key generation time. This reasoning is needed in order to reuse the key as the IV does not effect the key generation API.

Tests have been performed with uploads created using filesender-2.10 with key mode 0, 1, 2, and 3. Uploads were done in user supplied and generated password modes giving a total of 8 test uploads. The test file was 28.7mb in size using 4 terasender workers and a 4mb upload chunk size. All of these existing encrypted uploads could download fine with this PR.

For performance testing a file of 387mb size in key mode 3 was used to upload on a local gigabit LAN. It was found that one might see a performance increase of perhaps 10% in Firefox using this code over filesender-2.10.  That is, all config.php remaining static and changing only the installed code to compare the filesender-2.10 tag to this PR. More rigorous testing with repeated batches of 10 and averaging will be needed for any conclusive performance test. Performance numbers were gathered from the database upload times using the following query:

```
select id,created,made_available,(made_available-created) as time,key_version 
from Transfers order by id desc limit 10;
```

This relates to issue https://github.com/filesender/filesender/issues/374.
