### PR TITLE
console log: ui.log() to also add items to clientlog

### DIFF
--- a/templates/apisecretaup_page.php
+++ b/templates/apisecretaup_page.php
@@ -1,0 +1,12 @@
+<?php
+      include_once "pagemenuitem.php"
+?>
+
+
+ <div class="box">
+
+     <div id="dialog-about" title="About">
+        {tr:api_secret_aup_text}
+     </div>
+ </div>
+

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -56,7 +56,6 @@ window.filesender.logger = {
 
         this.stash.push(msg);
         this.stash = this.stash.slice(-1 * len);
-
         if(filesender.supports.localStorage) {
             window.localStorage.setItem('client_logs', JSON.stringify(this.stash))
         }

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -47,7 +47,11 @@ window.filesender.ui = {
      * @param mixed message
      */
     log: function(message) {
+        
         if(filesender.config.log) console.log('[' + (new Date()).toLocaleTimeString() + '] ' + message);
+        if(filesender.logger) {
+            filesender.logger.log(message);
+        }
     },
     
     /**


### PR DESCRIPTION
This is a preamble to handling cases where browsers ignore console.log() if developer tools are not open. This relates to https://github.com/filesender/filesender/issues/627