### PR TITLE
Auth: new SimpleSAMPphp module to verify against filesender db

### DIFF
--- a/classes/data/Authentication.class.php
+++ b/classes/data/Authentication.class.php
@@ -73,6 +73,11 @@ class Authentication extends DBObject
             'size' => 100,
             'null' => true
         ),
+        'passwordhash' => array(
+            'type' => 'string',
+            'size' => '255',
+            'null' => true
+        ),
     );
     protected static $secondaryIndexMap = array(
         'saml_user_identification_uid' => array(

--- a/scripts/simplesamlphp/passwordverify/PasswordVerify.php
+++ b/scripts/simplesamlphp/passwordverify/PasswordVerify.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace SimpleSAML\Module\sqlauth\Auth\Source;
+
+/**
+ * Simple SQL authentication source
+ *
+ * This class is very much like the SQL class. The major difference is that
+ * instead of using SHA2 and other functions in the database we use the PHP
+ * password_verify() function to allow for example PASSWORD_ARGON2ID to be used
+ * for verification.
+ *
+ * While this class has a query parameter as the SQL class does the meaning 
+ * is different. The query for this class should return at least a column 
+ * called passwordhash containing the hashed password which was generated 
+ * for example using
+ *    password_hash('hello', PASSWORD_ARGON2ID );
+ *
+ * Auth only passes if the PHP code below returns true.
+ *   password_verify($password, row['passwordhash'] );
+ *
+ * Unlike the SQL class the username is the only parameter passed to the SQL query,
+ * the query can not perform password checks, they are performed by the PHP code 
+ * in this class using password_verify().
+ *
+ * If there are other columns in the returned data they are assumed to be attributes
+ * you would like to be returned through SAML.
+ *
+ * @package SimpleSAMLphp
+ */
+
+class PasswordVerify extends \SimpleSAML\Module\sqlauth\Auth\Source\SQL
+{
+    /**
+     * The column in the result set containing the passwordhash.
+     */
+    private $passwordhashcolumn;
+
+    /**
+     * Constructor for this authentication source.
+     *
+     * @param array $info  Information about this authentication source.
+     * @param array $config  Configuration.
+     */
+    public function __construct($info, $config)
+    {
+        assert(is_array($info));
+        assert(is_array($config));
+
+        // Call the parent constructor first, as required by the interface
+        parent::__construct($info, $config);
+
+        $this->passwordhashcolumn = $config['passwordhashcolumn'];
+        if( !$this->passwordhashcolumn ) {
+            $this->passwordhashcolumn = 'passwordhash';
+        }
+    }
+
+
+    /**
+     * Extract SQL columns into SAML attribute array
+     *
+     * @param array  $data  Associative array from database in the format of PDO fetchAll
+     * @param array  $forbiddenAttributes An array of attributes to never return
+     * @return array  Associative array with the users attributes.
+     */
+    protected function extractAttributes( $data, $forbiddenAttributes = array() )
+    {
+        $attributes = [];
+        foreach ($data as $row) {
+            foreach ($row as $name => $value) {
+                if ($value === null) {
+                    continue;
+                }
+                if (in_array($name, $forbiddenAttributes)) {
+                    continue;
+                }
+               
+
+                $value = (string) $value;
+
+                if (!array_key_exists($name, $attributes)) {
+                    $attributes[$name] = [];
+                }
+
+                if (in_array($value, $attributes[$name], true)) {
+                    // Value already exists in attribute
+                    continue;
+                }
+
+                $attributes[$name][] = $value;
+            }
+        }
+        
+        return $attributes;
+    }
+
+
+    /**
+     * Attempt to log in using the given username and password.
+     *
+     * On a successful login, this function should return the users attributes. On failure,
+     * it should throw an exception. If the error was caused by the user entering the wrong
+     * username or password, a \SimpleSAML\Error\Error('WRONGUSERPASS') should be thrown.
+     *
+     * Note that both the username and the password are UTF-8 encoded.
+     *
+     * @param string $username  The username the user wrote.
+     * @param string $password  The password the user wrote.
+     * @return array  Associative array with the users attributes.
+     */
+    protected function login($username, $password)
+    {
+        assert(is_string($username));
+        assert(is_string($password));
+
+
+        
+        $db = $this->connect();
+
+        
+        try {
+            $sth = $db->prepare($this->query);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to prepare query: '.$e->getMessage());
+        }
+
+
+        try {
+            $sth->execute(['username' => $username]);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to execute query: '.$e->getMessage());
+        }
+
+        try {
+            $data = $sth->fetchAll(\PDO::FETCH_ASSOC);
+        } catch (\PDOException $e) {
+            throw new \Exception('sqlauth:'.$this->authId.
+                ': - Failed to fetch result set: '.$e->getMessage());
+        }
+
+        \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Got '.count($data).
+            ' rows from database');
+
+        if (count($data) === 0) {
+            // No rows returned - invalid username/password
+            \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                ': No rows in result set. Probably wrong username/password.');
+            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+        }
+
+        /**
+         * Sanity check, passwordhash must be in each resulting tuple and must have
+         * the same value in every tuple.
+         * 
+         * Note that $pwhash will contain the passwordhash value after this loop.
+         */
+        $pwhash = null;
+        foreach ($data as $row) {
+            if (!array_key_exists($this->passwordhashcolumn, $row)
+                || is_null($row[$this->passwordhashcolumn]))
+            {
+                \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                          ': column ' . $this->passwordhashcolumn . ' must be in every result tuple.');
+                throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            }
+            if( $pwhash ) {
+                if( $pwhash != $row[$this->passwordhashcolumn] ) {
+                    \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                              ': column ' . $this->passwordhashcolumn . ' must be THE SAME in every result tuple.');
+                    throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+                }
+            }
+            $pwhash = $row[$this->passwordhashcolumn];
+        }
+        /**
+         * This should never happen as the count(data) test above would have already thrown.
+         * But checking twice doesn't hurt.
+         */
+        if( is_null($pwhash)) {
+            if( $pwhash != $row[$this->passwordhashcolumn] ) {
+                \SimpleSAML\Logger::error('sqlauth:'.$this->authId.
+                                          ': column ' . $this->passwordhashcolumn . ' does not contain a password hash.');
+                throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+            }
+        }
+
+        /**
+         * VERIFICATION!
+         * Now to check if the password the user supplied is actually valid
+         */
+        if( !password_verify( $password, $pwhash )) {
+            \SimpleSAML\Logger::error('sqlauth:'.$this->authId. ': password is incorrect.');
+            throw new \SimpleSAML\Error\Error('WRONGUSERPASS');
+        }
+
+        
+        $attributes = $this->extractAttributes( $data, array($this->passwordhashcolumn) );
+
+        \SimpleSAML\Logger::info('sqlauth:'.$this->authId.': Attributes: '.
+            implode(',', array_keys($attributes)));
+
+        return $attributes;
+    }
+}

--- a/scripts/simplesamlphp/passwordverify/README.md
+++ b/scripts/simplesamlphp/passwordverify/README.md
@@ -1,0 +1,76 @@
+
+This is a work in progress created in March 2020. This should help
+small deployments of FileSender be created to allow people to share
+files using FileSender.
+
+The idea is to allow authentication against password hashes stored in
+the same database that FileSender is using for other activities.
+
+The passwords are using ARGON2ID and only the encoded password
+containing the salt and hash are stored in the database itself.
+
+I will shortly be looking at how to add new users to the system and
+and initial web interface to set and reset passwords. Having this SAML
+plugin allows the web interface to evolve and improve and be updated.
+
+In order to use this setup you have to do the following steps. Details
+are provided below
+
+* Apply a small (mainly two word) change to SQL.php in your SimpleSAMLphp installation (patch-to-simplesamlphp.patch)
+* Copy PasswordVerify.php to your SimpleSAMLphp installation (/opt/simplesamlphp/modules/sqlauth/lib/Auth/Source)
+* Run filesender-config-to-authsources-fragment.php and put that output into /opt/simplesamlphp/config/authsources.php
+* Select the filesender-dbauth SAML target in your /opt/filesender/config/config.php file
+  ($config['auth_sp_saml_authentication_source'] ="filesender-dbauth";)
+* Enable the filesender Web interface for managing the user passwords in it's web interface. This will be
+  an option to turn on in /opt/filesender/config/config.php.
+
+
+# Apply a small (mainly two word) change to SQL.php
+
+```
+cd ./simplesamlphp-1.18.5/
+patch -p1 < /opt/filesender/scripts/simplesamlphp/passwordverify/patch-to-simplesamlphp.patch
+```
+
+# Copy PasswordVerify.php to your SimpleSAMLphp installation
+
+```
+cp /opt/filesender/scripts/simplesamlphp/passwordverify/PasswordVerify.php ./modules/sqlauth/lib/Auth/Source/
+chgrp apache ./modules/sqlauth/lib/Auth/Source/PasswordVerify.php
+```
+
+# Run filesender-config-to-authsources-fragment.php
+
+```
+cd /opt/filesender/scripts/simplesamlphp/passwordverify
+php filesender-config-to-authsources-fragment.php
+
+'filesender-dbauth' => [
+    'sqlauth:PasswordVerify',
+    'dsn' => 'pgsql:host=localhost;port=5432;dbname=filesender',
+    'username' => 'filesender',
+    'password' => 'THISISSERIOUS',
+    'query' => 'select saml_user_identification_uid as uid, saml_user_identification_uid as email, passwordhash, created, \'uid\' as eduPersonTargetedID from authentications where saml_user_identification_uid = :username ',
+],
+
+vi /opt/simplesamlphp/config/authsources.php
+
+ ...
+ 'default-sp' => [
+        'saml:SP',
+ ...
+ ],
+
+  <<< INSERT-THE-ABOVE-FROM-filesender-config-to-authsources-fragment.php-HERE >>>
+
+```
+
+# Select the filesender-dbauth SAML target
+
+```
+vi /opt/filesender/config/config.php
+   ...
+   // move to end of file
+   $config['auth_sp_saml_authentication_source'] ="filesender-dbauth";
+
+```

--- a/scripts/simplesamlphp/passwordverify/filesender-config-to-authsources-fragment.php
+++ b/scripts/simplesamlphp/passwordverify/filesender-config-to-authsources-fragment.php
@@ -32,11 +32,14 @@
 
 require_once dirname(__FILE__).'/../../../includes/init.php';
 
+Logger::setProcess(ProcessTypes::UPGRADE);
+
 $db_host     = Config::get('db_host');
 $db_port     = Config::get('db_port');
 $db_database = Config::get('db_database');
 $db_username = Config::get('db_username');
 $db_password = Config::get('db_password');
+$authsTable = call_user_func('Authentication::getDBTable');
 
 echo <<<EOF
 'filesender-dbauth' => [
@@ -44,7 +47,7 @@ echo <<<EOF
     'dsn' => 'pgsql:host=$db_host;port=$db_port;dbname=$db_database',
     'username' => '$db_username',
     'password' => '$db_password',
-    'query' => 'select saml_user_identification_uid as uid, saml_user_identification_uid as email, passwordhash, created, \'uid\' as eduPersonTargetedID from authentications where saml_user_identification_uid = :username ',
+    'query' => 'select saml_user_identification_uid as uid, saml_user_identification_uid as email, passwordhash, created, \'uid\' as eduPersonTargetedID from $authsTable where saml_user_identification_uid = :username ',
 ],
 
 EOF;

--- a/scripts/simplesamlphp/passwordverify/filesender-config-to-authsources-fragment.php
+++ b/scripts/simplesamlphp/passwordverify/filesender-config-to-authsources-fragment.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../../includes/init.php';
+
+$db_host     = Config::get('db_host');
+$db_port     = Config::get('db_port');
+$db_database = Config::get('db_database');
+$db_username = Config::get('db_username');
+$db_password = Config::get('db_password');
+
+echo <<<EOF
+'filesender-dbauth' => [
+    'sqlauth:PasswordVerify',
+    'dsn' => 'pgsql:host=$db_host;port=$db_port;dbname=$db_database',
+    'username' => '$db_username',
+    'password' => '$db_password',
+    'query' => 'select saml_user_identification_uid as uid, saml_user_identification_uid as email, passwordhash, created, \'uid\' as eduPersonTargetedID from authentications where saml_user_identification_uid = :username ',
+],
+
+EOF;
+
+
+

--- a/scripts/simplesamlphp/passwordverify/patch-to-simplesamlphp.patch
+++ b/scripts/simplesamlphp/passwordverify/patch-to-simplesamlphp.patch
@@ -1,0 +1,20 @@
+--- simplesamlphp-1.18.5/modules/sqlauth/lib/Auth/Source/SQL.php	2019-12-03 19:07:09.000000000 +1000
++++ simplesamlphp.new/modules/sqlauth/lib/Auth/Source/SQL.php	2020-03-29 10:18:48.000674871 +1000
+@@ -38,7 +38,7 @@
+      *
+      * The username and password will be available as :username and :password.
+      */
+-    private $query;
++    protected $query;
+ 
+     /**
+      * Constructor for this authentication source.
+@@ -84,7 +84,7 @@
+      *
+      * @return \PDO  The database connection.
+      */
+-    private function connect()
++    protected function connect()
+     {
+         try {
+             $db = new \PDO($this->dsn, $this->username, $this->password, $this->options);


### PR DESCRIPTION
This is a SimpleSAMLphp module that can allow FileSender to authenticate against password hashes in it's local database. This is an effort to help make smalller sized installations of FileSender easier so that more people can setup their own instance of FileSender and use it now during the Covid crisis to securely share files. While the README.md is fairly technical it is hoped that packages can be created for FileSender in this setup to allow quick deployment.

I hope to push this auth module to SimpleSAMLphp itself including moving extractAttributes() up to the SQL class at the time. As that happens, the instructions for this can be updated to reflect the simpler installation process.

Next up will be an option to allow the Web interface of filesender to set passwords for users so they can login.
