### PR TITLE
rest api aup add the terms template page

### DIFF
--- a/templates/apisecretaup_page.php
+++ b/templates/apisecretaup_page.php
@@ -1,0 +1,12 @@
+<?php
+      include_once "pagemenuitem.php"
+?>
+
+
+ <div class="box">
+
+     <div id="dialog-about" title="About">
+        {tr:api_secret_aup_text}
+     </div>
+ </div>
+


### PR DESCRIPTION
The template adds no additional terms by default.