### PR TITLE
only get frequent email addresses over http post

### DIFF
--- a/classes/exceptions/RestExceptions.class.php
+++ b/classes/exceptions/RestExceptions.class.php
@@ -150,6 +150,22 @@ class RestMissingParameterException extends RestException
 }
 
 /**
+ * REST use POST for this feature now
+ */
+class RestUsePOSTException extends RestException
+{
+    /**
+     * Constructor
+     *
+     * @param string $name name of the missing parameter
+     */
+    public function __construct()
+    {
+        parent::__construct('rest_use_post', 403, array());
+    }
+}
+
+/**
  * REST bad parameter
  */
 class RestBadParameterException extends RestException

--- a/travis/filesender-config.php
+++ b/travis/filesender-config.php
@@ -335,3 +335,6 @@ $config['PUT_PERFORM_TESTSUITE'] = '';
 $config['crypto_pbkdf2_dialog_enabled'] = false;
 
 
+$config['internal_use_only_running_on_ci'] = 1;
+
+

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -170,6 +170,8 @@ window.filesender.config = {
 
     tr_dp_date_format:   "<?php echo Config::get('tr_dp_date_format') ?>",
     tr_dp_date_format_hint:   "<?php echo Config::get('tr_dp_date_format_hint') ?>",
+
+    internal_use_only_running_on_ci:  "<?php echo Config::get('internal_use_only_running_on_ci') ?>",
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -681,9 +681,14 @@ window.filesender.client = {
     
     
     getFrequentRecipients: function(needle, callback) {
-        return this.get('/user/@me/frequent_recipients', callback, needle ? {args: {'filterOp[email][contains]': needle}} : undefined);
+        return this.post('/user/@me',
+                         {
+                             property: 'frequent_recipients',
+                             needle: needle
+                         },
+                         callback );
     },
-    
+
     getTransferOption: function(id, option, token, callback) {
         return this.get('/transfer/' + id + '/options/' + option, callback, token ? {args: {token: token}} : undefined);
     },

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -164,20 +164,22 @@ filesender.ui.recipients = {
         
         $(filesender.ui.nodes.recipients.input).autocomplete({
             source: function (request, response) {
-                filesender.client.getFrequentRecipients(request.term,
-                    function (loc,data) {
-                        response($.map(data, function (item) { 
-                            if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
-                                return { 
-                                    label: item,
-                                    value: item
-                                };
-                            }else{
-                                return undefined;
-                            }
-                        })) 
-                    }
-                );
+                if(!filesender.config.internal_use_only_running_on_ci) {
+                    filesender.client.getFrequentRecipients(request.term,
+                        function (loc,data) {
+                            response($.map(data, function (item) { 
+                                if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
+                                    return { 
+                                        label: item,
+                                        value: item
+                                    };
+                                }else{
+                                    return undefined;
+                                }
+                            })) 
+                        }
+                    );
+                }
             },
             select: function (event, ui) {
                 filesender.ui.recipients.add(ui.item.value);

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -165,7 +165,7 @@ filesender.ui.recipients = {
         $(filesender.ui.nodes.recipients.input).autocomplete({
             source: function (request, response) {
                 filesender.client.getFrequentRecipients(request.term,
-                    function (data) {
+                    function (loc,data) {
                         response($.map(data, function (item) { 
                             if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
                                 return { 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -663,20 +663,22 @@ filesender.ui.recipients = {
         
         $(filesender.ui.nodes.recipients.input).autocomplete({
             source: function (request, response) {
-                filesender.client.getFrequentRecipients(request.term,
-                    function (loc,data) {
-                        response($.map(data, function (item) { 
-                            if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
-                                return { 
-                                    label: item,
-                                    value: item
-                                };
-                            }else{
-                                return undefined;
-                            }
-                        })) 
-                    }
-                );
+                if(!filesender.config.internal_use_only_running_on_ci) {
+                    filesender.client.getFrequentRecipients(request.term,
+                        function (loc,data) {
+                            response($.map(data, function (item) { 
+                                if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
+                                    return { 
+                                        label: item,
+                                        value: item
+                                    };
+                                }else{
+                                    return undefined;
+                                }
+                            })) 
+                        }
+                    );
+                }
             },
             select: function (event, ui) {
                 filesender.ui.recipients.add(ui.item.value);

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -664,7 +664,7 @@ filesender.ui.recipients = {
         $(filesender.ui.nodes.recipients.input).autocomplete({
             source: function (request, response) {
                 filesender.client.getFrequentRecipients(request.term,
-                    function (data) {
+                    function (loc,data) {
                         response($.map(data, function (item) { 
                             if (filesender.ui.nodes.recipients.list.find('[email="'+item+'"]').length == 0){
                                 return { 


### PR DESCRIPTION
Use HTTP post to get the list of frequent email addresses to avoid a GET request that has a chance that it might introduce some data into logs that is not necessarily desirable.