### PR TITLE
db: make translatableemails.variables mediumtext

### DIFF
--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -69,7 +69,7 @@ class TranslatableEmail extends DBObject
             'size' => 255
         ),
         'variables' => array(
-            'type' => 'text',
+            'type' => 'mediumtext',
             'transform' => 'json'
         ),
         'created' => array(

--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -251,6 +251,10 @@ class DatabaseMysql
             case 'text':
                 $typematcher = 'text';
                 break;
+
+            case 'mediumtext':
+                $typematcher = 'mediumtext';
+                break;
             
             case 'date':
                 $typematcher = 'date';
@@ -404,7 +408,11 @@ class DatabaseMysql
             case 'text':
                 $mysql = 'TEXT';
                 break;
-            
+
+            case 'mediumtext':
+                $mysql = 'MEDIUMTEXT';
+                break;
+                
             case 'date':
                 $mysql = 'DATE';
                 break;

--- a/classes/utils/DatabasePgsql.class.php
+++ b/classes/utils/DatabasePgsql.class.php
@@ -349,7 +349,11 @@ class DatabasePgsql
             case 'text':
                 $typematcher = 'text';
                 break;
-            
+
+            case 'mediumtext':
+                $typematcher = 'text';
+                break;
+                
             case 'date':
                 $typematcher = 'date';
                 break;
@@ -491,7 +495,11 @@ class DatabasePgsql
                 case 'text':
                     $type .= 'text';
                     break;
-                
+
+                case 'mediumtext':
+                    $type .= 'text';
+                    break;
+                    
                 case 'date':
                     $type .= 'date';
                     break;
@@ -610,7 +618,11 @@ class DatabasePgsql
             case 'text':
                 $sql .= 'text';
                 break;
-            
+
+            case 'mediumtext':
+                $sql .= 'text';
+                break;
+                
             case 'date':
                 $sql .= 'date';
                 break;


### PR DESCRIPTION
As recommended in https://github.com/filesender/filesender/issues/574 the variables in translatableemails is larger now. Longer term, it may make sense to have the code writing those variables trim down large (and hopefully redundant) data from variables.