### PR TITLE
crypto: add to test page some performance generators

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -307,7 +307,16 @@ class Config
                 throw new ConfigBadParameterException('terasender_worker_count must be between 1 and 30 inclusive.');
             }
         }
-            
+
+        if( self::get('crypto_pbkdf2_expected_secure_to_year')) {
+            $y = self::get('crypto_pbkdf2_expected_secure_to_year');
+            if( $y < 2021 ) {
+                throw new ConfigBadParameterException('crypto_pbkdf2_expected_secure_to_year must be above 2021.');
+            }
+            $iterations = Crypto::getPBKDF2IterationCountForYear($y);
+            self::$parameters['encryption_password_hash_iterations_new_files'] = $iterations;
+        }
+        
         // verify classes are happy
         Guest::validateConfig();
         ClientLog::validateConfig();

--- a/classes/utils/Crypto.class.php
+++ b/classes/utils/Crypto.class.php
@@ -61,4 +61,21 @@ class Crypto
         $v = base64_encode($v);
         return substr($v, 0, $len);
     }
+
+    /**
+     * This uses the formula from page 7 of the OpenFortress security analysis
+     * to get a PBKDF2 iteration count for an expected number of years of security
+     * from brute force attack.
+     */
+    public static function getPBKDF2IterationCountForYear( $wantedyear )
+    {
+        if( $wantedyear < 2010 ) {
+            throw new ConfigBadParameterException('getPBKDF2IterationCountForYear() called with invalid year: ' . $wantedyear );
+        }
+        $baseyear=2009;
+        $nbase=1000;
+        return ceil($nbase * pow(2.0, ( ($wantedyear - $baseyear)*2/3)));
+    }
+
+    
 }

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -118,7 +118,7 @@ $default = array(
 
     'crypto_pbkdf2_dialog_enabled' => false,     // display a dialog after delay_to_show_dialog ms
     'crypto_pbkdf2_delay_to_show_dialog' => 300, // in ms. 0 to disable the dialog
-    
+
 
     'testing_terasender_worker_uploadRequestChange_function_name' => '',
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -533,3 +533,4 @@ $lang['you_can_send_client_logs'] = 'In order to help your support team to find 
 $lang['crypto_pbkdf2_dialog'] = 'FileSender is generating a key from your password, this dialog will close automatically when the key is made. Generating a key is a computationally expensive operation to deter poeple from trying to guess passwords. <br/>This may take a few minutes depending on the speed of this computer.';
 $lang['crypto_pbkdf2_dialog_with_expected'] = 'FileSender is generating a key from your password, this dialog will close automatically when the key is made. Generating a key is a computationally expensive operation to deter people from trying to guess passwords. <br/>The expected delay is {seconds} seconds';
 $lang['upload_all_terasender_workers_completed_pbkdf2'] = 'All upload workers are now ready to start transferring encrypted data';
+$lang['time_to_complete_s'] = 'Time to complete (seconds)';

--- a/templates/admin_testing_section.php
+++ b/templates/admin_testing_section.php
@@ -49,4 +49,34 @@
 </table>
 
 
+
+<h2>PBKDF2 performance</h2>
+
+<p>
+    The below will derive a key for a series of years to allow you to see how long it takes on this PC.
+    Current crypto_pbkdf2_expected_secure_to_year is <?php echo Config::get('crypto_pbkdf2_expected_secure_to_year'); ?>.
+    Current hash iteartions is <?php echo Config::get('encryption_password_hash_iterations_new_files'); ?>.
+    
+</p>
+
+<input type="button" data-action="show-pbkdf2-crypto-performance" value="pbkdf2 perf" />
+
+<table class="pbkdf2-performance">
+    <tr>
+        <th>{tr:epoch_year}</th>
+        <th>{tr:iterations}</th>
+        <th>{tr:time_to_complete_s}</th>
+    </tr>
+    
+   
+    <tr class="tpl">
+        <td class="year"></td>
+        <td class="iterations number"></td>
+        <td class="seconds number"></td>
+    </tr>
+</table>
+
+
 <script type="text/javascript" src="{path:js/admin_testing.js}"></script>
+
+


### PR DESCRIPTION
The admin/testing page now contains a button to generate PBKDF2 performance information in the browser. This is useful for administrators who are looking to tweak the default number of iterations to use for PBKDF2 so that their intended users get a security-to-performance trade off that is known.

A subsequent PR will create a default value for crypto_pbkdf2_expected_secure_to_year which will be shipped in a subsequent release.