### PR TITLE
i18n: update oldterms to include current data from en_AU

### DIFF
--- a/scripts/language/oldterms.txt
+++ b/scripts/language/oldterms.txt
@@ -530,6 +530,7 @@ user_additionnal
 user_auth_secret
 user_created
 user_deleted
+user_hit_guest_limit
 user_id
 user_lang
 user_missing_uid


### PR DESCRIPTION
local repo oldterms.txt updated with ./export-terms-to-new-and-deleted-lists.sh to reflect the list of active terms on poeditor. That new term was already on poeditor so now things are in sync again.