### PR TITLE
transfer log, set file path to name if not set

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -452,7 +452,11 @@ $(function() {
                 var lid = 'report_event_' + log[i].event;
                 
                 var rpl = log[i];
-                rpl[log[i].target.type.toLowerCase()] = log[i].target;
+                var ttlc = log[i].target.type.toLowerCase();
+                rpl[ttlc] = log[i].target;
+                if( rpl[ttlc]['name'] && !rpl[ttlc]['path'] ) {
+                    rpl[ttlc]['path'] = rpl[ttlc]['name'];
+                }
                 
                 $('<td />').html(lang.tr(lid).r(rpl).out()).appendTo(tr);
                 


### PR DESCRIPTION
If there is no file.path set then set it to file.name. Many of the translations use file.path and were not seeing any substitution in the my transfers / "see the transfer logs" button. 

This relates to https://github.com/filesender/filesender/issues/642
