### PR TITLE
ui: allow tables on my transfers page to be sorted

### DIFF
--- a/templates/transfers_page.php
+++ b/templates/transfers_page.php
@@ -1,31 +1,72 @@
 <?php
 
     $openoffset   = Utilities::arrayKeyOrDefault( $_GET, 'openoffset',    0, FILTER_VALIDATE_INT  );
-    $openlimit    = Utilities::arrayKeyOrDefault( $_GET, 'openlimit',    10, FILTER_VALIDATE_INT  );
+    $openlimit    = Utilities::arrayKeyOrDefault( $_GET, 'openlimit',    15, FILTER_VALIDATE_INT  );
     $closedoffset = Utilities::arrayKeyOrDefault( $_GET, 'closedoffset',  0, FILTER_VALIDATE_INT  );
-    $closedlimit  = Utilities::arrayKeyOrDefault( $_GET, 'closedlimit',   5, FILTER_VALIDATE_INT  );
-    
+    $closedlimit  = Utilities::arrayKeyOrDefault( $_GET, 'closedlimit',  15, FILTER_VALIDATE_INT  );
+
+    $trsort = TransferQueryOrder::create();
+
+    $displayClosedTransfers = Config::get('auditlog_lifetime') > 0;
+
+    $section = 'available';
+    $sections = array('available','closed');
+    if(array_key_exists('as', $_REQUEST))
+        $section = $_REQUEST['as'];
+    if(!strlen($section)) {
+        $section = 'available';
+    }
+    if(!in_array($section, $sections)) {
+        throw new GUIUnknownAdminSectionException($section);
+    }
 ?>
 <div class="box">
-    <?php Template::display('transfers_table', array(
-        'status' => 'available',
-        'mode' => 'user',
-        'transfers' => Transfer::fromUser(Auth::user(), false, $openlimit+1, $openoffset ),
-        'limit' => $openlimit,
-        'offset' => $openoffset,
-        'pagerprefix' => 'open',
-        'header' => '{tr:available_transfers}'
-    )) ?>
-    
-    <?php if(Config::get('auditlog_lifetime') > 0) { ?>
-    <?php Template::display('transfers_table', array(
-        'status' => 'closed',
-        'mode' => 'user',
-        'transfers' => Transfer::fromUser(Auth::user(), true, $closedlimit+1, $closedoffset ),
-        'limit' => $closedlimit,
-        'offset' => $closedoffset,
-        'pagerprefix' => 'closed',
-        'header' => '{tr:closed_transfers}'
-    )) ?>
-    <?php } ?>
+
+    <div class="menu">
+        <ul>
+        <?php foreach($sections as $s) { ?>
+            <li class="<?php if($s == $section) echo 'current' ?>">
+                <a href="?s=transfers&as=<?php echo $s ?>">
+                    <?php echo Lang::tr($s.'_transfers') ?>
+                </a>
+            </li>
+        <?php } ?>
+        </ul>
+    </div>
+
+    <div class="<?php echo $section ?>_section section">
+
+        <?php 
+        if( $section == 'closed' ) {
+            Template::display('transfers_table', array(
+                'status' => 'closed',
+                'mode' => 'user',
+                'transfers' => Transfer::fromUserOrdered(Auth::user(),
+                                                         $trsort->getViewName(),
+                                                         $trsort->getOrderByClause(),
+                                                         true, $closedlimit+1, $closedoffset ),
+                'limit' => $closedlimit,
+                'offset' => $closedoffset,
+                'pagerprefix' => 'closed',
+                'header' => '{tr:closed_transfers}',
+                'trsort' => $trsort
+            ));
+        } else {
+            Template::display('transfers_table', array(
+                'status' => 'available',
+                'mode' => 'user',
+                'transfers' => Transfer::fromUserOrdered(Auth::user(),
+                                                         $trsort->getViewName(),
+                                                         $trsort->getOrderByClause(),
+                                                         false, $openlimit+1, $openoffset ),
+                'limit' => $openlimit,
+                'offset' => $openoffset,
+                'pagerprefix' => 'open',
+                'header' => '{tr:available_transfers}',
+                'trsort' => $trsort
+            ));
+        }
+        ?>
+    </div>
+
 </div>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -28,6 +28,7 @@ if (!function_exists('clickableHeader')) {
         $tr_url = Utilities::http_build_query(array(
             's' => Utilities::getGETparam('s','')
           , 'transfersort' => $trsort->clickableSortValue($trsortcol)
+          , 'as' => Utilities::getGETparam('as','')
         ));
         echo '<a href="' . $tr_url . '">';
         echo $displayName;
@@ -61,12 +62,13 @@ if (!function_exists('clickableHeader')) {
         $cgilimit  = $pagerprefix . 'limit';
         $nextPage  = $offset+$limit;
         $transfersort = Utilities::getGETparam('transfersort','');
-        $nextLink  = "$base&$cgioffset=$nextPage&$cgilimit=$limit&transfersort=$transfersort";
+        $cgias = Utilities::getGETparam('as','');
+        $nextLink  = "$base&$cgioffset=$nextPage&$cgilimit=$limit&transfersort=$transfersort&as=$cgias";
         
         if( $havePrev ) {
            $prevPage = max(0,$offset-$limit);
-           echo "<td class='pageprev0'><a href='$base&$cgioffset=0&$cgilimit=$limit&transfersort=$transfersort'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-double-left fa-stack-1x fa-inverse'></i></span></a></td>";
-           echo "<td class='pageprev'><a href='$base&$cgioffset=$prevPage&$cgilimit=$limit&transfersort=$transfersort'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-left fa-stack-1x fa-inverse'></i></span></a></td>";
+           echo "<td class='pageprev0'><a href='$base&$cgioffset=0&$cgilimit=$limit&transfersort=$transfersort&as=$cgias'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-double-left fa-stack-1x fa-inverse'></i></span></a></td>";
+           echo "<td class='pageprev'><a href='$base&$cgioffset=$prevPage&$cgilimit=$limit&transfersort=$transfersort&as=$cgias'><span class='fa-stack fa-lg'><i class='fa fa-square fa-stack-2x'></i><i class='fa fa-angle-left fa-stack-1x fa-inverse'></i></span></a></td>";
         } else {
            echo "<td class='pageprev0'>&nbsp;&nbsp;</td><td class='pageprev'>&nbsp;</td>";
         }

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -924,6 +924,43 @@ table.list .date {
     margin-right: 1em;
 }
 
+/* transfers page */
+
+.transfers_page .menu {
+    border-bottom: 1px solid #ccc;
+    overflow: hidden;
+    margin-bottom: 1em;
+}
+
+.transfers_page .menu ul {
+    display: inline;
+    float: left;
+    list-style: none outside none;
+    margin-bottom: -1px;
+}
+
+.transfers_page .menu li {
+    position: relative;
+    display: inline-block;
+    float: left;
+    margin: 0 0.3em;
+    border: 1px solid #ccc;
+    border-radius: 0.5em 0.5em 0 0;
+    -moz-border-radius: 0.5em 0.5em 0 0;
+    cursor: pointer;
+    background-color: #ccc;
+}
+
+.transfers_page .menu li a {
+    display: block;
+    padding: 0.1em 0.5em;
+    text-decoration: none;
+}
+
+.transfers_page .menu li.current {
+    background-color: #fff;
+}
+
 
 /* transfers table */
 


### PR DESCRIPTION
This allows the my transfers page tables to be sorted by the user. It splits the closed transfers table into a subpage and uses tabs to select which page the user wants. The default size of each table is now 15 entries as the pages are less cluttered because they only have one table on them.

This builds on the core code introduced in https://github.com/filesender/filesender/pull/794.