### PR TITLE
CI: move to modern chrome

### DIFF
--- a/travis/filesender-config.php
+++ b/travis/filesender-config.php
@@ -338,3 +338,4 @@ $config['crypto_pbkdf2_dialog_enabled'] = false;
 $config['internal_use_only_running_on_ci'] = 1;
 
 $config['streamsaver_enabled'] = false;
+

--- a/unittests/selenium/SeleniumTest.php
+++ b/unittests/selenium/SeleniumTest.php
@@ -9,6 +9,9 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     protected $use_mails = false;
 
+    protected $encryption_key_version_new_files = 0;
+    
+
     public static $browsers = array(
         // run FF15 on Windows 8 on Sauce
         //        array(
@@ -256,6 +259,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
     protected function setKeyVersionNewFiles($v = 0)
     {
+        $this->encryption_key_version_new_files = $v;
         $this->changeConfigValue('encryption_key_version_new_files', $v);
         $this->refresh();
         sleep(2);

--- a/unittests/selenium/SeleniumTest.php
+++ b/unittests/selenium/SeleniumTest.php
@@ -65,7 +65,8 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
 
         $this->setDesiredCapabilities([
             'goog:chromeOptions' => [
-               'w3c' => false
+                'w3c' => false,
+                'args' => ['--ignore-certificate-errors']
             ]
          ]);
 

--- a/unittests/selenium/SeleniumTest.php
+++ b/unittests/selenium/SeleniumTest.php
@@ -23,7 +23,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
             'browserName' => 'chrome',
             'desiredCapabilities' => array(
                 'platform' => 'Linux',
-//                'version' => '84' // needs updates
+                'version' => '84'
             )
         ),
         // run Mobile Safari on iOS
@@ -61,6 +61,15 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
         }
 
         $this->setSeleniumServerRequestsTimeout(120);
+
+
+        $this->setDesiredCapabilities([
+            'goog:chromeOptions' => [
+               'w3c' => false
+            ]
+         ]);
+
+         parent::setUp();
     }
 
     public static function browsers() {
@@ -71,10 +80,11 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
             return array(
                 // run Chrome on Linux locally
                 array(          
-                    'browserName            ' => 'chrome',
+                    'browserName' => 'chrome',
                     'local' => true,        
                     'desiredCapabilities' =>         array(
-                        'platform' => 'Linux'
+                        'platform' => 'Linux',
+                        'version' => '84'
                     )
                 )
             );

--- a/unittests/selenium/tests/EncryptionTest.php
+++ b/unittests/selenium/tests/EncryptionTest.php
@@ -16,7 +16,8 @@ class EncryptionTest extends SeleniumTest {
 
         // Turn on encrption
         $this->byId("encryption")->click();
-        
+
+        sleep(3);
         // Set encryption password
         $this->byName("encryption_password")->clear();
         $this->byName("encryption_password")->value("123123");


### PR DESCRIPTION
This took a little bit of digging but seems to allow the CI to run against chrome 84. On the upside I now have a local selenium environment to run tests against so updating that part of the CI system is going to be much less of a hassle.