### PR TITLE
clientlogs: increse log size to 100 by default. Rename stash_len to be consistent with config.php name

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1852,7 +1852,7 @@ $config['log_facilities'] =
 * __description:__ Client log backfeed stash size
 * __mandatory:__ no
 * __type:__ positive integer
-* __default:__ 10
+* __default:__ 100
 * __available:__ since version 2.0
 * __comment:__ Number of last client console entries that are to be back-fed to the server in case there is a client error.
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -203,7 +203,7 @@ $default = array(
     'disable_directory_upload' => true,
     'directory_upload_button_enabled' => true,
 
-    'clientlogs_stashsize' => 10,
+    'clientlogs_stashsize' => 100,
     'clientlogs_lifetime' => 10,
 
     'automatic_resume_number_of_retries' => 50,

--- a/templates/apisecretaup_page.php
+++ b/templates/apisecretaup_page.php
@@ -1,0 +1,12 @@
+<?php
+      include_once "pagemenuitem.php"
+?>
+
+
+ <div class="box">
+
+     <div id="dialog-about" title="About">
+        {tr:api_secret_aup_text}
+     </div>
+ </div>
+

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -158,7 +158,7 @@ window.filesender.config = {
 	},
     
     clientlogs: {
-        stash_len: <?php echo ClientLog::stashSize() ?>
+        stashsize: <?php echo ClientLog::stashSize() ?>
     },
 
     automatic_resume_number_of_retries: <?php echo Config::get('automatic_resume_number_of_retries') ?>,

--- a/www/js/logger.js
+++ b/www/js/logger.js
@@ -52,7 +52,7 @@ window.filesender.logger = {
         if(!(typeof msg).match(/^(number|string)$/))
             msg = JSON.stringify(msg);
 
-        var len = filesender.config ? filesender.config.clientlogs.stash_len : 10;
+        var len = filesender.config ? filesender.config.clientlogs.stashsize : 10;
 
         this.stash.push(msg);
         this.stash = this.stash.slice(-1 * len);


### PR DESCRIPTION
Slightly more context in clientlogs. The different name for the stash_len was only used in one place, so it was renamed to be more name consistent with the config.php setting.