### PR TITLE
Put configured days valid into Python API client

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -40,7 +40,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 #settings
 base_url = '[base_url]'
-default_transfer_days_valid = 20
+default_transfer_days_valid = 10
 
 #argv
 parser = argparse.ArgumentParser()

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -36,10 +36,10 @@ $one=1;
 $script=file_get_contents('../scripts/client/filesender.py');
 
 $apipath=Config::get('site_url').'rest.php';
-$daysvalid='default_transfer_days_valid = '.Config::get('default_transfer_days_valid');
+$daysvalid=Config::get('default_transfer_days_valid');
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
-$script=str_replace('default_transfer_days_valid = 10',$daysvalid,$script,$one);
+$script=preg_replace('/(default_transfer_days_valid).*/', '$1 = '.$daysvalid,$script);
 
 header('Content-Description: File Transfer');
 header('Content-Type: application/octet-stream');

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -36,8 +36,10 @@ $one=1;
 $script=file_get_contents('../scripts/client/filesender.py');
 
 $apipath=Config::get('site_url').'rest.php';
+$daysvalid='default_transfer_days_valid = '.Config::get('default_transfer_days_valid');
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
+$script=str_replace('default_transfer_days_valid = 10',$daysvalid,$script,$one);
 
 header('Content-Description: File Transfer');
 header('Content-Type: application/octet-stream');


### PR DESCRIPTION
Instead of hard-coding a value that doesn't even match the default value in `includes/ConfigDefaults.php`.