### PR TITLE
The ability to remove some transfer options, only daily stats for now.

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -887,6 +887,17 @@ class Transfer extends DBObject
         }
         return false;
     }
+    public function setOption($option,$v)
+    {
+        // allow population from default.
+        $this->getOption($option);
+        
+        $options = static::allOptions();
+        if (array_key_exists($option, $options)) {
+            $this->options[$option] = $v;
+        }
+        return $v;
+    }
     
     /**
      * Tells wether the transfer is expired

--- a/classes/rest/endpoints/RestEndpointRecipient.class.php
+++ b/classes/rest/endpoints/RestEndpointRecipient.class.php
@@ -147,7 +147,7 @@ class RestEndpointRecipient extends RestEndpoint
         if ($data->remind) {
             $recipient->remind();
         }
-        
+
         return self::cast($recipient);
     }
     

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -802,12 +802,24 @@ class RestEndpointTransfer extends RestEndpoint
             if ($data->remind) {
                 $transfer->remind();
             }
+
+            // Modify transfer option
+            if( $data->optionremove ) {
+                $v = false;
+                
+                if( $data->option == 'email_daily_statistics' ) {
+                    $transfer->setOption($data->option,$v);
+                    $transfer->save();
+                }
+            }
         }
         
         // Need to make the transfer available (sends email to recipients) ?
         if ($data->complete) {
             $transfer->makeAvailable();
         }
+
+
         
         return self::cast($transfer);
     }

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -570,3 +570,7 @@ $lang['oneweek'] = '1 week';
 $lang['twoeightdays'] = '28 days';
 $lang['show_transfers'] = 'Show transfers';
 $lang['transfers_uid_page'] = 'User Transfers';
+
+$lang['confirm_remove_daily_stats_transfer'] = 'Are you sure you no longer wish to receive daily statistics for this transfer';
+$lang['transfer_option_modified'] = 'Transfer option modified';
+$lang['remove_option'] = 'Remove option';

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -317,13 +317,20 @@ if (!function_exists('clickableHeader')) {
                             </tr>
                         <?php } ?>
 
-                        <tr>
+                        <tr class="transfer_options">
                             <td class="desc">{tr:options}</td>
                             <td><div class="options">
                                 <?php if(count($transfer->options)) { ?>
                                     <ul class="options">
                                         <li>
                                             <?php echo implode('</li><li>', array_map(function($o) {
+                                                if( $o == TransferOptions::EMAIL_DAILY_STATISTICS ) {
+                                                    return Lang::tr($o) . '&nbsp;'
+                                                    . '<span data-action="remove" data-option="' 
+                                                               . TransferOptions::EMAIL_DAILY_STATISTICS 
+                                                               . '" class="fa fa-lg fa-times" title="{tr:remove_option}"></span>'
+                                                    ;
+                                                }
                                                 return Lang::tr($o);
                                             }, array_keys(array_filter($transfer->options)))) ?>
                                         </li>

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -784,5 +784,8 @@ window.filesender.client = {
         return this.post('/user/' + id, {remind: true, username: id, password: password }, callback );
     },
     
+    removeTransferOption: function(id, tropt, callback) {
+        return this.put('/transfer/' + id, {'optionremove':true, option: tropt}, callback);
+    },
 
 };

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -339,6 +339,18 @@ $(function() {
             filesender.ui.relocatePopup(popup);
         });
     });
+
+    // Transfer options
+    $('.transfer_options [data-action="remove"]').on('click', function() {
+        var id = $(this).closest('[data-transfer]').attr('data-id');
+        if(!id || isNaN(id)) return;
+        
+        filesender.ui.confirm(lang.tr('confirm_remove_daily_stats_transfer'), function() {
+            filesender.client.removeTransferOption(id, 'email_daily_statistics', function() {
+                filesender.ui.notify('success', lang.tr('transfer_option_modified'));
+            });
+        });
+    });
     
     // File delete buttons
     $('.transfer_details .file [data-action="delete"]').on('click', function() {


### PR DESCRIPTION
This addresses https://github.com/filesender/filesender/issues/358 allowing the stats to be removed for a transfer. I think this is a better option than annoying users with many stats and confronting them with the choice to delete a transfer and remake it in order to hush stats.
