### PR TITLE
Fixing typo in apache vhost config

### DIFF
--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -3,7 +3,7 @@ Alias /simplesaml /opt/filesender/simplesaml/www
         Header always append X-Frame-Options SAMEORIGIN
         Header always edit Set-Cookie (.*) "$1; SameSite=Strict"
 
-        Otions -Indexes
+        Options -Indexes
 	Options None
 	AllowOverride None
 	Require all granted


### PR DESCRIPTION
Typo in vhost config causing vanilla apache deploy to crash