### PR TITLE
email addresses are case insensitive.

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -401,7 +401,7 @@ class User extends DBObject
         // Filter if requested
         if ($criteria) {
             $recipients = array_filter($recipients, function ($recipient) use ($criteria) {
-                return strpos($recipient->email, $criteria) !== false;
+                return stripos($recipient->email, $criteria) !== false;
             });
         }
         


### PR DESCRIPTION
The user should not have to remember the case used to find a frequent email address. This addresses the issue first reported here https://github.com/filesender/filesender/issues/531
