### PR TITLE
Fix wrong jquery test

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -91,7 +91,7 @@ $(function() {
         var id = $(this).closest('[data-transfer]').attr('data-id');
         if(!id || isNaN(id)) return;
         
-        if($(this).closest('table').filter('[data-mode="admin"][data-status="available"]')) {
+        if($(this).closest('table').is('[data-mode="admin"][data-status="available"]')) {
             var d = filesender.ui.chooseAction(['delete_transfer_nicely', 'delete_transfer_roughly'], function(choosen) {
                 var done = function() {
                     $('[data-transfer][data-id="' + id + '"]').remove();
@@ -110,7 +110,7 @@ $(function() {
                         break;
                 }
             });
-        } else if($(this).closest('table').filter('[data-mode="admin"][data-status="uploading"]')) {
+        } else if($(this).closest('table').is('[data-mode="admin"][data-status="uploading"]')) {
             filesender.ui.confirm(lang.tr('stop_transfer_upload'), function() {
                 filesender.client.deleteTransfer(id, function() {
                     $('[data-transfer][data-id="' + id + '"]').remove();


### PR DESCRIPTION
Fix wrong jquery test that led regular users to be presented with admin transfer deletion options (delete with notice or delete crudely) instead of closing the transfer as expected.