### PR TITLE
cron: seems running locally can bump into an issue with no REMOTE_ADDR

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -347,8 +347,12 @@ class Utilities
             return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
         });
         
-        if(!count($ips))
-            return $_SERVER['REMOTE_ADDR']; // fallback
+        if(!count($ips)) {
+            if (array_key_exists('REMOTE_ADDR', $_SERVER)) {
+                return $_SERVER['REMOTE_ADDR']; // fallback
+            }
+            return '127.0.0.1';
+        }
         
         return array_pop($ips);
     }


### PR DESCRIPTION
I found a few things bumping into this running a cron job locally. It seemed like a nice idea to make the REMOTE_ADDR 127.0.0.1 if it is not found and is running in a cron job.