### PR TITLE
Change PASSWORD to PASS in documentation to match script

### DIFF
--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -296,7 +296,7 @@ config file itself.
 * **NOTE**: Replace the PASSWORD line with a choice of your own!
 
 ```
-PASSWORD=something-really-long-and-wonderful-written-near-the-keyboard
+PASS=something-really-long-and-wonderful-written-near-the-keyboard
 
 cd config
 SALT=$(LC_CTYPE=C tr -c -d '0123456789abcdefghijklmnopqrstuvwxyz' </dev/urandom | dd bs=32 count=1 2>/dev/null;echo);


### PR DESCRIPTION
I noticed in the documentation for v2.0 installation that the PASSWORD variable set does not match the PASS variable that is actually used.  Here is the fix for the documentation.