### PR TITLE
crypto: new dialog displayed with pbkdf2 is taking place

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -129,7 +129,7 @@ class Transfer extends DBObject
         ),
         'password_hash_iterations' => array(
             'type'    => 'uint',
-            'size'    => 'medium',
+            'size'    => 'big',
             'null'    => false,
             'default' => 150000
         ),

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -301,6 +301,12 @@ class Config
         if( strlen($themeName) && preg_match('@[./]@',$themeName)) {
             throw new ConfigBadParameterException('the theme config can not contain / or . characters');
         }
+
+        if( self::get('terasender_enabled')) {
+            if( self::get('terasender_worker_count') < 1 || self::get('terasender_worker_count') > 30 ) {
+                throw new ConfigBadParameterException('terasender_worker_count must be between 1 and 30 inclusive.');
+            }
+        }
             
         // verify classes are happy
         Guest::validateConfig();

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -103,6 +103,7 @@ class GUI
             'js/crypter/crypto_common.js',
             'js/crypter/crypto_blob_reader.js',
             'js/crypter/crypto_app.js',
+            'js/pbkdf2dialog.js',
             'lib/xregexp/xregexp-all.js'
         );
         

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -88,6 +88,8 @@ A note about colours;
 * [upload_display_per_file_stats](#upload_display_per_file_stats)
 * [upload_force_transfer_resume_forget_if_encrypted](#upload_force_transfer_resume_forget_if_encrypted)
 * [upload_considered_too_slow_if_no_progress_for_seconds](#upload_considered_too_slow_if_no_progress_for_seconds)
+* [crypto_pbkdf2_dialog_enabled](#crypto_pbkdf2_dialog_enabled)
+* [crypto_pbkdf2_delay_to_show_dialog](#crypto_pbkdf2_delay_to_show_dialog)
 
 ## Transfers
 
@@ -775,6 +777,25 @@ User language detection is done in the following order:
 * __type:__ int
 * __default:__ 30
 * __available:__ since version 2.0
+
+
+
+### crypto_pbkdf2_dialog_enabled
+* __description:__ If set to true then a dialog is displayed with a key is being generated from a user supplied password. Such an action can be quite computationally expensive and may take half a minute to many minutes depending on your expectation of security for password based keys. See encryption_password_hash_iterations_new_files for an explanation of the delay expectation.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.12
+
+
+### crypto_pbkdf2_delay_to_show_dialog
+* __description:__ If crypto_pbkdf2_dialog_enabled is true then this is a delay that must pass before the dialog is shown. If PBKDF2 completes before this delay then no dialog is shown. Note that you should be seeing the dialog for password hashing iteration counts that offer a reasonable expectation of security.
+* __mandatory:__ no
+* __type:__ integer
+* __default:__ 300
+* __available:__ since version 2.12
+
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -116,6 +116,10 @@ $default = array(
     'terasender_worker_start_must_complete_within_ms' => 180000, // in ms, 3 minutes by default.
     'stalling_detection' => false,
 
+    'crypto_pbkdf2_dialog_enabled' => false,     // display a dialog after delay_to_show_dialog ms
+    'crypto_pbkdf2_delay_to_show_dialog' => 300, // in ms. 0 to disable the dialog
+    
+
     'testing_terasender_worker_uploadRequestChange_function_name' => '',
 
     'tmp_path' => FILESENDER_BASE.'/tmp/',

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -529,3 +529,7 @@ $lang['yes'] = 'Yes';
 $lang['you_can_report_exception'] = 'When reporting this error please give the following code to help the support finding out details';
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
+
+$lang['crypto_pbkdf2_dialog'] = 'FileSender is generating a key from your password, this dialog will close automatically when the key is made. Generating a key is a computationally expensive operation to deter poeple from trying to guess passwords. <br/>This may take a few minutes depending on the speed of this computer.';
+$lang['crypto_pbkdf2_dialog_with_expected'] = 'FileSender is generating a key from your password, this dialog will close automatically when the key is made. Generating a key is a computationally expensive operation to deter people from trying to guess passwords. <br/>The expected delay is {seconds} seconds';
+$lang['upload_all_terasender_workers_completed_pbkdf2'] = 'All upload workers are now ready to start transferring encrypted data';

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -141,6 +141,8 @@ window.filesender.config = {
 
     testing_terasender_worker_uploadRequestChange_function_name: '<?php echo Config::get('testing_terasender_worker_uploadRequestChange_function_name') ?>',
 
+    crypto_pbkdf2_dialog_enabled: '<?php echo Config::get('crypto_pbkdf2_dialog_enabled') ?>',
+    crypto_pbkdf2_delay_to_show_dialog: '<?php echo Config::get('crypto_pbkdf2_delay_to_show_dialog') ?>',
 
 	language: {
 		downloading : "<?php echo Lang::tr('downloading')->out(); ?>",

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -18,6 +18,25 @@ if (!('key_cache' in window.filesender)) {
     window.filesender.key_cache = new Map();
 }
 
+if (!('onPBKDF2Starting' in window.filesender)) {
+    window.filesender.onPBKDF2Starting = function() {
+        console.log("crypto_app onPBKDF2Starting()");
+    };
+}
+if (!('onPBKDF2Ended' in window.filesender)) {
+    window.filesender.onPBKDF2Ended = function() {
+        console.log("crypto_app onPBKDF2Ended()");
+    };
+}
+if (!('onPBKDF2AllEnded' in window.filesender)) {
+    window.filesender.onPBKDF2AllEnded = function() {
+        console.log("crypto_app onPBKDF2AllEnded()");
+    };
+}
+
+
+
+
 window.filesender.crypto_app = function () {
     return {
         crypto_is_supported: true,
@@ -268,7 +287,8 @@ window.filesender.crypto_app = function () {
             
             if( key_version == $this.crypto_key_version_constants.v2018_importKey_deriveKey )
             {
-
+                window.filesender.onPBKDF2Starting();
+                
                 crypto.subtle.importKey(
                     'raw', 
                     passwordBuffer,
@@ -290,6 +310,7 @@ window.filesender.crypto_app = function () {
                         false,                   // key is not extractable
                         [ "encrypt", "decrypt" ] // features desired
                     ).then(function (key) {
+                        window.filesender.onPBKDF2Ended();
                     
                         callback(key);
                     }, efunc );
@@ -298,6 +319,8 @@ window.filesender.crypto_app = function () {
 
             if( key_version == $this.crypto_key_version_constants.v2019_gcm_importKey_deriveKey )
             {
+                window.filesender.onPBKDF2Starting();
+                
                 crypto.subtle.importKey(
                     'raw', 
                     passwordBuffer,
@@ -319,7 +342,9 @@ window.filesender.crypto_app = function () {
                         false,                   // key is not extractable
                         [ "encrypt", "decrypt" ] // features desired
                     ).then(function (key) {
-                    
+
+                        window.filesender.onPBKDF2Ended();
+                        
                         callback(key);
                     }, efunc );
                 }, efunc );

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -33,6 +33,8 @@
 $(function() {
     var page = $('.download_page');
     if(!page.length) return;
+
+    window.filesender.pbkdf2dialog.setup();
     
     // Bind file selectors
     page.find('.file .select').on('click', function() {

--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -1,0 +1,127 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+if(!('filesender' in window)) window.filesender = {};
+
+
+/**
+ * Dialog letting user know that PBKDF2 is being calculated
+ */
+window.filesender.pbkdf2dialog = {
+
+    // delay in ms to show the dialog
+    // this is set from config in setup()
+    delay_to_show_dialog: 0,
+
+    // dialog window
+    dialog: null,
+
+    // if the delay causes the show dialog method
+    // to be run after the action is already complete don't
+    // flash the dialog at the user
+    already_complete: false,
+
+    // remember how long pbkdf2 took on this machine
+    time_start: 0,
+    time_end: 0,
+
+    // set in setup() from config.
+    encryption_password_hash_iterations: 0,
+
+    reset: function() {
+        $this = this
+        $this.already_complete = false;
+    },
+    usingGeneratedKey: function() {
+        $this = this
+        return $this.encryption_password_hash_iterations < 10;
+    },
+    setup: function() {
+        $this = this;
+
+        $this.delay_to_show_dialog = window.filesender.config.crypto_pbkdf2_delay_to_show_dialog;
+        $this.encryption_password_hash_iterations = filesender.config.encryption_password_hash_iterations_new_files;
+
+        window.filesender.onPBKDF2Starting = function() {
+            console.log("pbkdf2dialog onPBKDF2Starting()");
+            $this.time_start = Date.now();
+            expected_delay = window.localStorage.getItem('crypto_pbkdf2_delay_seconds');
+            
+            window.setTimeout(function() {
+                if( !$this.already_complete ) {
+                    if( window.filesender.config.crypto_pbkdf2_dialog_enabled ) {
+                        var trans = 'crypto_pbkdf2_dialog_with_expected';
+                        if( !expected_delay ) {
+                            trans = 'crypto_pbkdf2_dialog';
+                        }
+                        // Generated keys do not need repeated hashing
+                        // so they should be too quick for a dialog to be needed
+                        // See end of https://github.com/filesender/filesender/pull/375#issuecomment-439160499
+                        if( !($this.usingGeneratedKey())) {
+                            $this.dialog = filesender.ui.alert(
+                                "info", lang.tr(trans).r({seconds: expected_delay}).out());
+                        }
+                    }
+                }
+            }, $this.delay_to_show_dialog );
+                              
+        };
+        
+        window.filesender.onPBKDF2Ended = function() {
+            $this.time_end = Date.now();
+            console.log("pbkdf2dialog onPBKDF2Ended()");
+            $this.already_complete = true;
+            if( $this.dialog ) {
+                $this.dialog.dialog('close');
+                $this.dialog.remove();
+                $this.dialog = null;
+            }
+            if( window.filesender.supports.localStorage ) {
+                // dont record time for a generated key as it is different
+                // than user supplied key.
+                if( !($this.usingGeneratedKey())) {
+                    window.localStorage.setItem('crypto_pbkdf2_delay_seconds',
+                                                Math.ceil(($this.time_end - $this.time_start) / 1000 ));
+                }
+            }
+        };
+
+        // Chain this out so the UI can still get it.
+        var allEnded = window.filesender.onPBKDF2AllEnded;
+        window.filesender.onPBKDF2AllEnded = function() {
+            console.log("pbkdf2dialog onPBKDF2AllEnded()");
+            allEnded();
+        };
+    },
+       
+};

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -26,6 +26,8 @@ catch( e ) {
 }
 
 
+
+
 function isIE11()
 {
     if(navigator.userAgent.indexOf('MSIE')!==-1
@@ -189,6 +191,7 @@ var terasender_worker = {
 		} else {
 			xhr.send(blob);
 		}
+            
         } catch(err) {
             this.error({message: 'source_file_not_available', details: {job: this.job}});
         }
@@ -438,6 +441,15 @@ var terasender_worker = {
                 break;
         }
     },
+};
+
+window.filesender.onPBKDF2Starting = function() {
+    terasender_worker.log("onPBKDF2Starting");
+    terasender_worker.sendCommand("onPBKDF2Starting");
+};
+window.filesender.onPBKDF2Ended = function() {
+    terasender_worker.log("onPBKDF2Ended");
+    terasender_worker.sendCommand("onPBKDF2Ended");
 };
 
 /**

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -770,6 +770,13 @@ window.filesender.transfer = function() {
         this.watchdog_processes[id].progressTracker.clear();
         
     };
+    this.touchAllUploadStartedInWatchdog = function() {
+        
+        for(var id in this.watchdog_processes) {
+            this.watchdog_processes[id].started = (new Date()).getTime();
+            this.watchdog_processes[id].progressTracker.clear();
+        }
+    };
 
     /**
      * Record chunk upload progress for worker

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -33,6 +33,8 @@
 $(function() {
     if(window.transfers_table) return;
     window.transfers_table = true;
+
+    window.filesender.pbkdf2dialog.setup();
     
     // Expand each transfer's details
     $('.transfer .expand span, .transfer span.expand').on('click', function() {


### PR DESCRIPTION
An optional dialog can be shown when a password is bring turned into a key which can be a time consuming task.

This dialog is not shown by default currently. That is likely to change soon with other default config settings. The dialog can be enabled with the configuration setting crypto_pbkdf2_dialog_enabled=true.

Depending on how many iterations you are using for key derivation the action can take a long time. See for example https://en.wikipedia.org/wiki/PBKDF2 for more information. If the user is confronted with an interface that does not show any upload or download progress for tens of seconds or minutes they will very likely assume something has failed. This might not be the case, the browser may instead be performing PBKDF2 iterations to derive a key from a password.  Given this case this PR will show a dialog when PBKDF2 is being performed and remove the dialog when uploading (or download/decryption) is taking place.

If enabled and key derivation takes enough time, one should see this dialog on the upload_page, my transfers page, and download page.

Once a successful PBKDF2 has taken place the result is recorded to give a hint to the user the next time around as to what sort of delay to expect. This delay will be fairly bound to the speed of the PC in use so is put in localStorage in the browser.

An interesting implementation detail is that during upload terasender workers will themselves generate the key. This gives the situation that the crypto_app code is run in web workers but wishes to communicate the pbkdf2 begin/end information to the main browser thread/context. In order for that to happen the terasender_workers must override the onPBKDF2Starting() etc callbacks and send a message to the main context which will then be forwarded in that context. The terasender code only sends a single start and end signal and an allended when all terasender workers have generated the key.
