### PR TITLE
filesender.py ability to delete and create apisecret, uap

### DIFF
--- a/classes/constants/GUIPages.class.php
+++ b/classes/constants/GUIPages.class.php
@@ -54,4 +54,5 @@ class GUIPages extends Enum
     const ABOUT           = 'about';
     const PRIVACY         = 'privacy';
     const HELP            = 'help';
+    const APISECRETAUP    = 'apisecretaup';
 }

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -101,6 +101,10 @@ class User extends DBObject
             'size' => 64,
             'null' => true
         ),
+        'auth_secret_created' => array(
+            'type' => 'datetime',
+            'null' => true
+        ),
         'quota' => array(
             'type' => 'uint',
             'size' => 'big',
@@ -147,6 +151,7 @@ class User extends DBObject
     protected $created = 0;
     protected $last_activity = 0;
     protected $auth_secret = null;
+    protected $auth_secret_created = null;
     protected $quota = 0;
     
     /**
@@ -190,9 +195,19 @@ class User extends DBObject
         
         // Generate user remote auth secret
         if (Config::get('auth_remote_user_autogenerate_secret') && !$this->auth_secret) {
-            $this->auth_secret = hash('sha256', $this->id.'|'.time().'|'.Utilities::generateUID());
-            $this->save();
+            $this->authSecretCreate();
         }
+    }
+
+    public function authSecretCreate() {
+        $this->auth_secret = hash('sha256', $this->id.'|'.time().'|'.Utilities::generateUID());
+        $this->auth_secret_created = time();
+        $this->save();
+    }
+    public function authSecretDelete() {
+        $this->auth_secret = null;
+        $this->auth_secret_created = null;
+        $this->save();
     }
     
     /**
@@ -587,10 +602,15 @@ class User extends DBObject
     {
         if (in_array($property, array(
             'id','additional_attributes', 'lang', 'aup_ticked', 'aup_last_ticked_date', 'auth_secret',
+            'auth_secret_created',
             'transfer_preferences', 'guest_preferences', 'frequent_recipients', 'created', 'last_activity',
             'email_addresses', 'name', 'quota', 'authid'
         ))) {
             return $this->$property;
+        }
+
+        if( $property == 'auth_secret_created_formatted' ) {
+            return $this->auth_secret_created ? Utilities::formatDate($this->auth_secret_created,true) : '';
         }
 
         if ($property == 'saml_user_identification_uid') {

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -195,7 +195,10 @@ class User extends DBObject
         
         // Generate user remote auth secret
         if (Config::get('auth_remote_user_autogenerate_secret') && !$this->auth_secret) {
-            $this->authSecretCreate();
+            // do not auto generate if the user must accept aup
+            if( !Config::get('api_secret_aup_enabled')) {
+                $this->authSecretCreate();
+            }
         }
     }
 

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -285,6 +285,12 @@ class RestEndpointUser extends RestEndpoint
                 unset($_SESSION['lang']);
             }
         }
+        if( $data->apisecretcreate ) {
+            $user->authSecretCreate();
+        }
+        if( $data->apisecretdelete ) {
+            $user->authSecretDelete();
+        }
         
         return true;
     }

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -316,6 +316,14 @@ class Config
             $iterations = Crypto::getPBKDF2IterationCountForYear($y);
             self::$parameters['encryption_password_hash_iterations_new_files'] = $iterations;
         }
+
+        //
+        // you can not autogenerate the secret and expect the user to accept aup
+        // at the same time.
+        if( self::get('api_secret_aup_enabled')) {
+            self::$parameters['auth_remote_user_autogenerate_secret'] = false;
+        }
+        
         
         // verify classes are happy
         Guest::validateConfig();

--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -92,7 +92,7 @@ class DatabasePgsql
     }
     public static function dropView($table, $viewname)
     {
-        DBI::exec('DROP VIEW IF EXISTS CASCADE'.$viewname);
+        DBI::exec('DROP VIEW IF EXISTS '.$viewname.' CASCADE');
     }
     
     /**

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -345,10 +345,10 @@ class GUI
             if (Auth::isAuthenticated(false)) {
                 if (Auth::isGuest()) {
                     self::$allowed_pages = array('upload',
-                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY );
+                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY, GUIPages::APISECRETAUP );
                 } else {
                     self::$allowed_pages = array('home', 'upload', 'transfers', 'guests', 'download',
-                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY );
+                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY, GUIPages::APISECRETAUP );
                     
                     // ... and admin to even more !
                     if (Auth::isAdmin()) {

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -97,6 +97,7 @@ A note about colours;
 
 * [aup_default](#aup_default)
 * [aup_enabled](#aup_enabled)
+* [api_secret_aup_enabled](#api_secret_aup_enabled)
 * [ban_extension](#ban_extension)
 * [chunk_upload_security](#chunk_upload_security)
 * [default_transfer_days_valid](#default_transfer_days_valid)
@@ -820,7 +821,6 @@ User language detection is done in the following order:
 
 
 
-
 ---
 
 ## Transfers
@@ -846,6 +846,16 @@ User language detection is done in the following order:
 * __available:__ since version 1.0
 * __1.x name:__ AuP_default
 * __comment:__
+
+### api_secret_aup_enabled
+
+* __description:__ If set to 'true' the AuP (terms of service) must be accepted before the api secret can be created.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.15
+* __comment:__
+
 
 ### ban_extension
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -849,7 +849,7 @@ User language detection is done in the following order:
 
 ### api_secret_aup_enabled
 
-* __description:__ If set to 'true' the AuP (terms of service) must be accepted before the api secret can be created.
+* __description:__ If set to 'true' the AuP (terms of service) must be accepted before the api secret can be created. Note that if this setting is enabled then auth_remote_user_autogenerate_secret will be disabled.
 * __mandatory:__ no
 * __type:__ boolean
 * __default:__ false

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -69,6 +69,7 @@ $default = array(
     
     'aup_default' => false,
     'aup_enabled' => false,
+    'api_secret_aup_enabled' => false,
     'mac_unzip_name' => 'The Unarchiver',
     'mac_unzip_link' => 'https://theunarchiver.com/',
     'ban_extension' => 'exe,bat',
@@ -247,6 +248,7 @@ $default = array(
     // https://docs.filesender.org/v2.0/admin/configuration/#encryption_password_hash_iterations_new_files
     //
     'encryption_password_hash_iterations_new_files' => 150000,
+
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -536,3 +536,9 @@ $lang['you_can_send_client_logs'] = 'In order to help your support team to find 
 
 $lang['configuration'] = 'configuration';
 $lang['python_cli_client_setup_information'] = 'To use the Python CLI Client configuration, create a directory ~/.filesender and copy the configuration file filesender.py.ini to the directory ~/.filesender. The configuration file is optional but is recommended as it means you do not always have to specify all parameters on the command line. The python CLI Client can be downloaded to any location and requires Python version 3 to execute.<p>With the configuration file in place you can upload a file using <pre>python3 filesender.py -r person-to-send-to@emailserver.edu research-data-file.txt</pre>';
+$lang['api_secret_delete'] = 'Delete API secret';
+$lang['api_secret_recreate'] = 'Create API secret';
+$lang['api_secret_use_the_button_below_to_create'] = 'Please use the button below to create';
+$lang['confirm_api_secret_create_aup'] = 'Please confirm that you and read and accept the use policy for remote authentication with this site. Please see the latest <a href="?s=apisecretaup">policy for remote authentication</a>.';
+$lang['api_secret_aup_text'] = '<h1>Welcome to {cfg:site_name}</h1><p>This site has no additional explicit policy for remote authentication</p>';
+$lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -4,6 +4,7 @@
     
     <?php
 
+
     if(GUI::isUserAllowedToAccessPage('admin'))
     {
         echo "<h2>".Lang::tr('admin_page')."</h2>\n";
@@ -11,7 +12,16 @@
     }
     
     $readonly = function($info) {
-        echo '<div class="readonly">'.Utilities::sanitizeOutput($info['value']).'</div>';
+        $extraclass = 'readonly';
+        if( !$info['value'] ) {
+            $info['value'] = '';
+            $extraclass = 'unknown';
+            if( $info['key'] == 'auth_secret' ) {
+                $info['value'] = Lang::tr('api_secret_use_the_button_below_to_create');
+            }
+        }
+        
+        echo "<div class='$extraclass'>".Utilities::sanitizeOutput($info['value']).'</div>';
     };
     
     $infos = array(
@@ -38,9 +48,42 @@
         'remote_authentication' => array(
             'auth_secret' => function($info) use($readonly) {
                 if(!Config::get('auth_remote_user_enabled')) return;
-                
+
+                $v = Auth::user()->auth_secret_created_formatted;
+                if( $v == '' ) {
+                } else {
+                    $tt = Lang::tr('you_generated_this_auth_secret_at')->r('datetime', $v);
+                    echo "<p class='datetime'>$tt</p>";
+                }
+                $info['key'] = 'auth_secret';
                 $readonly($info);
-                echo '<span data-info="remote_config">'.Auth::user()->remote_config.'</span>';
+//                echo '<span data-info="remote_config">'.Auth::user()->remote_config.'</span>';
+
+                echo <<<EOT
+                <div>
+                   <div class="api_secret_delete">
+                      <a href="#">
+                         <span class="fa fa-lg fa-times"></span>
+                         {tr:api_secret_delete}
+                      </a>
+                   </div>
+                   <div class="api_secret_create">
+                      <a href="#">
+                         <span class="fa fa-lg fa-plus"></span>
+                         {tr:api_secret_recreate}
+                      </a>
+                   </div>
+                </div>
+EOT;
+                
+                echo <<<EOT
+                   <h2>Python CLI Client</h2>
+                   {tr:python_cli_client_setup_information}
+                   <br/>
+                   <a href="clidownload.php" target="_blank">{tr:download} Python CLI Client</a>
+                   <br/>
+                   <a href="clidownload.php?config=1" target="_blank">{tr:download} Python CLI Client {tr:configuration}</a>
+EOT;
             },
         ),
         'additional' => array(
@@ -72,7 +115,7 @@
                     }
                 }
                 
-                if($value) $displayed[] = array(
+                if($value || $id=='auth_secret') $displayed[] = array(
                     'id' => $id,
                     'mode' => $page[$id],
                     'generator' => $generator,
@@ -122,12 +165,6 @@
     
     ?>
     
-    <h2>Python CLI Client</h2>
-    {tr:python_cli_client_setup_information}
-    <br/>
-  <a href="clidownload.php" target="_blank">{tr:download} Python CLI Client</a>
-  <br/>
-  <a href="clidownload.php?config=1" target="_blank">{tr:download} Python CLI Client {tr:configuration}</a>
 
     <h2>{tr:actions}</h2>
 

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1314,6 +1314,14 @@ table.guests .guest .to .errors .details {
     white-space: nowrap;
 }
 
+.user_page .info .unknown {
+    border: 1px solid black;
+    background-color: #EABEBE;
+    padding: 0.25em;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
 .user_page span[data-info="remote_config"] {
     display: none;
 }

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -165,6 +165,7 @@ window.filesender.config = {
     automatic_resume_delay_to_resume:   <?php echo Config::get('automatic_resume_delay_to_resume') ?>,
 
 
+    api_secret_aup_enabled: <?php echo value_to_TF(Config::get('api_secret_aup_enabled')) ?>,
 
     tr_dp_date_format:   "<?php echo Config::get('tr_dp_date_format') ?>",
     tr_dp_date_format_hint:   "<?php echo Config::get('tr_dp_date_format_hint') ?>",

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -715,5 +715,6 @@ window.filesender.client = {
         
         return this.delete('/user/' + id, callback, opts);
     },
-    
+
+
 };

--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -50,6 +50,48 @@ $(function() {
         
         return false;
     });
+
+    $('.api_secret_delete a').button().on('click', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        var p = {};
+        p['apisecretdelete'] = '1';
+        
+        filesender.client.updateUserPreferences(p, function() {
+            filesender.ui.notify('success', lang.tr('preferences_updated'));
+            filesender.ui.reload();
+        });
+        
+        return false;
+    });
+
+
+    $('.api_secret_create a').button().on('click', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        var secret_create = function() {
+            var p = {};
+            p['apisecretcreate'] = '1';
+            
+            filesender.client.updateUserPreferences(p, function() {
+                filesender.ui.notify('success', lang.tr('preferences_updated'));
+                filesender.ui.reload();
+            });
+        };
+
+        if( filesender.config.api_secret_aup_enabled ) {
+            filesender.ui.confirm(lang.tr('confirm_api_secret_create_aup'), function() {
+                secret_create();
+            });
+        } else {
+            secret_create();
+        }
+        
+        return false;
+    });
+    
     
     page.find(':input').on('change', function() {
         var i = $(this);


### PR DESCRIPTION
The time that the api secret was generated is now tracked in the database. The secret can be deleted and created through the "my profile" page on the site. When creating an api secret, if the config api_secret_aup_enabled=true then a dialog is displayed with a link to the full apisecretaup page that allows the aup to be displayed in full in a single page. A secret is not generated unless the user confirms acceptance of this dialog.

The time of acceptance of the api secret aup is also displayed on this page.

This relates to issue https://github.com/filesender/filesender/issues/679