### PR TITLE
admin transfers page allow sorting

### DIFF
--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -247,7 +247,16 @@ class DBObject
      */
     private static function buildStatement($selectClause, $criteria = null, $placeholders = array())
     {
-        $query = 'SELECT ' . $selectClause . ' FROM '.static::getDBTable();
+        $tablename = static::getDBTable();
+        if (is_array($criteria)) {
+            if (array_key_exists('view', $criteria)) {
+                $v = $criteria['view'];
+                if( $v ) {
+                    $tablename = $v;
+                }
+            }
+        }
+        $query = 'SELECT ' . $selectClause . ' FROM '. $tablename . ' ';
         $count = null;
         $offset = null;
         

--- a/classes/utils/TransferQueryOrder.class.php
+++ b/classes/utils/TransferQueryOrder.class.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+/**
+ * Class containing transfer table sort options
+ */
+class TransferQueryOrder
+{
+
+    // These are the columns in an SQL table or view
+    const COLUMN_CREATED = 'created';
+    const COLUMN_EXPIRES = 'expires';
+    const COLUMN_SIZE    = 'size';
+    const COLUMN_RECIPIENTS = 'recipients';
+    const COLUMN_ID = 'id';
+    const COLUMN_FILE = 'file';
+    const COLUMN_DOWNLOAD = 'download';
+
+    // These are the only valid valules for CGI parameter to select sort ordering.
+    // there must be a COLUMN_NAME plus _desc in these string values for all the above
+    // otherwise functions like screenArrowHTML() will not work as expected.
+    const SORT_EXPIRES_DESC = 'expires_desc';
+    const SORT_EXPIRES_ASC  = 'expires_asc';
+    const SORT_CREATED_DESC = 'created_desc';
+    const SORT_CREATED_ASC  = 'created_asc';
+    const SORT_SIZE_DESC    = 'size_desc';
+    const SORT_SIZE_ASC     = 'size_asc';
+    const SORT_RECIPIENTS_DESC = 'recipients_desc';
+    const SORT_RECIPIENTS_ASC  = 'recipients_asc';
+    const SORT_ID_DESC         = 'id_desc';
+    const SORT_ID_ASC          = 'id_asc';
+    const SORT_FILE_DESC       = 'file_desc';
+    const SORT_FILE_ASC        = 'file_asc';
+    const SORT_DOWNLOAD_DESC   = 'download_desc';
+    const SORT_DOWNLOAD_ASC    = 'download_asc';
+    
+    protected $usedSort     = 'created_desc'; // default, this is explicitly cleaned from the $cgiparam
+    protected $columnname   = 'created';
+    protected $orderclause  = ' created DESC';
+    protected $whereclause  = '';
+    protected $viewname     = null;
+
+    protected function __construct($cgiparam = 'transfersort')
+    {
+        // we validate $order by explicitly checking for constants
+        // and then throw it away because it came from CGI
+        $order = Utilities::arrayKeyOrDefault( $_GET, $cgiparam, 'created_desc' );
+        
+        switch($order) {
+            case self::SORT_EXPIRES_DESC:
+                $this->usedSort = $order;
+                $this->columnname = self::COLUMN_EXPIRES;
+                $this->orderclause = ' expires DESC';
+                break;
+            case self::SORT_EXPIRES_ASC:
+                $this->usedSort = $order;
+                $this->columnname = self::COLUMN_EXPIRES;
+                $this->orderclause = ' expires ASC';
+                break;
+            case self::SORT_CREATED_DESC:
+                $this->usedSort = $order;
+                $this->columnname = self::COLUMN_CREATED;
+                $this->orderclause = ' created DESC';
+                break;
+            case self::SORT_CREATED_ASC:
+                $this->usedSort = $order;
+                $this->columnname = self::COLUMN_CREATED;
+                $this->orderclause = ' created ASC';
+                break;
+            case self::SORT_SIZE_DESC:
+                $this->usedSort = $order;
+                $this->viewname    = 'transferssizeview';
+                $this->orderclause = ' size DESC, created DESC';
+                $this->columnname  = self::COLUMN_SIZE;
+                break;
+            case self::SORT_SIZE_ASC:
+                $this->usedSort = $order;
+                $this->viewname    = 'transferssizeview';
+                $this->orderclause = ' size ASC, created DESC ';
+                $this->columnname  = self::COLUMN_SIZE;
+                break;
+            case self::SORT_RECIPIENTS_DESC:
+                $this->usedSort = $order;
+                $this->viewname    = 'transfersrecipientview';
+                $this->orderclause = ' recipientemail DESC, created DESC ';
+                $this->columnname  = self::COLUMN_RECIPIENTS;
+                break;
+            case self::SORT_RECIPIENTS_ASC:
+                $this->usedSort = $order;
+                $this->viewname    = 'transfersrecipientview';
+                $this->orderclause = ' recipientemail ASC, created DESC ';
+                $this->columnname  = self::COLUMN_RECIPIENTS;
+                break;
+            case self::SORT_ID_DESC:
+                $this->usedSort = $order;
+                $this->orderclause = ' id DESC, created DESC ';
+                $this->columnname  = self::COLUMN_ID;
+                break;
+            case self::SORT_ID_ASC:
+                $this->usedSort = $order;
+                $this->orderclause = ' id ASC, created DESC ';
+                $this->columnname  = self::COLUMN_ID;
+                break;
+            case self::SORT_FILE_DESC:
+                $this->usedSort    = $order;
+                $this->viewname    = 'transfersfilesview';
+                $this->orderclause = ' filename DESC, created DESC ';
+                $this->columnname  = self::COLUMN_FILE;
+                break;
+            case self::SORT_FILE_ASC:
+                $this->usedSort    = $order;
+                $this->viewname    = 'transfersfilesview';
+                $this->orderclause = ' filename ASC, created DESC ';
+                $this->columnname  = self::COLUMN_FILE;
+                break;
+            case self::SORT_DOWNLOAD_DESC:
+                $this->usedSort    = $order;
+                $this->viewname    = 'transfersauditlogsdlcountview';
+                $this->orderclause = ' count DESC, created DESC ';
+                $this->columnname  = self::COLUMN_DOWNLOAD;
+//                $this->whereclause = " ( event = 'download_ended' or event = 'archive_download_ended' ) ";
+                break;
+            case self::SORT_DOWNLOAD_ASC:
+                $this->usedSort    = $order;
+                $this->viewname    = 'transfersauditlogsdlcountview';
+                $this->orderclause = ' count ASC, created DESC ';
+                $this->columnname  = self::COLUMN_DOWNLOAD;
+//                $this->whereclause = " ( event = 'download_ended' or event = 'archive_download_ended' ) ";
+                break;
+                
+            default:
+                $this->usedSort = self::SORT_CREATED_DESC;
+                $this->orderclause = ' created DESC';
+                $this->columnname  = self::COLUMN_CREATED;
+                break;
+        }
+    }
+    
+    public static function create($cgiparam = 'transfersort')
+    {
+        $obj = new TransferQueryOrder($cgiparam);
+        return $obj;
+    }
+    public static function reverseSort( $v )
+    {
+        if( strstr( $v, '_desc' )) {
+            return str_replace( '_desc', '_asc', $v );
+        }
+        return str_replace( '_asc', '_desc', $v );
+    }
+
+    public function getViewName()
+    {
+        return $this->viewname;
+    }
+    public function getWhereClause( $useAnd )
+    {
+        if( $this->whereclause == '' ) {
+            return $this->whereclause;
+        }
+        $ret = '';
+        if( $useAnd ) {
+            $ret .= ' AND ';
+        }
+        $ret .= $this->whereclause;
+        return $ret;
+    }
+    public function getOrderByClause()
+    {
+        return $this->orderclause;
+    }
+    public function getUsedSort()
+    {
+        return $this->usedSort;
+    }
+    public function clickableSortValue( $col )
+    {
+        if( $this->columnname == $col ) {
+            return self::reverseSort($this->usedSort);
+        }
+        return $col . '_desc';
+    }
+    public function screenArrowHTML($sortcol)
+    {
+        if( $this->columnname != $sortcol ) {
+            return "";
+        }
+        if( strstr( $this->usedSort, '_asc' )) {
+            return "<i class='fa fa-angle-up'></i>";
+        }
+        return "<i class='fa fa-angle-down'></i>";
+    }
+}

--- a/templates/admin_transfers_section.php
+++ b/templates/admin_transfers_section.php
@@ -30,11 +30,12 @@ $transfers_page = function($status) {
     ));
     
     $navigation = '<div class="transfers_list_page_navigation">'."\n";
-    
+    $transfersort = Utilities::getGETparam('transfersort','');
+
     if($offset) {
         $po = max(0, $offset - $page_size);
-        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo=0#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-double-left fa-stack-1x fa-inverse"></i></span></a>'."\n";
-        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$po.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-left fa-stack-1x fa-inverse"></i></span></a>'."\n";
+        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo=0&transfersort='.$transfersort.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-double-left fa-stack-1x fa-inverse"></i></span></a>'."\n";
+        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$po.'&transfersort='.$transfersort.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-left fa-stack-1x fa-inverse"></i></span></a>'."\n";
     }
     
     $p = 1;
@@ -42,7 +43,7 @@ $transfers_page = function($status) {
         if($o >= $offset && $o < $offset + $page_size) {
             $navigation .= '<span>'.$p.'</span>'."\n";
         } else {
-            $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$o.'#'.$status.'_transfers">'.$p.'</a>'."\n";
+            $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$o.'&transfersort='.$transfersort.'#'.$status.'_transfers">'.$p.'</a>'."\n";
         }
         
         $p++;
@@ -51,8 +52,8 @@ $transfers_page = function($status) {
     if($offset + $page_size < $total_count) {
         $no = $offset + $page_size;
         $lo = $total_count - ($total_count % $page_size);
-        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$no.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
-        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$lo.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-double-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
+        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$no.'&transfersort='.$transfersort.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
+        $navigation .= '<a href="?s=admin&as=transfers&'.$status.'_tpo='.$lo.'&transfersort='.$transfersort.'#'.$status.'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-double-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
     }
     
     $navigation .= '</div>'."\n";

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -1,4 +1,7 @@
 <?php
+$nosort = false;
+if(!isset($trsort))  $nosort = true;
+
     if(!isset($status)) $status = 'available';
     if(!isset($mode)) $mode = 'user';
     if(!isset($transfers) || !is_array($transfers)) $transfers = array();
@@ -16,8 +19,12 @@
 
 if (!function_exists('clickableHeader')) {
 
-    function clickableHeader($displayName,$trsortcol,$trsort) {
-    
+    function clickableHeader($displayName,$trsortcol,$trsort,$nosort) {
+        
+        if( $nosort ) {
+            echo $displayName;
+            return;
+        }
         $tr_url = Utilities::http_build_query(array(
             's' => Utilities::getGETparam('s','')
           , 'transfersort' => $trsort->clickableSortValue($trsortcol)
@@ -84,7 +91,7 @@ if (!function_exists('clickableHeader')) {
             </th>
             
             <th class="transfer_id">
-                <?php clickableHeader('{tr:transfer_id}',TransferQueryOrder::COLUMN_ID,$trsort); ?>
+                <?php clickableHeader('{tr:transfer_id}',TransferQueryOrder::COLUMN_ID,$trsort,$nosort); ?>
             </th>
             
             <?php if($show_guest) { ?>
@@ -94,23 +101,23 @@ if (!function_exists('clickableHeader')) {
             <?php } ?>
             
             <th class="recipients">
-                <?php clickableHeader('{tr:recipients}',TransferQueryOrder::COLUMN_RECIPIENTS,$trsort); ?>
+                <?php clickableHeader('{tr:recipients}',TransferQueryOrder::COLUMN_RECIPIENTS,$trsort,$nosort); ?>
             </th>
             
             <th class="size">
-                <?php clickableHeader('{tr:size}',TransferQueryOrder::COLUMN_SIZE,$trsort); ?>
+                <?php clickableHeader('{tr:size}',TransferQueryOrder::COLUMN_SIZE,$trsort,$nosort); ?>
             </th>
             
             <th class="files">
-                <?php clickableHeader('{tr:files}',TransferQueryOrder::COLUMN_FILE,$trsort); ?>
+                <?php clickableHeader('{tr:files}',TransferQueryOrder::COLUMN_FILE,$trsort,$nosort); ?>
             </th>
             
             <th class="downloads">
-                <?php clickableHeader('{tr:downloads}',TransferQueryOrder::COLUMN_DOWNLOAD,$trsort); ?>
+                <?php clickableHeader('{tr:downloads}',TransferQueryOrder::COLUMN_DOWNLOAD,$trsort,$nosort); ?>
             </th>
             
             <th class="expires">
-                <?php clickableHeader('{tr:expires}',TransferQueryOrder::COLUMN_EXPIRES,$trsort); ?>
+                <?php clickableHeader('{tr:expires}',TransferQueryOrder::COLUMN_EXPIRES,$trsort,$nosort); ?>
             </th>
             
             <th class="actions">

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -60,12 +60,13 @@ if (!function_exists('clickableHeader')) {
         $cgioffset = $pagerprefix . 'offset';
         $cgilimit  = $pagerprefix . 'limit';
         $nextPage  = $offset+$limit;
-        $nextLink  = "$base&$cgioffset=$nextPage&$cgilimit=$limit";
+        $transfersort = Utilities::getGETparam('transfersort','');
+        $nextLink  = "$base&$cgioffset=$nextPage&$cgilimit=$limit&transfersort=$transfersort";
         
         if( $havePrev ) {
            $prevPage = max(0,$offset-$limit);
-           echo "<td class='pageprev0'><a href='$base&$cgioffset=0&$cgilimit=$limit'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-double-left fa-stack-1x fa-inverse'></i></span></a></td>";
-           echo "<td class='pageprev'><a href='$base&$cgioffset=$prevPage&$cgilimit=$limit'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-left fa-stack-1x fa-inverse'></i></span></a></td>";
+           echo "<td class='pageprev0'><a href='$base&$cgioffset=0&$cgilimit=$limit&transfersort=$transfersort'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-double-left fa-stack-1x fa-inverse'></i></span></a></td>";
+           echo "<td class='pageprev'><a href='$base&$cgioffset=$prevPage&$cgilimit=$limit&transfersort=$transfersort'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-left fa-stack-1x fa-inverse'></i></span></a></td>";
         } else {
            echo "<td class='pageprev0'>&nbsp;&nbsp;</td><td class='pageprev'>&nbsp;</td>";
         }

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -5,11 +5,29 @@
     if(!isset($limit)) $limit = 100000;
     if(!isset($offset)) $offset = 0;
     if(!isset($pagerprefix)) $pagerprefix = '';
+    if(!isset($trsort)) $trsort = TransferQueryOrder::create(); 
     $show_guest = isset($show_guest) ? (bool)$show_guest : false;
     $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
     $audit = (bool)Config::get('auditlog_lifetime') ? '1' : '';
     $haveNext = 0;
     $havePrev = 0;
+
+
+
+if (!function_exists('clickableHeader')) {
+
+    function clickableHeader($displayName,$trsortcol,$trsort) {
+    
+        $tr_url = Utilities::http_build_query(array(
+            's' => Utilities::getGETparam('s','')
+          , 'transfersort' => $trsort->clickableSortValue($trsortcol)
+        ));
+        echo '<a href="' . $tr_url . '">';
+        echo $displayName;
+        echo ' ' . $trsort->screenArrowHTML($trsortcol); 
+        echo '</a>';
+    }
+}
 
 
     // This allows us to key informational displays to a large
@@ -66,7 +84,7 @@
             </th>
             
             <th class="transfer_id">
-                {tr:transfer_id}
+                <?php clickableHeader('{tr:transfer_id}',TransferQueryOrder::COLUMN_ID,$trsort); ?>
             </th>
             
             <?php if($show_guest) { ?>
@@ -76,23 +94,23 @@
             <?php } ?>
             
             <th class="recipients">
-                {tr:recipients}
+                <?php clickableHeader('{tr:recipients}',TransferQueryOrder::COLUMN_RECIPIENTS,$trsort); ?>
             </th>
             
             <th class="size">
-                {tr:size}
+                <?php clickableHeader('{tr:size}',TransferQueryOrder::COLUMN_SIZE,$trsort); ?>
             </th>
             
             <th class="files">
-                {tr:files}
+                <?php clickableHeader('{tr:files}',TransferQueryOrder::COLUMN_FILE,$trsort); ?>
             </th>
             
             <th class="downloads">
-                {tr:downloads}
+                <?php clickableHeader('{tr:downloads}',TransferQueryOrder::COLUMN_DOWNLOAD,$trsort); ?>
             </th>
             
             <th class="expires">
-                {tr:expires}
+                <?php clickableHeader('{tr:expires}',TransferQueryOrder::COLUMN_EXPIRES,$trsort); ?>
             </th>
             
             <th class="actions">


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/745 so the admin section the transfers listings can be sorted by clicking on the table headers.

A follow up PR might also use this base code for the my transfers page to allow the user to sort their transfers view too.