### PR TITLE
transfer logs: allow full path for files with it

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -261,6 +261,7 @@ class RestEndpointTransfer extends RestEndpoint
                             break;
                             
                         case 'File': // Actions on file gets file name, file size and upload time added
+                            $target_data['path'] = $target->path;
                             $target_data['name'] = $target->name;
                             $target_data['size'] = $target->size;
                             


### PR DESCRIPTION
This improves upon https://github.com/filesender/filesender/pull/723 and addresses issue https://github.com/filesender/filesender/issues/642.

Testing was done in the my transfers / see the transfer logs.

This PR helps for the case that you drop a directory in the upload. Such uploads may have one or more leading directories that are created and in those cases this PR this will show the full path used for those files. Otherwise, just the file name is shown in the transfer log as there is no user supplied leading relative paths in that case.
