### PR TITLE
UX: better error message when you attempt to download expired or deleted transfer

### DIFF
--- a/classes/exceptions/TransferExceptions.class.php
+++ b/classes/exceptions/TransferExceptions.class.php
@@ -334,6 +334,22 @@ class TransferExpiredException extends TransferException
 }
 
 /**
+ * Presumed Expired, when a recipient token is given but it is not found in the database
+ */
+class TransferPresumedExpiredException extends TransferException
+{
+    /**
+     * Constructor
+     *
+     * @param Transfer $transfer
+     */
+    public function __construct()
+    {
+        parent::__construct(null, 'presumed_expired');
+    }
+}
+
+/**
  * Not available
  */
 class TransferNotAvailableException extends TransferException

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -474,6 +474,7 @@ $lang['tracking_unknown_event'] = 'Unknown tracking event';
 $lang['transfer_closed'] = 'Transfer closed';
 $lang['transfer_deleted'] = 'Transfer deleted';
 $lang['transfer_expired'] = 'Transfer expired';
+$lang['transfer_presumed_expired'] = 'The transfer has expired and files have been deleted from {cfg:site_name}.';
 $lang['transfer_expiry_extension_count_exceeded'] = 'Transfer expiry date extension maximum reached';
 $lang['transfer_expiry_extension_not_allowed'] = 'Transfer expiry date extension is not allowed';
 $lang['transfer_extended'] = 'Expiry date extended until {expires}';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -9,8 +9,12 @@
     $token = $_REQUEST['token'];
     if(!Utilities::isValidUID($token))
         throw new TokenHasBadFormatException($token);
-    
-    $recipient = Recipient::fromToken($token); // Throws
+
+    try {
+        $recipient = Recipient::fromToken($token); // Throws
+    } catch (RecipientNotFoundException $e) {
+        throw new TransferPresumedExpiredException();
+    }
     $transfer = $recipient->transfer;
     
     if($transfer->isExpired()) throw new TransferExpiredException($transfer);

--- a/www/download.php
+++ b/www/download.php
@@ -52,6 +52,7 @@ try {
     
     if(count($files_ids) != count($good_files_ids))
         throw new DownloadBadFilesIDsException(array_diff($files_ids, $good_files_ids));
+
     
     if(array_key_exists('token', $_REQUEST)) {
         // Token on get request
@@ -59,9 +60,13 @@ try {
         
         if(!Utilities::isValidUID($token))
             throw new TokenHasBadFormatException($token);
-        
-        // Getting recipient from the token
-        $recipient = Recipient::fromToken($token); // Throws
+
+        try {
+            // Getting recipient from the token
+            $recipient = Recipient::fromToken($token); // Throws
+        } catch (RecipientNotFoundException $e) {
+            throw new TransferPresumedExpiredException();
+        }
         
         // Getting associated transfer 
         $transfer = $recipient->transfer;


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/754

It was certainly confusing to see the old error message. I have used a new "presumed expired" exception type because we don't really know what happened to the data, if it was once valid it has been removed from the database but it might also be that it never was in there in the first place. We presume it expired because we presume the link was once valid.