### PR TITLE
computest-414: increase lockdown that transaction creator is the file uploader

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -145,7 +145,16 @@ class Transfer extends DBObject
             'size'    => '44',
             'null'    => true,
         ),
-        
+
+        //
+        // This is to hand to a client that is making the transfer and to upload
+        // they have to hand it back to ensure they are the one who made the transfer
+        //
+        'roundtriptoken' => array(
+            'type'    => 'string',
+            'size'    => '44',
+            'null'    => true,
+        ),
     );
 
     /**
@@ -199,6 +208,8 @@ class Transfer extends DBObject
     const FROM_USER = "userid = :userid AND status='available' ORDER BY created DESC";
     const FROM_USER_CLOSED = "userid = :userid AND status='closed' ORDER BY created DESC";
     const FROM_GUEST = "guest_id = :guest_id AND status='available' ORDER BY created DESC";
+
+    const ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT = 16;
     
     /**
      * Properties
@@ -224,6 +235,7 @@ class Transfer extends DBObject
     protected $password_encoding_string = 'none';
     protected $password_hash_iterations = 150000;
     protected $client_entropy = '';
+    protected $roundtriptoken = '';
     
     /**
      * Related objects cache
@@ -390,6 +402,9 @@ class Transfer extends DBObject
         $transfer->logsCache = array();
         
         $transfer->userid = Auth::user()->id;
+
+        $transfer->roundtriptoken = Utilities::generateEntropyString(
+            self::ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT );
 
         if (!$user_email) {
             $user_email = Auth::user()->email;
@@ -787,7 +802,7 @@ class Transfer extends DBObject
             'subject', 'message', 'created', 'made_available',
             'expires', 'expiry_extensions', 'options', 'lang', 'key_version', 'userid',
             'password_version', 'password_encoding', 'password_encoding_string', 'password_hash_iterations'
-            , 'client_entropy'
+            , 'client_entropy', 'roundtriptoken'
         ))) {
             return $this->$property;
         }

--- a/classes/exceptions/RestExceptions.class.php
+++ b/classes/exceptions/RestExceptions.class.php
@@ -89,6 +89,20 @@ class RestAuthenticationRequiredException extends RestException
 }
 
 /**
+ * REST roundtrip tokens to not match expected value
+ */
+class RestRoundTripTokensInvalidException extends RestException
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct('rest_roundtrip_token_invalid', 403);
+    }
+}
+
+/**
  * REST admin required
  */
 class RestAdminRequiredException extends RestException

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -192,6 +192,17 @@ class RestEndpointFile extends RestEndpoint
                 throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
             }
         }
+
+        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
+            $userrtt = Utilities::getGETparam('roundtriptoken');
+
+            // make sure the db token is something
+            // and that what the client has passed us is that exact token
+            if( strlen($file->transfer->roundtriptoken) < 5 ||
+                $file->transfer->roundtriptoken != $userrtt ) {
+                throw new RestRoundTripTokensInvalidException();
+            }
+        }
         
         // Get chunk data
         $data = $this->request->input;

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -313,7 +313,7 @@ class RestEndpointFile extends RestEndpoint
         
         // Get file we need to add data to or update
         $file = File::fromId($id);
-        
+
         // Check access rights depending on config
         if ($security == 'key') {
             if (!array_key_exists('key', $_GET) || !$_GET['key'] || ($_GET['key'] != $file->uid)) {
@@ -326,9 +326,23 @@ class RestEndpointFile extends RestEndpoint
                 throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
             }
         }
+
+        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
+            $userrtt = Utilities::getGETparam('roundtriptoken');
+
+            // make sure the db token is something
+            // and that what the client has passed us is that exact token
+            if( strlen($file->transfer->roundtriptoken) < 5 ||
+                $file->transfer->roundtriptoken != $userrtt ) {
+                throw new RestRoundTripTokensInvalidException();
+            }
+        }
+
         
         // Get request data
         $data = $this->request->input;
+
+        
 
         $this->put_perform_testsuite($data, $file, $id, $mode, $offset);
 

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -140,6 +140,43 @@ class RestEndpointFile extends RestEndpoint
         
         return self::cast($file);
     }
+
+    /**
+     * Test that the supplied round trip token from the client meets
+     * the security configuraiton that is set for this server. This method
+     * may throw RestRoundTripTokensInvalidException to indicate failure.
+     *
+     * @param object $file
+     * @param string $rtt the round trip token from the client.
+     */
+    private function testRoundTripToken( $file, $userrtt )
+    {
+        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
+
+            // To allow old transfers to complete we allow this test to pass
+            // with a warning if there is no roundtriptoken in the database
+            // and the transfer was already 'created' before the server was upgraded
+            if( strlen($file->transfer->roundtriptoken) < 5 ) {
+                $accept_before = Config::get('chunk_upload_roundtriptoken_accept_empty_before');
+                if( $accept_before > 0 ) {
+                    if( $file->transfer->created < $accept_before ) {
+                        Logger::warn('Allowing a transfer roundtriptoken_check to pass because the transfer is older than accept_empty_before.');
+                        return;
+                    }
+                }
+            }
+            
+
+            // make sure the db token is something
+            // and that what the client has passed us is that exact token
+            if( strlen($file->transfer->roundtriptoken) < 5 ||
+                $file->transfer->roundtriptoken != $userrtt )
+            {
+                throw new RestRoundTripTokensInvalidException();
+            }
+        }
+        
+    }
     
     /**
      * Add chunk to a file or upload whole file
@@ -193,16 +230,7 @@ class RestEndpointFile extends RestEndpoint
             }
         }
 
-        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
-            $userrtt = Utilities::getGETparam('roundtriptoken');
-
-            // make sure the db token is something
-            // and that what the client has passed us is that exact token
-            if( strlen($file->transfer->roundtriptoken) < 5 ||
-                $file->transfer->roundtriptoken != $userrtt ) {
-                throw new RestRoundTripTokensInvalidException();
-            }
-        }
+        self::testRoundTripToken( $file, Utilities::getGETparam('roundtriptoken'));
         
         // Get chunk data
         $data = $this->request->input;
@@ -338,16 +366,8 @@ class RestEndpointFile extends RestEndpoint
             }
         }
 
-        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
-            $userrtt = Utilities::getGETparam('roundtriptoken');
-
-            // make sure the db token is something
-            // and that what the client has passed us is that exact token
-            if( strlen($file->transfer->roundtriptoken) < 5 ||
-                $file->transfer->roundtriptoken != $userrtt ) {
-                throw new RestRoundTripTokensInvalidException();
-            }
-        }
+        self::testRoundTripToken( $file, Utilities::getGETparam('roundtriptoken'));
+        
 
         
         // Get request data

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -45,10 +45,11 @@ class RestEndpointTransfer extends RestEndpoint
      *
      * @param Transfer $transfer
      * @param array $files_cids files client given id for strict matching
+     * @param bool $creatingTransfer if true then the roundtriptoken is also sent to the client
      *
      * @return array
      */
-    public static function cast(Transfer $transfer, $files_cids = null)
+    public static function cast(Transfer $transfer, $files_cids = null, $creatingTransfer = false )
     {
         return array(
             'id' => $transfer->id,
@@ -61,6 +62,7 @@ class RestEndpointTransfer extends RestEndpoint
             'expiry_date_extension' => $transfer->expiry_date_extension,
             'options' => $transfer->options,
             'salt' => $transfer->salt,
+            'roundtriptoken' => $creatingTransfer ? $transfer->roundtriptoken : '',
             
             'files' => array_map(function ($file) use ($files_cids) {
                 $file = RestEndpointFile::cast($file);
@@ -387,7 +389,7 @@ class RestEndpointTransfer extends RestEndpoint
                 }
             }
         }
-        
+
         if (!$creating_transfer) {
             // Add data to a specific transfer
             $transfer = Transfer::fromId($id);
@@ -695,7 +697,7 @@ class RestEndpointTransfer extends RestEndpoint
             
             return array(
                 'path' => '/transfer/'.$transfer->id,
-                'data' => self::cast($transfer, $files_cids)
+                'data' => self::cast($transfer, $files_cids, $creating_transfer)
             );
         }
     }

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -105,6 +105,22 @@ class Utilities
     }
 
     /**
+     * Generate a string contains numbytes of entropy and is then
+     * encoded as a hex string for storage in a database or transmission.
+     *
+     * @param $numbytes int number of bytes with forced min value of 16.
+     */
+    public static function generateEntropyString( $numbytes = 16 )
+    {
+        if( is_null($numbytes) || $numbytes < 16 ) {
+            $numbytes = 16;
+        }
+        $bytes = random_bytes($numbytes);
+        $ret = bin2hex($bytes);
+        return $ret;
+    }
+    
+    /**
      * Validates a personal message
      *
      */
@@ -643,5 +659,20 @@ class Utilities
             Logger::haltWithErorr('Failed to include file from path ' . $path
                                 . ' ' . $haltmsg);
         }
+    }
+
+    /**
+     * A central call to interact with the $_GET[] array
+     * 
+     * @param name name of CGI arg to get
+     * @param def default value to return if name is not set in query.
+     */
+    public static function getGETparam( $name, $def = null ) 
+    {
+        $ret = $def;
+        if(array_key_exists($name, $_GET)) {
+            $ret = $_GET[$name];
+        }
+        return $ret;
     }
 }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -122,6 +122,7 @@ A note about colours;
 * [automatic_resume_number_of_retries](#automatic_resume_number_of_retries)
 * [automatic_resume_delay_to_resume](#automatic_resume_delay_to_resume)
 * [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)
+* [chunk_upload_roundtriptoken_check_enabled](#chunk_upload_roundtriptoken_check_enabled)
 
 ## Graphs
 
@@ -1170,6 +1171,19 @@ these iteration counts take to perform on your local machine.
 * __default:__ see ConfigDefaults.php
 * __available:__ since version 2.6
 * __comment:__ 
+
+
+### chunk_upload_roundtriptoken_check_enabled
+* __description:__ Check that a random token handed out during transfer creation is always passed back exactly as expected from the client. This parameter was created to disable the check in case some edge case is discovered and a site wishes to turn off this security feature temporarily.
+* __mandatory:__ no 
+* __recommend_leaving_at_default:__ true
+* __type:__ boolean
+* __default:__ true
+* __available:__ since version 2.16
+* __comment:__ 
+
+
+
 
 
 * [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -123,6 +123,7 @@ A note about colours;
 * [automatic_resume_delay_to_resume](#automatic_resume_delay_to_resume)
 * [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)
 * [chunk_upload_roundtriptoken_check_enabled](#chunk_upload_roundtriptoken_check_enabled)
+* [chunk_upload_roundtriptoken_check_accept_before](#chunk_upload_roundtriptoken_check_accept_before)
 
 ## Graphs
 
@@ -1181,6 +1182,54 @@ these iteration counts take to perform on your local machine.
 * __default:__ true
 * __available:__ since version 2.16
 * __comment:__ 
+
+
+### chunk_upload_roundtriptoken_accept_empty_before
+* __description:__ As of FileSender 2.16 all newly created transfers will have a
+roundtriptoken created and stored on the server. The roundtriptoken is
+only sent to client when a tranfer is being created. The aim is that
+knowledge of the roundtriptoken means that a particular client is the
+one that created the transfer. The roundtriptoken is a large random
+value. The roundtriptoken is sent back by the clients during chunk
+uploads to be able to verify that they made the transfer. Creating and
+sending the roundtriptoken will happen regardless of the
+chunk_upload_roundtriptoken_check_enabled setting.
+If chunk_upload_roundtriptoken_check_enabled is set to true then the
+transfer on the server must have a roundtriptoken recorded and the
+roundtriptoken supplied by the client must match the one from the
+database on the server in order for the chunk upload to be accepted.
+Though without another option one might see a migration issue when a
+client tries to load a failed transfer and resume it. This will happen
+for example if a user revists the upload page and the dialog offers to
+reload a failed transfer. This failed transfer state will have no
+roundtriptoken on the client and as the transfer was created with
+older server code there will be no roundtriptoken stored in the
+database either.
+To allow easier migration of existing transfers this configuration
+setting can be used. If
+chunk_upload_roundtriptoken_accept_empty_before is non zero then
+transfers with an empty roundtriptoken which were created before the
+value of chunk_upload_roundtriptoken_accept_empty_before will be
+accepted. This allows transfers created before deployment of FileSender 2.16 to continue
+as they would have. It may be tempting to just allow transfers that
+have no roundtriptoken in the database to pass, but if you have set
+chunk_upload_roundtriptoken_check_enabled to true you cerainly want
+to enforce that all new transfers have a token in the database to ensure that this
+test is active.
+Setting this to the deployment time plus one week for example should
+allow existing uploads to complete. The value for the current time can
+be found using "date +%s" on a Linux machine for example. Though that
+will not have any wiggle room added.  Note that if a transfer has a roundtriptoken
+set then this setting will not change if the client must present the roundtriptoken again.
+This is only for old, existing transfers which have no roundtriptoken set.
+* __mandatory:__ no 
+* __recommend_leaving_at_default:__ false
+* __type:__ int
+* __default:__ 0
+* __available:__ since version 2.16
+* __comment:__ 
+
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -91,7 +91,7 @@ $default = array(
     'legacy_upload_progress_refresh_period' => 5,
     'upload_chunk_size' => 5 * 1024 * 1024,
     'chunk_upload_security' => 'key',
-    'chunk_upload_roundtriptoken_check_enabled' => true,
+    'chunk_upload_roundtriptoken_check_enabled' => false,
     'download_chunk_size' => 5 * 1024 * 1024,
     
     'encryption_enabled' => true,

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -91,6 +91,7 @@ $default = array(
     'legacy_upload_progress_refresh_period' => 5,
     'upload_chunk_size' => 5 * 1024 * 1024,
     'chunk_upload_security' => 'key',
+    'chunk_upload_roundtriptoken_check_enabled' => true,
     'download_chunk_size' => 5 * 1024 * 1024,
     
     'encryption_enabled' => true,

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -92,6 +92,7 @@ $default = array(
     'upload_chunk_size' => 5 * 1024 * 1024,
     'chunk_upload_security' => 'key',
     'chunk_upload_roundtriptoken_check_enabled' => false,
+    'chunk_upload_roundtriptoken_accept_empty_before' => 0,
     'download_chunk_size' => 5 * 1024 * 1024,
     
     'encryption_enabled' => true,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -552,3 +552,4 @@ $lang['email_address'] = 'Email address';
 $lang['password'] = 'Password';
 $lang['change_password'] = 'Change password';
 $lang['create_user_details'] = 'When you create a new user an email with the nominated password will be sent to their email address and they will be encouraged to login and change the password. If the user already exists in the system then attempting to create them a second time will set their password to your nominated value and send the email out to them again.';
+$lang['rest_roundtrip_token_invalid'] = 'FileSender checks that the same web browser that started an operation is used for subsequent operations to complete that operation. For example, to upload all the parts of a file. This check has failed.';

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -207,21 +207,21 @@ def postTransfer(user_id, files, recipients, subject=None, message=None, expires
     {}
   )
 
-def putChunk(f, chunk, offset):
+def putChunk(t, f, chunk, offset):
   return call(
     'put',
     '/file/'+str(f['id'])+'/chunk/'+str(offset),
-    { 'key': f['uid'] },
+    { 'key': f['uid'], 'roundtriptoken': t['roundtriptoken'] },
     None,
     chunk,
     { 'Content-Type': 'application/octet-stream' }
   )
 
-def fileComplete(f):
+def fileComplete(t,f):
   return call(
     'put',
     '/file/'+str(f['id']),
-    { 'key': f['uid'] },
+    { 'key': f['uid'], 'roundtriptoken': t['roundtriptoken'] },
     { 'complete': True },
     None,
     {}
@@ -292,12 +292,12 @@ try:
           print('Uploading: '+path+' '+str(offset)+'-'+str(min(offset+upload_chunk_size, size))+' '+str(round(offset/size*100))+'%')
         data = fin.read(upload_chunk_size)
         #print(data)
-        putChunk(f, data, offset)
+        putChunk(transfer, f, data, offset)
 
     #fileComplete
     if debug:
       print('fileComplete: '+path)
-    fileComplete(f)
+    fileComplete(transfer,f)
     if progress:
       print('Uploading: '+path+' '+str(size)+' 100%')
 

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -154,7 +154,8 @@ window.filesender.config = {
 		file_encryption_enter_password : "<?php echo Lang::tr('file_encryption_enter_password')->out(); ?>",
 		file_encryption_need_password : "<?php echo Lang::tr('file_encryption_need_password')->out(); ?>",
 		storage_filesystem_file_not_found : "<?php echo Lang::tr('storage_filesystem_file_not_found')->out(); ?>",
-		user_hit_guest_limit : "<?php echo Lang::tr('user_hit_guest_limit')->out(); ?>"
+		user_hit_guest_limit : "<?php echo Lang::tr('user_hit_guest_limit')->out(); ?>",
+		rest_roundtrip_token_invalid : "<?php echo Lang::tr('rest_roundtrip_token_invalid')->out(); ?>"
 	},
     
     clientlogs: {

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -192,6 +192,16 @@ window.filesender.client = {
                     filesender.client.authentication_required.text(lang.tr('authentication_required_explanation'));
                     return;
                 }
+
+
+                if( error.message == 'rest_roundtrip_token_invalid')
+                {
+                    filesender.ui.alert('error',
+                                        filesender.config.language.rest_roundtrip_token_invalid,
+                                        function() {} );
+                    return;
+                }
+
                 
                 if(error.message == 'undergoing_maintenance') {
                     if(filesender.client.maintenance) return;
@@ -750,7 +760,7 @@ window.filesender.client = {
     },
 
     remindLocalAuthDBPassword: function(id, password, callback ) {
-        return this.post('/user/' + id, {remind: true, username: id, password, password }, callback );
+        return this.post('/user/' + id, {remind: true, username: id, password: password }, callback );
     },
     
 

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -141,6 +141,7 @@ window.filesender.terasender = {
             },
 	    encryption: this.transfer.encryption,
 	    encryption_details: encryption_details,
+            roundtriptoken: this.transfer.roundtriptoken,
             file: {
                 id: file.id,
                 name: file.name,

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -185,6 +185,7 @@ window.filesender.transfer = function() {
     this.failed_transfer_restart = false;
     this.uploader = null;
     this.aup_checked = false;
+    this.roundtriptoken = '';
     
     this.watchdog_processes = {};
     
@@ -603,7 +604,8 @@ window.filesender.transfer = function() {
             files: [],
             file_index: 0,
             guest_token: null,
-            download_link: null
+            download_link: null,
+            roundtriptoken: this.roundtriptoken
         };
         
         for(var i=0; i<this.files.length; i++) {
@@ -728,7 +730,8 @@ window.filesender.transfer = function() {
         for(var i=0; i<tracker.files.length; i++) {
             filesender.ui.log('uploaded: ' + tracker.files[i].uploaded);
         }
-        
+
+        this.roundtriptoken = tracker.roundtriptoken;
         this.time = (new Date()).getTime();
         
         // Start uploading chunks
@@ -1022,6 +1025,9 @@ window.filesender.transfer = function() {
         
         if(this.guest_token)
             args.vid = this.guest_token;
+
+        if(this.roundtriptoken)
+            args.roundtriptoken = this.roundtriptoken;
         
         var q = [];
         for(var k in args) q.push(k + '=' + args[k]);
@@ -1180,6 +1186,7 @@ window.filesender.transfer = function() {
         filesender.client.postTransfer(this, function(path, data) {
             transfer.id = data.id;
             transfer.encryption_salt = data.salt;
+            transfer.roundtriptoken  = data.roundtriptoken;
             
             for (var i = 0; i < transfer.files.length; i++) {
                 for (var j = 0; j < data.files.length; j++) {


### PR DESCRIPTION
To add yet more security to the existing checks this PR creates a 16 byte random string when a transaction is created and returns that to the client. When the client is uploading file chunks (encrypted or not) it has to return that same roundtriptoken or the upload is rejected. This effectively binds the person creating a transfer to be the only person who can upload data to the files associated with that transfer.

Tested on Firefox, Chrome, {Edge, and IE11 on Windows 10}. In case this does something undesired in an environment is can be disabled with the chunk_upload_roundtriptoken_check_enabled config option (off by default).

This feature is off by default so that information stored in the browser that does not contain the roundtriptoken can still be used to upload a file. Also if a transfer is already in progress it will not be rejected by this test. 

Once the code in this PR is being used the roundtriptoken values are still created and sent to the client and back. At some stage, a system admin can say that transfers that were started in the browser that were not completed (say, 1 month after moving to the release) will be considered lost and turn on chunk_upload_roundtriptoken_check_enabled. This is a trade off between enabling the feature right away and annoying some users or enabling it a little later when almost all users will have the roundtriptokens in the browser for a started but abandoned transfer.

Note that the above "not completed transfer" is an abandoned transfer such as if the user navigates away from the upload page and on returning is asked if they want to setup the transfer again. Play, pause, and reconnect and resume will work right away as they will use the roundtriptoken sent when the transfer was created.

The REST filesender.py is updated. Functions such as restartFailedTransfer() are updated. 
