### PR TITLE
i18n: new script to import from json from poeditor

### DIFF
--- a/scripts/language/compare-php-lang-files.php
+++ b/scripts/language/compare-php-lang-files.php
@@ -1,0 +1,55 @@
+<?php
+
+//
+// This simple script will check two php translation files to see if they contain the same translations.
+//
+// Usage:
+//  php compare-php-lang-files.php generated_translation_from_json.php /tmp/Filesender_file_from_web_export_on_poeditor.php
+//
+// Note that this is rough and ready, it is mainly for testing that the terms as loaded from
+// both a generated and manually downloaded file are the same, ignoring extra data that might
+// be in the web download like context strings and the like.
+//
+
+$phpfile1 = $argv[1];
+$phpfile2 = $argv[2];
+
+function findTerm( $term, $lang ) {
+    foreach ($lang as $ti => $t) {
+        if( $t['term'] == $term ) {
+            return $t;
+        }
+    }
+    return null;
+}
+
+function test12( $lang1, $lang2 )
+{
+    foreach ($lang1 as $ti => $t) {
+        $term = $t['term'];
+        $t2 = findTerm( $t['term'], $lang2 );
+        if( !$t2 ) {
+            echo "term $term is missing from one of the translations...\n";
+        } else {
+            if( $t['definition'] != $t2['definition'] ) {
+                echo "term $term has different definition...\n";
+            }
+        }
+    }
+}
+
+include($phpfile1);
+$lang1 = $LANG;
+include($phpfile2);
+$lang2 = $LANG;
+
+test12( $lang1, $lang2 );
+
+
+include($phpfile1);
+$lang1 = $LANG;
+include($phpfile2);
+$lang2 = $LANG;
+
+test12( $lang2, $lang1 );
+

--- a/scripts/language/convert-poeditor-json-to-php.php
+++ b/scripts/language/convert-poeditor-json-to-php.php
@@ -1,0 +1,39 @@
+<?php
+
+$jsonfile = $argv[1];
+$phpfile = $argv[2];
+
+echo "converting from JSON format in $jsonfile to php format in $phpfile\n";
+$jsondata = file_get_contents($jsonfile);
+$j = json_decode( $jsondata, true );
+
+
+function quotedef($definition) {
+    return "'" . preg_replace("~(?<!\\\)'~", "\\'", $definition) . "'";
+}
+
+$fp = fopen($phpfile, 'w');
+
+fwrite($fp, "<?php  \n");
+fwrite($fp, " \$LANG = array ( \n");
+
+foreach ($j as $key => $value) {
+    $term = $value['term'];
+    $definition = $value['definition'];
+
+    if( $term == "serverlog_config_directive" ) {
+        echo "DEF $definition\n";
+    }
+    
+    fwrite($fp, "$key => \n");
+    fwrite($fp, "array (\n");
+    fwrite($fp, "  'term' => '".$term."',\n");
+    fwrite($fp, "  'definition' => ".quotedef($definition).",\n");
+    fwrite($fp, "), \n");
+}
+
+fwrite($fp, " );\n");
+fwrite($fp, "?>");
+fclose($fp);
+
+

--- a/scripts/language/import-all-from-poeditor.sh
+++ b/scripts/language/import-all-from-poeditor.sh
@@ -65,7 +65,7 @@ echo ""
 echo "running import-langs-directory.sh $dirname"
 echo ""
 
-"SCRIPTDIR/import-langs-directory.sh" "$dirname"
+"$SCRIPTDIR/import-langs-directory.sh" "$dirname"
 
 
 

--- a/scripts/language/import-all-from-poeditor.sh
+++ b/scripts/language/import-all-from-poeditor.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ~/.filesender/poeditor-apikey
+
+
+function downloadAndConvert {
+    LANG=$1
+    PHPFILE=$2
+    dirname=$3
+
+    echo "LANG $LANG "
+    echo "dir $dirname "
+    
+    data=$(curl -s -X POST https://api.poeditor.com/v2/projects/export \
+                -d api_token="$API_TOKEN" \
+                -d id="$PROJECT_ID" \
+                -d language="$LANG" \
+                -d type="json"
+        );
+
+    if [ 'success' != "$(echo $data | jq -r .response.status)" ]; then
+        echo "$data"
+        echo ""
+        echo "BAD SERVER RESPONSE FOR LANG $LANG"
+        exit 1
+    fi
+
+    earl="$(echo $data | jq -r .result.url)";
+    curl  "$earl" --output "FileSender_2.0_$LANG.json"
+    php "$SCRIPTDIR/convert-poeditor-json-to-php.php" "FileSender_2.0_$LANG.json" "FileSender_2.0_$PHPFILE.php"
+}
+
+dirname=$(mktemp -d "/tmp/filesender-poeditor-imports-XXXXX");
+cd "$dirname"
+echo "Creating downloaded files in $dirname"
+
+
+downloadAndConvert "cs" "Czech"     $dirname
+downloadAndConvert "da" "Danish"    $dirname
+downloadAndConvert "nl" "Dutch"     $dirname
+downloadAndConvert "en-au" "English_AU" $dirname
+downloadAndConvert "et" "Estonian"  $dirname
+downloadAndConvert "fi" "Finnish"   $dirname
+downloadAndConvert "de" "German"    $dirname
+downloadAndConvert "it" "Italian"   $dirname
+downloadAndConvert "fa" "Persian"   $dirname
+downloadAndConvert "ru" "Russian"   $dirname
+downloadAndConvert "sl" "Slovenian" $dirname
+downloadAndConvert "es" "Spanish"   $dirname
+downloadAndConvert "fr" "French"    $dirname
+
+
+
+ls -lh "$dirname"
+
+echo "Checking syntax of generated .php files, please wait..."
+for f in $(find "$dirname" -type f -name \*.php)
+do
+	php -l $f
+done
+
+echo ""
+echo "running import-langs-directory.sh $dirname"
+echo ""
+
+"SCRIPTDIR/import-langs-directory.sh" "$dirname"
+
+
+

--- a/scripts/language/import-langs-directory.sh
+++ b/scripts/language/import-langs-directory.sh
@@ -39,6 +39,7 @@ importfile fa_IR FileSender_2.0_Persian.php
 importfile ru_RU FileSender_2.0_Russian.php
 importfile sl_SI FileSender_2.0_Slovenian.php
 importfile es_ES FileSender_2.0_Spanish.php
+importfile fr_FR FileSender_2.0_French.php
 
 echo "Checking syntax of generated .php files, please wait..."
 for f in $(find ../../language -type f -name \*.php)


### PR DESCRIPTION
A new import-all-from-poeditor.sh top level script to get the language files from poeditor (in json) and convert those to php format before importing them all. The compare-php-lang-files.php script is there to help tell of a php file that is manually exported using the poeditor web interface has significant differences to the converted json file that was obtained using the web api for poeditor.

The direct poeditor import script needs an API key which is expected to be in a file in the user's home directory.

These scripts still need testing. I will start doing some imports using the code like is in these scripts in the next days and comparing their output to the output generated by importing the php from the poeditor web interface. These scripts may see some updates to get into final state once they have been used against the real world data. The plan is to separate the updates to these scripts from the language imports.
