### PR TITLE
pbkdf2: enable dialog by default

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -116,8 +116,8 @@ $default = array(
     'terasender_worker_start_must_complete_within_ms' => 180000, // in ms, 3 minutes by default.
     'stalling_detection' => false,
 
-    'crypto_pbkdf2_dialog_enabled' => false,     // display a dialog after delay_to_show_dialog ms
-    'crypto_pbkdf2_delay_to_show_dialog' => 300, // in ms. 0 to disable the dialog
+    'crypto_pbkdf2_dialog_enabled' => true,          // display a dialog after delay_to_show_dialog ms
+    'crypto_pbkdf2_delay_to_show_dialog' => 300,     // in ms. 0 to disable the dialog
     'crypto_pbkdf2_expected_secure_to_year' => 2027, // expected year for pbkdf2 to be secure through to under brute force.
 
 

--- a/travis/filesender-config.php
+++ b/travis/filesender-config.php
@@ -331,3 +331,7 @@ $config['encryption_key_version_new_files'] = 0;
 
 $config['PUT_PERFORM_TESTSUITE'] = '';
 
+
+$config['crypto_pbkdf2_dialog_enabled'] = false;
+
+

--- a/unittests/selenium/tests/EncryptionTest.php
+++ b/unittests/selenium/tests/EncryptionTest.php
@@ -36,7 +36,7 @@ class EncryptionTest extends SeleniumTest {
             {
                 return true;
             }
-        }, 60000);
+        }, 30000);
         // the popup is not instant.. sleep a bit
         sleep(2);
         

--- a/unittests/selenium/tests/EncryptionTest.php
+++ b/unittests/selenium/tests/EncryptionTest.php
@@ -36,7 +36,7 @@ class EncryptionTest extends SeleniumTest {
             {
                 return true;
             }
-        }, 30000);
+        }, 60000);
         // the popup is not instant.. sleep a bit
         sleep(2);
         


### PR DESCRIPTION
now that crypto_pbkdf2_expected_secure_to_year has a default value, enable the pbkdf2 delay dialog by default.