### PR TITLE
transfer-logs better for file log

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -133,7 +133,7 @@ class RestEndpointTransfer extends RestEndpoint
      * @throws RestAuthenticationRequiredException
      * @throws RestOwnershipRequiredException
      */
-    public function get($id = null, $property = null, $property_id = null)
+    public function get($id = null, $property = null, $property_id = null, $filtertype = null, $filterid = null )
     {
 
         // Special case when checking if enable_recipient_email_download_complete option is enabled for a specific transfer
@@ -216,6 +216,18 @@ class RestEndpointTransfer extends RestEndpoint
                 if ($property_id == 'mail') {
                     // ... to be sent by email
                     $report = new Report($transfer);
+                    if( $filtertype && $filterid ) {
+                        $files = $transfer->files;
+                        $report = null;
+                        foreach ($files as $file) {
+                            if( $file->id == $filterid ) {
+                                $report = new Report($file);
+                            }
+                        }
+                        if( !$report ) {
+                            throw new RestBadParameterException('filterid');
+                        }
+                    }
                     $report->sendTo(Auth::user());
                     return true;
                 }

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -682,8 +682,12 @@ window.filesender.client = {
         return this.get('/transfer/' + id + '/auditlog', callback);
     },
     
-    getTransferAuditlogByEmail: function(id, callback) {
-        return this.get('/transfer/' + id + '/auditlog/mail', callback);
+    getTransferAuditlogByEmail: function(id, filterid, callback) {
+        var tailer = '';
+        if( filterid ) {
+            tailer = '/file/' + filterid;
+        }
+        return this.get('/transfer/' + id + '/auditlog/mail' + tailer, callback);
     },
     
     getLegacyUploadProgress: function(key, callback, error) {

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -420,6 +420,8 @@ $(function() {
                 filter = filter.split('/');
                 if(filter.length != 3) filter = null;
             }
+
+            var filterid = null;
             
             if(filter) {
                 var flt = $('<div class="filtered" />').text(lang.tr('filtered_transfer_log')).prependTo(popup);
@@ -428,10 +430,12 @@ $(function() {
                     e.preventDefault();
                     $(this).closest('.wide_info').find('table tr').show('fast');
                     $(this).closest('.filtered').hide('fast');
+                    filtered = false;
+                    filterid = null;
                     return false;
                 });
             }
-            
+
             var tb = $('<tbody />').appendTo(tbl);
             for(var i=0; i<log.length; i++) {
                 var tr = $('<tr />').appendTo(tb);
@@ -441,6 +445,7 @@ $(function() {
                     var v = log[i][filter[0]];
                     if(v && v.type) {
                         if(v.type.toLowerCase() == filter[1]) {
+                            filterid = filter[2];
                             if(v.id != filter[2]) filtered = true;
                         } else filtered = true;
                     }
@@ -472,7 +477,7 @@ $(function() {
                 e.stopPropagation();
                 e.preventDefault();
                 
-                filesender.client.getTransferAuditlogByEmail(transfer_id, function() {
+                filesender.client.getTransferAuditlogByEmail(transfer_id, filterid, function() {
                     filesender.ui.notify('success', lang.tr('email_sent'));
                 });
                 
@@ -485,22 +490,20 @@ $(function() {
     };
     
     $('[data-transfer] .auditlog a').button().on('click', function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-        auditlogs($(this).closest('tr').attr('data-id'));
-        return false;
-    });
-    
-    $('[data-action="auditlog"]').on('click', function(e) {
         auditlogs($(this).closest('tr').attr('data-id'));
     });
     
-    $('.transfer_details .recipient [data-action="auditlog"]').on('click', function() {
+    
+    $('.transfer_details .recipient [data-action="auditlog"]').on('click', function(e) {
         auditlogs($(this).closest('tr').attr('data-id'), 'author/recipient/' + $(this).closest('.recipient').attr('data-id'));
     });
-    
-    $('.transfer_details .file [data-action="auditlog"]').on('click', function() {
+
+    $('.transfer_details .file [data-action="auditlog"]').on('click', function(e) {
         auditlogs($(this).closest('tr').attr('data-id'), 'target/file/' + $(this).closest('.file').attr('data-id'));
+    });
+
+    $('[data-action="auditlog"]').not('.transfer_details .file [data-action="auditlog"]').on('click', function(e) {
+        auditlogs($(this).closest('tr').attr('data-id'));
     });
     
     // Downloadlinks auto-selection


### PR DESCRIPTION
When you click on the see what happened to this file button on the my transfers page only the file specific dialog is shown. Stacking modal dialogs is not good form. Clicking to send an email report for a file will send a file specific report.

Expanding the file dialog to the transfers level dialog will also loosen the filtering so that the transfers level email is then sent if you want a report from that dialog.

This should fix https://github.com/filesender/filesender/issues/694.