### PR TITLE
localdbauth: create-user command line script chicken and egg

### DIFF
--- a/scripts/simplesamlphp/passwordverify/create-user.php
+++ b/scripts/simplesamlphp/passwordverify/create-user.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../../includes/init.php';
+
+Logger::setProcess(ProcessTypes::UPGRADE);
+
+$original_count = count($argv);
+$password = array_pop($argv);
+$username = array_pop($argv);
+
+if( $original_count != 3 || strlen($username) < 1 || strlen($password) < 1 )
+{
+   echo "\n";
+   echo "Please call this php script like the following\n";
+   echo "php create-user.php myadmin@example.com mypasswordhere\n";
+   echo "\n";
+   exit(1);
+}
+
+echo "Adding user $username with password $password\n";
+
+$aa = Authentication::ensure( $username );
+$aa->password = $password;
+$aa->save();
+
+echo "Done.\n";
+echo "\n";
+echo "NOTE: to enable this user admin privileges so they can create\n";
+echo "new users, you might like to add the following to your\n";
+echo "/opt/filesender/config/config.php file \n";
+echo "\n";
+echo "\$config['admin'] = '" . $username . "';\n";
+echo "\n";
+


### PR DESCRIPTION
Making the initial user can not be done by the web interface because you need the initial user to login to the web interface. So this command line php script is the solution and hints that you might like to make that user an admin user so they can then use the web interface to create other users.

The my profile page of the web interface should also let the admin change their own password.  This is assuming that the create-user.php script is being run by a package installer and then the admin logs in with a known initial password and changes their own as the first step.

This is related to the recent changes in https://github.com/filesender/filesender/pull/762 and https://github.com/filesender/filesender/pull/761.
