### PR TITLE
guests: better handling of do not expire

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -582,10 +582,6 @@ class Guest extends DBObject
         }
         return false;
     }
-    public function does_not_expire()
-    {
-        return $this->getOption(GuestOptions::DOES_NOT_EXPIRE);
-    }
     
     /**
      * Delete the guest related objects
@@ -693,6 +689,37 @@ class Guest extends DBObject
             $identity = explode('@', $this->email);
             return $identity[0];
         }
+
+        //
+        // Simple access to $this->options 
+        //
+        if ($property == 'does_not_expire') {
+            return $this->getOption(GuestOptions::DOES_NOT_EXPIRE);
+        }
+        if ($property == 'email_upload_started') {
+            return $this->getOption(GuestOptions::EMAIL_UPLOAD_STARTED);
+        }
+        if ($property == 'email_upload_page_access') {
+            return $this->getOption(GuestOptions::EMAIL_UPLOAD_PAGE_ACCESS);
+        }
+        if ($property == 'valid_only_one_time') {
+            return $this->getOption(GuestOptions::VALID_ONLY_ONE_TIME);
+        }
+        if ($property == 'can_only_send_to_me') {
+            return $this->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME);
+        }
+        if ($property == 'email_guest_created') {
+            return $this->getOption(GuestOptions::EMAIL_GUEST_CREATED);
+        }
+        if ($property == 'email_guest_created') {
+            return $this->getOption(GuestOptions::EMAIL_GUEST_CREATED);
+        }
+        if ($property == 'email_guest_created_receipt') {
+            return $this->getOption(GuestOptions::EMAIL_GUEST_CREATED_RECEIPT);
+        }
+        if ($property == 'email_guest_created_expired') {
+            return $this->getOption(GuestOptions::EMAIL_GUEST_EXPIRED);
+        }
         
         throw new PropertyAccessException($this, $property);
     }
@@ -738,7 +765,7 @@ class Guest extends DBObject
             $this->email = (string)$value;
         } elseif ($property == 'expires' || $property == 'last_activity') {
 
-            if($property == 'expires' && $this->does_not_expire() && is_null($value))
+            if($property == 'expires' && $this->does_not_expire && is_null($value))
             {
                 $this->$property = $value;
             }

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -388,6 +388,9 @@ class Guest extends DBObject
      */
     public function isExpired()
     {
+        if( is_null($this->expires)) {
+            return false;
+        }
         $today = (24 * 3600) * floor(time() / (24 * 3600));
         return $this->expires < $today;
     }
@@ -400,6 +403,9 @@ class Guest extends DBObject
      */
     public function isExpiredDaysAgo($days)
     {
+        if( is_null($this->expires)) {
+            return false;
+        }
         $d = (24 * 3600) * floor(time() / (24 * 3600) - ($days * (24*3600)));
         return $this->expires < $d;
     }

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -350,7 +350,7 @@ class Transfer extends DBObject
              . Transfer::getDBTable() . " t, "
              . Guest::getDBTable()    . " g "
              . " where "
-             . " g.userid   = :userid AND g.expires > :date AND "
+             . " g.userid   = :userid AND (g.expires is null or g.expires > :date) AND "
              . " t.guest_id = g.id    AND t.status  = 'available' ";
         if( $user_can_only_view_guest_transfers_shared_with_them ) {
             // filter back to only transfers that are can_only_send_to_me for the user

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -234,7 +234,7 @@ class RestEndpointGuest extends RestEndpoint
         $expires = $data->expires ? $data->expires : Guest::getDefaultExpire();
         $guest->expires = $expires;
         
-        if($guest->does_not_expire()) {
+        if($guest->does_not_expire) {
             $guest->expires = null;
         }
         

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -164,7 +164,7 @@ class RestEndpointGuest extends RestEndpoint
         
         // User who is creating the new guest
         $user = Auth::user();
-        
+
         // Raw guest data
         $data = $this->request->input;
 
@@ -233,6 +233,10 @@ class RestEndpointGuest extends RestEndpoint
         // Set expiry date
         $expires = $data->expires ? $data->expires : Guest::getDefaultExpire();
         $guest->expires = $expires;
+        
+        if($guest->does_not_expire()) {
+            $guest->expires = null;
+        }
         
         // Make guest available, this saves the object and send email to the guest
         $guest->makeAvailable();

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -74,7 +74,7 @@ foreach(Transfer::allFailed() as $transfer) {
 // Close expired guests
 $days = Config::get('guests_expired_lifetime');
 foreach(Guest::allExpired() as $guest) {
-    if($guest->getOption(GuestOptions::DOES_NOT_EXPIRE)) continue;
+    if($guest->does_not_expire()) continue;
 
     if( $days != -1 && $guest->isExpiredDaysAgo($days)) {
         Logger::info($guest.' expired and before guests_expired_lifetime so deleting it');

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -74,7 +74,7 @@ foreach(Transfer::allFailed() as $transfer) {
 // Close expired guests
 $days = Config::get('guests_expired_lifetime');
 foreach(Guest::allExpired() as $guest) {
-    if($guest->does_not_expire()) continue;
+    if($guest->does_not_expire) continue;
 
     if( $days != -1 && $guest->isExpiredDaysAgo($days)) {
         Logger::info($guest.' expired and before guests_expired_lifetime so deleting it');

--- a/scripts/upgrade/explicit/upgrade-2.11-to-2.12-after-database-guestsexpire.php
+++ b/scripts/upgrade/explicit/upgrade-2.11-to-2.12-after-database-guestsexpire.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../../includes/init.php';
+
+Logger::setProcess(ProcessTypes::UPGRADE);
+
+set_error_handler(function($no, $str, $file = '', $line = '') {
+    if($no == '2048') return;
+    Logger::error('['.$no.'] '.$str.' in '.$file.' at line '.$line);
+});
+
+echo "current db_database is " . Config::get('db_database') . "\n";
+
+
+$sql = "update " . call_user_func('Guest::getDBTable') . " \n"
+     . " set expires = null "
+     . " where options like '%does_not_expire\":true%' ";
+$s = DBI::prepare($sql);
+$s->execute(array());

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -253,6 +253,7 @@ $(function() {
         subject: send_voucher.find('input[name="subject"]'),
         message: send_voucher.find('textarea[name="message"]'),
         expires: send_voucher.find('input[name="expires"]'),
+        does_not_expire: send_voucher.find('input[name="does_not_expire"]'),
         get_a_link: send_voucher.find('input[name="get_a_link"]'),
         can_only_send_to_me: send_voucher.find('input[name="can_only_send_to_me"]'),
         options: {guest: {}, transfer: {}},
@@ -346,7 +347,13 @@ $(function() {
     });
     get_a_link_updates();
 
-    
+
+    if( filesender.ui.nodes.does_not_expire ) {
+        filesender.ui.nodes.does_not_expire.on('click', function() {
+            var checked = filesender.ui.nodes.does_not_expire.is(':checked');
+            filesender.ui.nodes.expires.prop('disabled', checked);
+        });
+    }
     
     
     // Bind advanced options display toggle


### PR DESCRIPTION
This brings out the do not expire option to near the expire date selection. The expires column in the Guests table can now be null to indicate that the guest does not expire. This is explicitly set if does not expire is selected during guest creation. 

Some of the SQL fragments had to be updated to return results where the guest does not expire. Without doing this then some guests might not have been returned, for example ones that had a expires time before now but are set to never expire. IMHO it is better to use null for guests that do not expire to explicitly capture the intent that the guest has no expire time.

Tested on Firefox, will test on other browsers soon.
