### PR TITLE
hide download password text visibility by default, option in dialog to show it

### DIFF
--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -155,7 +155,8 @@ window.filesender.config = {
 		file_encryption_need_password : "<?php echo Lang::tr('file_encryption_need_password')->out(); ?>",
 		storage_filesystem_file_not_found : "<?php echo Lang::tr('storage_filesystem_file_not_found')->out(); ?>",
 		user_hit_guest_limit : "<?php echo Lang::tr('user_hit_guest_limit')->out(); ?>",
-		rest_roundtrip_token_invalid : "<?php echo Lang::tr('rest_roundtrip_token_invalid')->out(); ?>"
+		rest_roundtrip_token_invalid : "<?php echo Lang::tr('rest_roundtrip_token_invalid')->out(); ?>",
+		file_encryption_show_password : "<?php echo Lang::tr('file_encryption_show_password')->out(); ?>"
 	},
     
     clientlogs: {

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -855,7 +855,18 @@ window.filesender.crypto_app = function () {
             });
 
             // Add a field to the prompt
-            var input = $('<input type="text" class="wide" />').appendTo(prompt);
+            var trshowhide = window.filesender.config.language.file_encryption_show_password;
+            var input = $('<input id="dlpass" type="password" class="wide" autocomplete="new-password" />').appendTo(prompt);
+            var toggleView = $('<br/><input type="checkbox" id="showdlpass" name="showdlpass" value="false"><label for="showdlpass">' + trshowhide + '</label>');
+            prompt.append(toggleView);
+            $('#showdlpass').on(
+                "click",
+                function() {
+                    var v = $('#showdlpass').is(':checked');
+                    if( v ) { $('#dlpass').attr('type','text'); }
+                    else    { $('#dlpass').attr('type','password'); }
+                }
+            );
             input.focus();
         },
         /**


### PR DESCRIPTION
As mentioned in https://github.com/filesender/filesender/issues/757 there is a difference between the encrypt and decrypt password input. This PR makes the decrypt password hidden by default with a checkbox option to show/hide it, similar to the upload page.
