### PR TITLE
api secret: allow admin to delete for one or all users

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -212,6 +212,10 @@ class User extends DBObject
         $this->auth_secret_created = null;
         $this->save();
     }
+    public static function authSecretDeleteAll() {
+        $statement = DBI::prepare('update '.self::getDBTable().' set auth_secret_created=null, auth_secret=null ');
+        $statement->execute(array());
+    }
     
     /**
      * Loads user from Auth attributes, handling cache
@@ -323,10 +327,14 @@ class User extends DBObject
         // Escape special chars
         $match = str_replace(array('%', '_'), array('\\%', '\\_'), $match);
 
+        $escapeClause = '';
+        if( DBLayer::isMySQL() ) {
+            $escapeClause = " ESCAPE '\\\\' ";
+        }
         $sql = "select u.* from "
              . User::getDBTable() . " u,"
              . " " . Authentication::getDBTable()
-             . " a where a.id = u.authid and a.saml_user_identification_uid like :match ESCAPE '\\\\' ";
+             . " a where a.id = u.authid and a.saml_user_identification_uid like :match " . $escapeClause;
         $statement = DBI::prepare($sql);
         $placeholders =  array(':match' => '%'.$match.'%');
         $statement->execute($placeholders);

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -248,9 +248,8 @@ class RestEndpointUser extends RestEndpoint
         if (!Auth::isAuthenticated()) {
             throw new RestAuthenticationRequiredException();
         }
-        
         // Check ownership if specific user id given
-        if ($id) {
+        if ($id && $id!='@all') {
             $user = User::fromId($id);
             
             if (!Auth::user()->is($user) && !Auth::isAdmin()) {
@@ -289,7 +288,17 @@ class RestEndpointUser extends RestEndpoint
             $user->authSecretCreate();
         }
         if( $data->apisecretdelete ) {
-            $user->authSecretDelete();
+            if ($id && $id=='@all')
+            {
+                if (!$user->is(Auth::user()) && !Auth::isAdmin()) {
+                    throw new RestAdminRequiredException();
+                }
+                User::authSecretDeleteAll();
+            }
+            else
+            {
+                $user->authSecretDelete();
+            }
         }
         
         return true;

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -542,3 +542,5 @@ $lang['api_secret_use_the_button_below_to_create'] = 'Please use the button belo
 $lang['confirm_api_secret_create_aup'] = 'Please confirm that you and read and accept the use policy for remote authentication with this site. Please see the latest <a href="?s=apisecretaup">policy for remote authentication</a>.';
 $lang['api_secret_aup_text'] = '<h1>Welcome to {cfg:site_name}</h1><p>This site has no additional explicit policy for remote authentication</p>';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['perform_these_actions_on_all_users'] = 'Perform these actions on all users';
+$lang['confirm_api_secret_delete_all'] = 'Are you sure you wish to delete the API secret for all users in the system?';

--- a/templates/admin_users_section.php
+++ b/templates/admin_users_section.php
@@ -1,7 +1,16 @@
-<h2>{tr:users}</h2>
 
+<h2>{tr:perform_these_actions_on_all_users}</h2>
+    <table class="">
+        <tr>
+            <td>
+                <input type="button" data-action="all-delete-api-secret" value="{tr:api_secret_delete}" />
+            </td>
+        </tr>
+    </table>
+<br/>
+
+<h2>{tr:search_user}</h2>
 <fieldset class="search">
-    <legend>{tr:search_user}</legend>
     
     <input type="text" name="match" /> <input type="button" name="go" value="{tr:search}" />
 </fieldset>
@@ -28,6 +37,7 @@
         
         <td>
             <input type="button" data-action="show-client-logs" value="{tr:show_client_logs}" />
+            <input type="button" data-action="delete-api-secret" value="{tr:api_secret_delete}" />
         </td>
     </tr>
 </table>

--- a/www/js/admin_users.js
+++ b/www/js/admin_users.js
@@ -81,8 +81,28 @@ $(function() {
             var id = $(this).closest('.user').attr('data-id');
             show_logs(id);
         });
+        u.find('[data-action="delete-api-secret"]').on('click', function() {
+            var id = $(this).closest('.user').attr('data-id');
+
+            var p = {};
+            p['apisecretdelete'] = '1';
+        
+            filesender.client.updateUserIDPreferences( id, p, function() {
+                filesender.ui.notify('success', lang.tr('preferences_updated'));
+            });
+        });
     };
 
+    section.find('[data-action="all-delete-api-secret"]').on('click', function() {
+        var p = {};
+        p['apisecretdelete'] = '1';
+        filesender.ui.confirm(lang.tr('confirm_api_secret_delete_all'), function() {
+            filesender.client.updateUserIDPreferences( '@all', p, function() {
+                filesender.ui.notify('success', lang.tr('preferences_updated'));
+            });
+        });
+    });
+    
     var search_user = function() {
         results.removeClass('no_results').addClass('searching');
         filesender.client.get('/user', function(matches) {

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -693,6 +693,9 @@ window.filesender.client = {
     updateUserPreferences: function(preferences, callback) {
         return this.put('/user', preferences, callback);
     },
+    updateUserIDPreferences: function(id, preferences, callback) {
+        return this.put('/user/' + id + '/', preferences, callback);
+    },
     
     getUserQuota: function(callback, onerror) {
         this.get('/user/@me/quota', callback, {ignore_authentication_required: true});


### PR DESCRIPTION
This allows a user to be found have the admin to revoke their api secret. They can still make it again if they like, but if there is an aup in place they must accept that to remake the api secret. This button can also be handy to disable a key if a site notices what it regards as abuse of the rest api key. In this case it would be assumed to be unintended abuse, such as a compromised key. This is because the key is revoked but the user can remake a key and continue.

There is also a super "delete all api keys" which was added to allow the introduction of an aup which would require everybody to accept the api secret aup in order to start using the rest clients again.

This also leaves off the ESCAPE clause for pgsql, relates to https://github.com/filesender/filesender/pull/583. I think perhaps we should be doing the escaping client side rather than asking the database do to things. It seems that the same sort of thing as this ESCAPE can be enabled in pgsql using E'my\tstring' but trying to combine the escape 'E' prefix with parameters to prepared statements was becoming a digression in and of itself. In this case we could expand the tab in the php code and pass the final string to the database in the parameter. Perhaps this was needed in the past when ascii was the default encoding but we could expand citations to unicode characters to the real codepoint these days. For example, the \uxxxx codes from https://www.postgresql.org/docs/current/sql-syntax-lexical.html#id-1.5.3.5.9.5.2


