### PR TITLE
Add missing parameter to DBView::cast_as_number; provide default viewcolname

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -429,7 +429,7 @@ class AuditLog extends DBObject
                           . " set target_id = 'null' "
                           . " where a.target_type = 'Guest' "
                           . " and 0=(select count(*) as c from Guests g "
-                          . "        where g.id = ".DBView::cast_as_number("a.target_id")
+                          . "        where g.id = ".DBView::cast_as_number($dbtype,"a.target_id")
                           . "        limit 1"
                           ."        ) "
         );

--- a/classes/utils/DBView.class.php
+++ b/classes/utils/DBView.class.php
@@ -78,7 +78,8 @@ class DBView
     }
    public static function cast_as_number(
         $dbtype,
-        $basecolname
+        $basecolname,
+        $viewcolname = ''
     ) {
         if (!strlen($viewcolname)) {
             $viewcolname = $basecolname . "_as_number";


### PR DESCRIPTION
DBView::cast_as_number was called without the required $dbtype.  DBView::cast_as_number function also expects a viewcolname, which should be provided in the function parameter list.