### PR TITLE
small update to pr 677 to tighten the regex

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -40,7 +40,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 #settings
 base_url = '[base_url]'
-default_transfer_days_valid = 20
+default_transfer_days_valid = 10
 
 #argv
 parser = argparse.ArgumentParser()

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -36,8 +36,10 @@ $one=1;
 $script=file_get_contents('../scripts/client/filesender.py');
 
 $apipath=Config::get('site_url').'rest.php';
+$daysvalid=Config::get('default_transfer_days_valid');
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
+$script=preg_replace('/(default_transfer_days_valid).*/', '$1 = '.$daysvalid,$script);
 
 header('Content-Description: File Transfer');
 header('Content-Type: application/octet-stream');

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -39,7 +39,9 @@ $apipath=Config::get('site_url').'rest.php';
 $daysvalid=Config::get('default_transfer_days_valid');
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
-$script=preg_replace('/(default_transfer_days_valid).*/', '$1 = '.$daysvalid,$script);
+$script=preg_replace("/\ndefault_transfer_days_valid[ =]*[0-9]+\n/",
+                     "\ndefault_transfer_days_valid = $daysvalid\n",
+                     $script);
 
 header('Content-Description: File Transfer');
 header('Content-Type: application/octet-stream');

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -39,7 +39,7 @@ $apipath=Config::get('site_url').'rest.php';
 $daysvalid=Config::get('default_transfer_days_valid');
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
-$script=preg_replace("/\ndefault_transfer_days_valid[ =]*[0-9]+\n/",
+$script=preg_replace("/\ndefault_transfer_days_valid[ ]*=[ ]*[0-9]+\n/",
                      "\ndefault_transfer_days_valid = $daysvalid\n",
                      $script);
 


### PR DESCRIPTION
Thanks to @peter- for PR 677 which found this issue and suggested a good solution to it. This is a slight update to https://github.com/filesender/filesender/pull/677 to make the regex more specific so that it can only match on the variable declaration line. I found that 677 would substitute on the line https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py#L149 as well with unintended side effects. It is also tempting to use ^ and $ to limit the match scope but as the script is passed as a single string that would not match. Thus the fallback to using the newline to limit the match to only the variable declaration.

Maybe in the future we are better off building a map of configuration names that should be substituted and looping over that map doing a substitution of each configuration setting with a restrictive regex like the one in this PR. Such a solution would allow new config variables to be referenced without needing to tinker with regexes.