### PR TITLE
Strengthen lang.js variable replacement

### DIFF
--- a/www/js/lang.js
+++ b/www/js/lang.js
@@ -75,6 +75,7 @@ window.filesender.lang = {
                     }
                     
                     if(typeof v == 'function') v = v();
+                    if(v === undefined || v === null) v = ''; // catch it here since next statement is going to fail
                     if((typeof v == 'object') && (typeof v.length != 'undefined')) v = v.length; // Array
                     
                     switch(fct) {


### PR DESCRIPTION
Strengthen lang.js translation variable replacement against null/undefined values.
Without this any null value in placeholders will end up triggering a js error, interrupting translation process and resulting in a broken ui.
We noticed this when slightly inconsistent auditlogs data is sent to the client, it ended up in a broken auditlogs popup.