### PR TITLE
filesender.py accept aup in client

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -200,6 +200,7 @@ def postTransfer(user_id, files, recipients, subject=None, message=None, expires
       'subject': subject,
       'message': message,
       'expires': expires,
+      'aup_checked':1,
       'options': options
     },
     None,


### PR DESCRIPTION
If a site wants an AUP on the rest clients then it is best to constrain that at the API secret generation point. There is now code that allows for that. So the client will pass along that the aup is accepted because you must have accepted the aup in order to even get an api secret that will be acceptable to the site.