### PR TITLE
Have the PBKDF2 dialog remain open until all terasender workers are ready

### DIFF
--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -34,7 +34,7 @@ $(function() {
     var page = $('.download_page');
     if(!page.length) return;
 
-    window.filesender.pbkdf2dialog.setup();
+    window.filesender.pbkdf2dialog.setup( true );
     
     // Bind file selectors
     page.find('.file .select').on('click', function() {

--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -55,6 +55,9 @@ window.filesender.pbkdf2dialog = {
     time_start: 0,
     time_end: 0,
 
+    only_one_pbkdf2_process: true,
+
+
     // set in setup() from config.
     encryption_password_hash_iterations: 0,
 
@@ -66,11 +69,13 @@ window.filesender.pbkdf2dialog = {
         $this = this
         return $this.encryption_password_hash_iterations < 10;
     },
-    setup: function() {
+    setup: function( only_one_pbkdf2_process_v ) {
         $this = this;
+        $this.only_one_pbkdf2_process = only_one_pbkdf2_process_v;
 
         $this.delay_to_show_dialog = window.filesender.config.crypto_pbkdf2_delay_to_show_dialog;
         $this.encryption_password_hash_iterations = filesender.config.encryption_password_hash_iterations_new_files;
+
 
         window.filesender.onPBKDF2Starting = function() {
             console.log("pbkdf2dialog onPBKDF2Starting()");
@@ -97,33 +102,47 @@ window.filesender.pbkdf2dialog = {
                               
         };
         
+
         window.filesender.onPBKDF2Ended = function() {
+            
+            console.log("ended() only_one_pbkdf2_process: " + $this.only_one_pbkdf2_process );
+            if( $this.only_one_pbkdf2_process ) {
+                $this.onPBKDF2Over();
+            }
         };
 
         // Chain this out so the UI can still get it.
         var allEnded = window.filesender.onPBKDF2AllEnded;
         window.filesender.onPBKDF2AllEnded = function() {
-
-            $this.time_end = Date.now();
-            console.log("pbkdf2dialog onPBKDF2AllEnded(top)");
-            $this.already_complete = true;
-            if( $this.dialog ) {
-                $this.dialog.dialog('close');
-                $this.dialog.remove();
-                $this.dialog = null;
-            }
-            if( window.filesender.supports.localStorage ) {
-                // dont record time for a generated key as it is different
-                // than user supplied key.
-                if( !($this.usingGeneratedKey())) {
-                    window.localStorage.setItem('crypto_pbkdf2_delay_seconds',
-                                                Math.ceil(($this.time_end - $this.time_start) / 1000 ));
-                }
+            console.log("ending() only_one_pbkdf2_process: " + $this.only_one_pbkdf2_process );
+            if( !($this.only_one_pbkdf2_process)) {
+                $this.onPBKDF2Over();
             }
             
             console.log("pbkdf2dialog onPBKDF2AllEnded()");
             allEnded();
         };
     },
-       
+
+
+    onPBKDF2Over: function() {
+        $this = this;
+        $this.time_end = Date.now();
+        console.log("pbkdf2dialog onPBKDF2Over()");
+        $this.already_complete = true;
+        if( $this.dialog ) {
+            $this.dialog.dialog('close');
+            $this.dialog.remove();
+            $this.dialog = null;
+        }
+        if( window.filesender.supports.localStorage ) {
+            // dont record time for a generated key as it is different
+            // than user supplied key.
+            if( !($this.usingGeneratedKey())) {
+                window.localStorage.setItem('crypto_pbkdf2_delay_seconds',
+                                            Math.ceil(($this.time_end - $this.time_start) / 1000 ));
+            }
+        }
+    },
+    
 };

--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -98,8 +98,14 @@ window.filesender.pbkdf2dialog = {
         };
         
         window.filesender.onPBKDF2Ended = function() {
+        };
+
+        // Chain this out so the UI can still get it.
+        var allEnded = window.filesender.onPBKDF2AllEnded;
+        window.filesender.onPBKDF2AllEnded = function() {
+
             $this.time_end = Date.now();
-            console.log("pbkdf2dialog onPBKDF2Ended()");
+            console.log("pbkdf2dialog onPBKDF2AllEnded(top)");
             $this.already_complete = true;
             if( $this.dialog ) {
                 $this.dialog.dialog('close');
@@ -114,11 +120,7 @@ window.filesender.pbkdf2dialog = {
                                                 Math.ceil(($this.time_end - $this.time_start) / 1000 ));
                 }
             }
-        };
-
-        // Chain this out so the UI can still get it.
-        var allEnded = window.filesender.onPBKDF2AllEnded;
-        window.filesender.onPBKDF2AllEnded = function() {
+            
             console.log("pbkdf2dialog onPBKDF2AllEnded()");
             allEnded();
         };

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -34,7 +34,7 @@ $(function() {
     if(window.transfers_table) return;
     window.transfers_table = true;
 
-    window.filesender.pbkdf2dialog.setup();
+    window.filesender.pbkdf2dialog.setup( true );
     
     // Expand each transfer's details
     $('.transfer .expand span, .transfer span.expand').on('click', function() {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1589,7 +1589,7 @@ $(function() {
     window.filesender.onPBKDF2AllEnded = function() {
         filesender.ui.uploadLogPrepend(lang.tr('upload_all_terasender_workers_completed_pbkdf2'));
     }
-    window.filesender.pbkdf2dialog.setup();
+    window.filesender.pbkdf2dialog.setup(!filesender.config.terasender_enabled)
     
     // Check if there is a failed transfer in tracker and if it still exists
     var failed = filesender.ui.transfer.isThereFailedInRestartTracker();


### PR DESCRIPTION
On chrome it can take a while for all workers to complete, so keep the dialog open until all workers are uploading to avoid a little 1-2 second delay without any UI updates.

This complicates things a little because the dialog is closed either on ended (single worker) or allended (terasender upload).
