### PR TITLE
Move to a new havePermission method for testing access

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -632,6 +632,40 @@ class Transfer extends DBObject
     {
         return $this->owner->is($user);
     }
+
+    /**
+     * Check that the user has read/write permission 
+     * for this transfer.
+     * 
+     * @return true if they are allowed or false if access should be forbidden
+     */
+    public function havePermission()
+    {
+        $user = Auth::user();
+
+        // This should never happen
+        if (Auth::isGuest() && Auth::isAdmin()) {
+            return FALSE;
+        }
+        
+        if (Auth::isGuest()) {
+            $guest = AuthGuest::getGuest();
+            if( !$guest ) {
+                return FALSE;
+            }
+            if( $guest->id != $this->guest_id ) {
+                return FALSE;
+            }
+        }
+        
+        if (!$this->isOwner($user)) {
+            if( !Auth::isAdmin()) {
+                return FALSE;
+            }
+        }
+
+        return TRUE;
+    }
     
     /**
      * Get all options

--- a/classes/exceptions/RestExceptions.class.php
+++ b/classes/exceptions/RestExceptions.class.php
@@ -134,6 +134,31 @@ class RestOwnershipRequiredException extends RestException
 }
 
 /**
+ * Used when Transfer::havePermission() returns false. 
+ * Similar to throwing RestOwnershipRequiredException but
+ * user info does not need to be passed it is taken from 
+ * active environment.
+ */
+class RestTransferPermissionRequiredException extends RestException
+{
+    /**
+     * Constructor
+     *
+     * @param mixed $resource the wanted resource selector
+     */
+    public function __construct($resource)
+    {
+        $user = Auth::user();
+        $uid = $user->id;
+        if (Auth::isGuest()) {
+            $guest = AuthGuest::getGuest();
+            $uid = $guest->id;
+        }
+        parent::__construct('rest_ownership_required', 403, array('uid' => $uid, 'ressource' => $resource));
+    }
+}
+
+/**
  * REST missing parameter
  */
 class RestMissingParameterException extends RestException

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -131,11 +131,10 @@ class RestEndpointFile extends RestEndpoint
         }
         
         // Get required file and current user then check ownership
-        $user = Auth::user();
         $file = File::fromId($id);
         
-        if (!$file->transfer->isOwner($user) && !Auth::isAdmin()) {
-            throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
+        if( !$file->transfer->havePermission()) {
+            throw new RestTransferPermissionRequiredException('file = '.$file->id);
         }
         
         return self::cast($file);
@@ -223,10 +222,8 @@ class RestEndpointFile extends RestEndpoint
                 throw new RestAuthenticationRequiredException();
             }
         } else {
-            $user = Auth::user();
-            
-            if (!$file->transfer->isOwner($user) && !Auth::isAdmin()) {
-                throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
+            if( !$file->transfer->havePermission()) {
+                throw new RestTransferPermissionRequiredException('file = '.$file->id);
             }
         }
 
@@ -359,10 +356,8 @@ class RestEndpointFile extends RestEndpoint
                 throw new RestAuthenticationRequiredException();
             }
         } else {
-            $user = Auth::user();
-            
-            if (!$file->transfer->isOwner($user) && !Auth::isAdmin()) {
-                throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
+            if( !$file->transfer->havePermission()) {
+                throw new RestTransferPermissionRequiredException('file = '.$file->id);
             }
         }
 
@@ -532,12 +527,11 @@ class RestEndpointFile extends RestEndpoint
         }
         
         // Get file object and user ...
-        $user = Auth::user();
         $file = File::fromId($id);
-        
+
         // ... and check ownership
-        if (!$file->transfer->isOwner($user) && !Auth::isAdmin()) {
-            throw new RestOwnershipRequiredException($user->id, 'file = '.$file->id);
+        if( !$file->transfer->havePermission()) {
+            throw new RestTransferPermissionRequiredException('file = '.$file->id);
         }
         
         if (count($file->transfer->files) > 1) {

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -199,8 +199,8 @@ class RestEndpointTransfer extends RestEndpoint
             $transfer = Transfer::fromId($id);
             
             // Check ownership
-            if (!$transfer->isOwner($user) && !Auth::isAdmin()) {
-                throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
+            if( !$transfer->havePermission()) {
+                throw new RestTransferPermissionRequiredException('transfer = '.$transfer->id);
             }
             
             // Only want transfer options
@@ -395,8 +395,8 @@ class RestEndpointTransfer extends RestEndpoint
             $transfer = Transfer::fromId($id);
             
             // Check ownership
-            if (!$transfer->isOwner($user) && !Auth::isAdmin()) {
-                throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
+            if( !$transfer->havePermission()) {
+                throw new RestTransferPermissionRequiredException('transfer = '.$transfer->id);
             }
             
             // Cannot update a closed transfer
@@ -771,8 +771,8 @@ class RestEndpointTransfer extends RestEndpoint
             }
         } else {
             // check ownership
-            if (!$transfer->isOwner($user) && !Auth::isAdmin()) {
-                throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
+            if( !$transfer->havePermission()) {
+                throw new RestTransferPermissionRequiredException('transfer = '.$transfer->id);
             }
             
             // Close and remind action need to stay here as only complete action is allowed with either session or key
@@ -835,10 +835,8 @@ class RestEndpointTransfer extends RestEndpoint
         
         $transfer = Transfer::fromId($id);
         
-        $user = Auth::user();
-        
-        if (!$transfer->isOwner($user) && !Auth::isAdmin()) {
-            throw new RestOwnershipRequiredException($user->id, 'transfer = '.$transfer->id);
+        if( !$transfer->havePermission()) {
+            throw new RestTransferPermissionRequiredException('transfer = '.$transfer->id);
         }
         
         // Delete the transfer (not recoverable)


### PR DESCRIPTION
This moves code from being replicated to test access into a new Transfer::havePermission() method to make the code checking for permission simpler. A new exception class was also added to avoid having to pass the user->id around to slipstream that code path.