### PR TITLE
flash: remove older references to Flash

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -228,7 +228,7 @@ class Config
             }
         }
 
-        // update max_flash_upload_size if php.ini post_max_size and upload_max_filesize is set lower
+        // update max_system_upload_size if php.ini post_max_size and upload_max_filesize is set lower
         $max_system_upload_size = min(
             Utilities::sizeToBytes(ini_get('post_max_size')) - 2048,
             Utilities::sizeToBytes(ini_get('upload_max_filesize'))

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,16 +24,20 @@ about the project [please visit our homepage](http://filesender.org).
 
 ### Which version should you choose
 
-Version 2.5 has been released in December 2018 and is the recommended
-choice.
+The version 2.x series is the recommended choice. The latest version
+can be obtained from the [github releases
+page](https://github.com/filesender/filesender/releases). 
 
-Following the 2.0 release there will be subsequent releases in the
-pattern 2.1, 2.2, 2.30 etc. Each of these releases will build on
-version 2.0 adding bugfixes and features. It is planned that you can
-migrate from 2.0 upwards in the 2.x series.
+The release numbering for the 2.x series follows the
+pattern 2.1, 2.2, 2.30 etc. Each of these releases builds on
+version 2.0 adding bugfixes and features. Each new
+release in the 2.x series will describe if database updates are needed
+(most often by running a script) and if web page templates have been
+updated in case you customize those on your site. If is intended that
+you can migrate an active site to new releases with very minimal downtime.
 
-The previous production release is [1.6.1, released on December 30th
-2015](https://downloads.filesender.org/filesender-1.6.1.tar.gz). 
+The 1.6.x series is considered deprecated. It is still available
+for those who have not upgraded to a 2.x installation: [1.6.1, released on December 30th 2015](https://downloads.filesender.org/filesender-1.6.1.tar.gz).
 
 ### Documentation
 
@@ -58,25 +62,25 @@ page if you have a feature you would like to see added to FileSender.
 
 ### Features
 
-Version 2.0 features are [described here](v2.0/features/).
-
-A snapshot of features for the latest 1.6(.x) release is located at [Features](v1.6/features). 
+For a more detailed list of version 2.x features see the [v2.0 features page](v2.0/features/).
 
 * light-weight server footprint, optimized for least possible dependencies
 * share arbitrarily large files from standard desktop environments, no client-side deployment required
+* WebCrypto backed End-to-End encryption of files using AES-CBC or AES-GCM modes.
 * Native HTML5 and JavaScript UI with supported browsers. No plugins required.
 * High-speed upload module with HTML5 uploads
-* Graceful fallback to invisible Flash component for non-HTML5 browsers, allowing uploads up to 2GB
 * integrates with various authentication mechanisms using SimpleSAMLphp (SAML2, RADIUS, LDAP)
-* upload guest vouchers to allow users without an account to upload a file
+* upload guest vouchers to allow users without an account to upload a file. This can be restricted to only
+  allow such uploads to be seen by the person who invited the guest.
 * cancel / resume file uploads using the HTML5 File API in supported browsers
+* resume an upload even after laptop sleep or from another machine with access to the same file.
 * download files multiple times, from link with built-in password in auto-generated email, or directly from interface by authenticated user
 * automatic deletion of shared files and issued vouchers after X amount of time, or manual deletion by authenticated user any time prior to expiry
 * email notification each time a file is uploaded, downloaded or manually deleted, or a voucher is issued or manually deleted
 * MyFiles provides overview lists of currently shared files * Overview list of unused issued guest vouchers
 * resend download link emails to file recipients without re-uploading the file * add additional recipients to already uploaded files
 * UTF8 support, supports all international character sets
-* Multi-language support. Out-of-the-box FileSender 1.6 supports Czech, Croatian, Dutch, English (Australian), Finnish, French, German, Hungarian, Italian, Norwegian (Bokmål), Serbian, Slovenian and Spanish. You can easily adapt relevant language labels to your local needs in an upgrade-friendly way, for example to localise the splash screen text. You can also easily modify which languages you make available to your users
+* Multi-language support. Out-of-the-box FileSender supports Czech, Croatian, Dutch, English (Australian), Finnish, French, German, Hungarian, Italian, Norwegian (Bokmål), Serbian, Slovenian and Spanish. You can easily adapt relevant language labels to your local needs in an upgrade-friendly way, for example to localise the splash screen text. You can also easily modify which languages you make available to your users
 * PDO-based multi-database support for PostgreSQL, MySQL and sqlite
 
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -937,7 +937,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __default:__ 5.  Setting this to 0 is not a wise choice as it will make the timer refresh every millisecond (the min. value for a JavaScript timer)
 * __available:__ since version 2.0
 * __1.x name:__
-* __comment:__ Normally FileSender will use the browser's HTML5 FileAPI functionality for uploading, splitting files in chunks and uploading these chunks.  This allows for uploads of any size.  Older browsers which you may find in a locked-down environment do not support the necessary HTML5 functionality.  For these browsers a legacy fallback upload method is provided.  Before version 2.0 a flash component was used for legacy uploads.  As of version 2.0 this is replaced by a native HTML upload with a limit of 2GB per file.  A user **can** select multiple files but in a less smooth way than with the HTML5 drag & drop box.  The upload progress for legacy uploads is polled from the server (via PHP) based on what has arrived (how many bytes) server side.  <span style="background-color:orange">This only became possible as of PHP version 5.x, released in x</span>
+* __comment:__ Normally FileSender will use the browser's HTML5 FileAPI functionality for uploading, splitting files in chunks and uploading these chunks.  This allows for uploads of any size.  Older browsers which you may find in a locked-down environment do not support the necessary HTML5 functionality.  For these browsers a legacy fallback upload method is provided.  This uses a native HTML upload with a limit of 2GB per file.  A user **can** select multiple files but in a less smooth way than with the HTML5 drag & drop box.  The upload progress for legacy uploads is polled from the server (via PHP) based on what has arrived (how many bytes) server side.  <span style="background-color:orange">This only became possible as of PHP version 5.x, released in x</span>
 
 ### max_legacy_file_size
 
@@ -946,7 +946,6 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __type:__ int
 * __default:__ 2147483648 (2GB)
 * __available:__ since version 1.0
-* __1.x name:__ max_flash_upload_size
 * __comment:__ Files are uploaded serially.  A hidden iframe and hidden form is created for each file, containing the required data (session key for upload etc.).  A single file element is cloned into each hidden form.  This form is submitted to the hidden iframe which then uploads the file.  At the end of the upload the server sends a bit of javascript which triggers the next upload in the queue.  Each file is an "entire file at once" upload rather then the chunked upload used to get over the 2GB limit of 32 bit browsers.
 
 ### max_transfer_size

--- a/docs/v2.0/admin/reference/index.md
+++ b/docs/v2.0/admin/reference/index.md
@@ -76,7 +76,7 @@ The <...> is set in the SAML2 message received by
 
 ## fall-back for non-html5 browsers
 
-no longer flash: now normal html post.  User can still select multiple files, when uploading a hidden iframe takes care of the upload.  Progress event through polling the server.  How often polling is done is defined by legacy_upload_progress_refresh_period.
+This uses an html post.  User can still select multiple files, when uploading a hidden iframe takes care of the upload.  Progress event through polling the server.  How often polling is done is defined by legacy_upload_progress_refresh_period.
 
 ## TeraSender high speed upload module
 

--- a/docs/v2.0/development-upgrade-notes/index.md
+++ b/docs/v2.0/development-upgrade-notes/index.md
@@ -117,4 +117,4 @@ releases.
 * filestorage_filesystem_temp_location (2.0 prototype?)
 * statlog_enable (prototype?): built-in in lifetime parameter
 * auditlog_enable (prototype?): built-in in lifetime parameter
-* max_flash_upload_size: the Flash upload component is now removed.  To present a reliable progress bar to a user, functionality that was first available in PHP 5.4 is required (which functionality?)
+* max_flash_upload_size: the Flash upload component is now removed.

--- a/docs/v2.0/features/index.md
+++ b/docs/v2.0/features/index.md
@@ -6,14 +6,6 @@ title: Detailed feature list
 
 This document lists most of the features currently implemented in the 2.0-beta1 code.  Please note that while most of the features are stable, some features may disappear or change.
 
-## Summarised changes compared to version 1.x
-
-* New feature: multi-file transfer of unlimited size files with drag & drop support
-* New feature: fine-grained email receipt control
-* New feature: user-accessible transfer audit log
-* Removed dependency on Flash for uploads with legacy browsers without HTML5 FileAPI support.  Note the per-file limit with legacy browsers is 2GB.
-* REST API
-
 # User visible features
 
 ## Multi-file transfer of any size
@@ -29,7 +21,7 @@ This document lists most of the features currently implemented in the 2.0-beta1 
 	* Can detect whether a file was actually downloaded (but for the last download chunk).   This also means download completed emails are now sent once the file is actually downloaded, not when the download starts.
 	* Show a warning when downloading (to) a file > 2GB on Mac that you need a different unarchiver.
 * Automatic deletion of transfers
-* Flash-free legacy multi-file upload for older browsers lacking HTML5 FileAPI upload capability.  Not as pretty but it does work.
+
 
 ## Easy to use UI
 

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -664,14 +664,6 @@ On **Debian**, run:
 
 ## Manual
 
-To allow for max. 2 GB Flash uploads change these settings to the values indicated:
-
-	max_input_time = 3600 ; in seconds
-	upload_max_filesize = 2047M ; in M, the default value is 2MB
-	post_max_size = 2146446312 ; in M, 2047M + 10K
-
-* **NOTE**: when you edit your FileSender config.php remember to change `$config['max_flash_upload_size']` to match your `upload_max_filesize`. If they are not the same FileSender will use the lowest value as the actual maximum upload size for Flash uploads.
-
 Ensure the php temporary upload directory points to a location with enough space:
 
 	upload_tmp_dir = /tmp

--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -48,7 +48,7 @@ window.filesender.pbkdf2dialog = {
 
     // if the delay causes the show dialog method
     // to be run after the action is already complete don't
-    // flash the dialog at the user
+    // quickly flash the dialog at the user
     already_complete: false,
 
     // remember how long pbkdf2 took on this machine


### PR DESCRIPTION
Removing some of these old left over references to flash as mentioned in https://github.com/filesender/filesender/issues/715.

I have also refreshed the main page to list the 1.6.x release line as deprecated. 