### PR TITLE
Improve client IP lookup

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -316,7 +316,25 @@ class Utilities
      */
     public static function getClientIP()
     {
-        return isset($_SERVER[Config::get('client_ip_key')]) ? $_SERVER[Config::get('client_ip_key')] : '';
+        $ips = array();
+        
+        $candidates = array_reverse((array)Config::get('client_ip_key'));
+        foreach($candidates as $candidate) {
+            if(!array_key_exists($candidate, $_SERVER)) continue;
+            
+            foreach(explode(',', $_SERVER[$candidate]) as $value) {
+                $ips[] = trim($value);
+            }
+        }
+        
+        $ips = array_filter($ips, function($ip) {
+            return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+        });
+        
+        if(!count($ips))
+            return $_SERVER['REMOTE_ADDR']; // fallback
+        
+        return array_pop($ips);
     }
     
     /**


### PR DESCRIPTION
Adds support for multi-valuated client_ip_key config parameter (expressed from most significant source to least significant one).

When previously using X_FORWARDED_FOR with chained proxies the returned client IP was wonky since the header may be multi-valuated and needs parsing in that case.

IPs are validated using php's internals, rejecting local/private network IPs and reserved ones.

Configuration example :
  - $config['client_ip_key'] = 'REMOTE_ADDR'; // filesender is its own front server
  - $config['client_ip_key'] = 'X_FORWARDED_FOR'; // there is a proxy in front
  - $config['client_ip_key'] = array('X_REAL_IP', 'X_FORWARDED_FOR'); // there is a proxy in front that uses real-ip, then x-forwarded-for