### PR TITLE
filesender.py rest client: refresh

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -533,3 +533,6 @@ $lang['yes'] = 'Yes';
 $lang['you_can_report_exception'] = 'When reporting this error please give the following code to help the support finding out details';
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
+
+$lang['configuration'] = 'configuration';
+$lang['python_cli_client_setup_information'] = 'To use the Python CLI Client configuration, create a directory ~/.filesender and copy the configuration file filesender.py.ini to the directory ~/.filesender. The configuration file is optional but is recommended as it means you do not always have to specify all parameters on the command line. The python CLI Client can be downloaded to any location and requires Python version 3 to execute.<p>With the configuration file in place you can upload a file using <pre>python3 filesender.py -r person-to-send-to@emailserver.edu research-data-file.txt</pre>';

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -122,8 +122,12 @@
     
     ?>
     
-  <h2>Python CLI Client</h2>
+    <h2>Python CLI Client</h2>
+    {tr:python_cli_client_setup_information}
+    <br/>
   <a href="clidownload.php" target="_blank">{tr:download} Python CLI Client</a>
+  <br/>
+  <a href="clidownload.php?config=1" target="_blank">{tr:download} Python CLI Client {tr:configuration}</a>
 
     <h2>{tr:actions}</h2>
 

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -33,10 +33,35 @@ require_once('../includes/init.php');
 
 $one=1;
 
-$script=file_get_contents('../scripts/client/filesender.py');
-
 $apipath=Config::get('site_url').'rest.php';
 $daysvalid=Config::get('default_transfer_days_valid');
+
+//
+// This makes a config file for the python script to connect to this filesender
+// server and authenticate as this user.
+//
+if( $_GET['config']=='1' ) {
+    header('Content-Description: File Transfer');
+    header('Content-Type: application/octet-stream');
+    header('Content-Disposition: attachment; filename="filesender.py.ini"');
+    header('Expires: 0');
+    header('Cache-Control: must-revalidate');
+    header('Pragma: public');
+
+    $username = Auth::user()->saml_user_identification_uid;
+    $apikey   = Auth::user()->auth_secret;
+    echo "[system]\n";
+    echo "base_url = $apipath\n";
+    echo "default_transfer_days_valid = $daysvalid\n";
+    echo "\n";
+    echo "[user]\n";
+    echo "username = $username\n";
+    echo "apikey = $apikey\n";
+    return;
+}
+
+$script=file_get_contents('../scripts/client/filesender.py');
+
 
 $script=str_replace('[base_url]',$apipath,$script,$one);
 $script=preg_replace("/\ndefault_transfer_days_valid[ ]*=[ ]*[0-9]+\n/",


### PR DESCRIPTION
This allows the base_url, apikey, and username to all be set in a configuration file instead of merged into the python script or provided explicitly on the command line. This relates to https://github.com/filesender/filesender/issues/716. There is now also a link to get this generated configuration file in the "my profile" page. 

The filesender.py wants python3 which is now described in the web interface and the script itself. Some minor python 3.8 updates were also done.

If you have get_a_link=1 as the default configuration for the filesender instance then unintended things used to happen. The script now explicitly sets get_a_link=0 because it expects a recipient on the command line. The script could be expanded to allow "get a link" but we should do the right thing right now with the mandatory -r argument to filesender.py.

