### PR TITLE
Fix user lang preference use

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -186,7 +186,7 @@ class Lang
                     }
                     
                     // User preference stored language
-                    if (Config::get('lang_userpref_enabled') && Auth::isAuthenticated()) {
+                    if (Config::get('lang_userpref_enabled') && Auth::isAuthenticated() && Auth::user()) {
                         $code = Auth::user()->lang;
                         if ($code && !in_array($code, $stack)) {
                             $stack[] = $code;


### PR DESCRIPTION
Restrict user lang preference use for when there actually is a user.
When we are running as LocalProcess auth considers that there is indeed authentication active but without any attributes, so Auth::user() returns a boolean, which cannot be used to get a lang pref property ...