### PR TITLE
CI: now that we have recent chrome, use streamsaver in CI

### DIFF
--- a/travis/filesender-config.php
+++ b/travis/filesender-config.php
@@ -337,5 +337,5 @@ $config['crypto_pbkdf2_dialog_enabled'] = false;
 
 $config['internal_use_only_running_on_ci'] = 1;
 
-$config['streamsaver_enabled'] = false;
+$config['streamsaver_enabled'] = true;
 

--- a/unittests/selenium/SeleniumTest.php
+++ b/unittests/selenium/SeleniumTest.php
@@ -249,6 +249,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
     protected function setMaxTransferFileSize($max_file_size = 2107374182400)
     {
         $this->changeConfigValue('max_transfer_size', $max_file_size);
+        sleep(2);
         $this->refresh();
         sleep(2);
     }
@@ -258,6 +259,7 @@ class SeleniumTest extends Sauce\Sausage\WebDriverTestCase
     protected function setInvalidExtensions($invalid_extensions = "'exe,bat'")
     {
         $this->changeConfigValue('ban_extension', $invalid_extensions);
+        sleep(2);
         $this->refresh();
         sleep(2);
     }


### PR DESCRIPTION
Now that CI is updated to using Chrome 84 we should be able to use StreamSaver on the CI.