### PR TITLE
keep i18n terms list up to date on poeditor

### DIFF
--- a/scripts/language/oldterms.txt
+++ b/scripts/language/oldterms.txt
@@ -100,6 +100,7 @@ confirm_delete_recipient
 confirm_dialog
 confirm_download_notify
 confirm_extend_expiry
+confirm_leave_download_page
 confirm_leave_upload_page
 confirm_remind_guest
 confirm_remind_recipient
@@ -144,11 +145,14 @@ done_uploading_redirect
 download
 download_bad_files_ids
 download_bad_token_format
+download_chunk_progress
 download_complete
 download_disclamer
 download_disclamer_archive
 download_disclamer_crypto_message
 download_disclamer_nocrypto_message
+download_error
+download_error_abort
 download_file
 download_invalid_range
 download_link
@@ -277,6 +281,7 @@ help_text
 hide_details
 hit_guest_creation_rate_limit
 hit_guest_creation_total_limit
+hit_guest_remind_rate_limit
 host_quota
 host_quota_usage
 ignore
@@ -570,6 +575,7 @@ upload_stalled_due_to_testing
 upload_started
 uploaded
 uploading_transfers
+use_streamsaver_for_download
 user_additional
 user_additional_body
 user_additionnal


### PR DESCRIPTION
This is the update performed by
```
cd scripts/language
./export-terms-to-new-and-deleted-lists.sh
``` 
as per the i18n docs.