### PR TITLE
config: a validation script to do more complex validation

### DIFF
--- a/classes/data/ClientLog.class.php
+++ b/classes/data/ClientLog.class.php
@@ -235,7 +235,7 @@ class ClientLog extends DBObject
      * by calling class::validateConfig() so that particular pages do not
      * have to be loaded to find configuration issues.
      */
-    public static function validateConfig()
+    public static function validateConfig( $allowSlowerTests = false )
     {
         $days = Config::get('clientlogs_lifetime');
         if (!$days || !is_int($days) || $days <= 0) {
@@ -245,6 +245,9 @@ class ClientLog extends DBObject
         $size = Config::get('clientlogs_stashsize');
         if (!is_int($size) || ($size <= 0)) {
             throw new ConfigBadParameterException('clientlogs_stashsize must be a positive integer');
+        }
+
+        if( $allowSlowerTests ) {
         }
     }
 

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -538,9 +538,13 @@ class Guest extends DBObject
      * by calling class::validateConfig() so that particular pages do not
      * have to be loaded to find configuration issues.
      */
-    public static function validateConfig()
+    public static function validateConfig( $allowSlowerTests = false )
     {
         self::allOptions();
+
+        if( $allowSlowerTests ) {
+        }
+        
     }
     
     /**

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -329,6 +329,21 @@ class Config
         Guest::validateConfig();
         ClientLog::validateConfig();
     }
+
+    
+    public static function performLongerValidation()
+    {
+        Config::get('db_database');
+
+        echo "performing longer configuration validation...\n";
+        Logger::info("You have executed checkconfig.php to perform longer validation...");
+        
+        $allowSlowerTests = true;
+        Guest::validateConfig($allowSlowerTests);
+        ClientLog::validateConfig($allowSlowerTests);
+        
+        echo "longer configuration validation has passed\n";
+    }
             
     /**
      * Get virtualhosts list

--- a/scripts/upgrade/checkconfig.php
+++ b/scripts/upgrade/checkconfig.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../includes/init.php';
+
+Logger::setProcess(ProcessTypes::UPGRADE);
+
+echo "FileSender checkconfig.php starting at " . date(DateTimeInterface::RFC850) . "\n";
+echo "Your database is " . Config::get('db_database') . "\n";
+
+Config::performLongerValidation();
+
+echo "FileSender checkconfig.php completed at " . date(DateTimeInterface::RFC850) . "\n";


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/633.

While there are no new tests in place this opens the door for longer tests on configuration settings. One issue here is if tests should be moved from Config::load() and moved to the longer validation method instead of being performed on every call for a static config.
