### PR TITLE
Use db sum instead of fetching all individual sizes

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -468,7 +468,7 @@ class Transfer extends DBObject
         $quota = Config::get('host_quota');
         
         $used = 0;
-        $s = DBI::query('SELECT size FROM '.File::getDBTable().' INNER JOIN '.self::getDBTable().' ON ('.self::getDBTable().'.id = '.File::getDBTable().'.transfer_id) WHERE status=\'available\'');
+        $s = DBI::query('SELECT SUM(size) AS size FROM '.File::getDBTable().' INNER JOIN '.self::getDBTable().' ON ('.self::getDBTable().'.id = '.File::getDBTable().'.transfer_id) WHERE status=\'available\'');
         foreach ($s->fetchAll() as $r) {
             $used += $r['size'];
         }


### PR DESCRIPTION
Transfer space usage was evaluated by fetching all individual stored files' sizes which, when there was a lot of online transfers, lead to php memory exhaustion, switching to db side sum fixes that problem.