### PR TITLE
do not go sifting a non array if there was an exception

### DIFF
--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -240,8 +240,10 @@ class RestServer
                         foreach ($v as $p => $f) {
                             $request->filterOp[$p] = array();
                             foreach (array('equals', 'startWith', 'contains', 'present') as $k) {
-                                if (array_key_exists($k, $f)) {
-                                    $request->filterOp[$p][$k] = $f[$k];
+                                if (is_array($f)) {
+                                    if (array_key_exists($k, $f)) {
+                                        $request->filterOp[$p][$k] = $f[$k];
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
If there was an exception during processing of the filter operation then do not try to lookup values there as that is not going to be an array and will cause issues for those who have
```
display_errors = On
```
in /etc/php.ini.
