### PR TITLE
Downloading encrypted files into unencrypted zip64 container

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -109,7 +109,9 @@ class GUI
         if( Browser::instance()->allowStreamSaver ) {
             array_push( $sources,
                         'lib/streamsaver/StreamSaver.js',
-                        'js/crypter/streamsaver_sink.js'
+                        'js/crypter/streamsaver_sink.js',
+                        'js/crc32handler.js',
+                        'js/zip64handler.js'
             );
         }
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -612,3 +612,5 @@ $lang['ui2_no_active_transfers'] = 'No active transfers anymore';
 $lang['ui2_no_inactive_transfers'] = 'No inactive transfers anymore';
 $lang['ui2_show_more'] = 'Show more';
 $lang['ui2_show_all'] = 'Show all';
+
+$lang['encrypted_archive_download_overall_progress'] = 'Downloading file {currentfilenumber} of {totalfilestodownload}';

--- a/templates/admin_testing_section.php
+++ b/templates/admin_testing_section.php
@@ -77,6 +77,24 @@
 </table>
 
 
+<h2>StreamSaver file generation</h2>
+
+<p>
+    The below button will create a small file with some text in it.
+</p>
+
+<input type="button" data-action="generate-test-ss" value="generate file with StreamSaver" />
+
+
+<h2>Streaming zip64 generation</h2>
+
+<p>
+    The below button will create and save a zip64 file to your downloads directory for format testing.
+</p>
+
+<input type="button" data-action="generate-test-zip64" value="generate zip64" />
+
+
 <script type="text/javascript" src="{path:js/admin_testing.js}"></script>
 
 

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -40,10 +40,16 @@
 
     $isEncrypted = isset($transfer->options['encryption']) && $transfer->options['encryption'];
     $canDownloadArchive = count($transfer->files) > 1;
+    $canDownloadAsTar = true;
+    $canDownloadAsZip = true;
     if($isEncrypted) {
-        // It is not possible to download archives of the encrypted files. 
-        // since there is no unzip -> decrypt -> zip process in the current filesender 
+        // Streaming to a local decrypted archive requires StreamSaver feature
         $canDownloadArchive = false;
+        // no stream to tar file support yet.
+        $canDownloadAsTar = false;
+        if( Browser::instance()->allowStreamSaver ) {
+            $canDownloadArchive = true;
+        }
     }
     ?>
     
@@ -95,7 +101,8 @@
             </div>
         <?php } ?>
     </div>
-    <div class="files box" data-count="<?php echo ($isEncrypted)?'1':count($transfer->files) ?>">
+    <div class="files box" data-count="<?php echo ($canDownloadArchive)?count($transfer->files):'1' ?>">
+        <?php if($canDownloadArchive) { ?>
         <div class="select_all">
             <span class="fa fa-lg fa-mail-reply fa-rotate-270"></span>
             <span class="select clickable">
@@ -103,6 +110,7 @@
                 <span>{tr:select_all_for_archive_download}</span>
             </span>
         </div>
+        <?php } ?>
     <?php foreach($transfer->files as $file) { ?>
         <div class="file" data-id="<?php echo $file->id ?>"
              data-encrypted="<?php echo isset($transfer->options['encryption'])?$transfer->options['encryption']:'false'; ?>"
@@ -120,7 +128,9 @@
              data-fileaead="<?php echo $file->aead; ?>"
         >
             
-            <span class="select clickable fa fa-2x fa-square-o" title="{tr:select_for_archive_download}"></span>
+            <?php if($canDownloadArchive) { ?>
+                <span class="select clickable fa fa-2x fa-square-o" title="{tr:select_for_archive_download}"></span>
+            <?php } ?>
             <span class="name"><?php echo Utilities::sanitizeOutput($file->path) ?></span>
             <span class="size"><?php echo Utilities::formatBytes($file->size) ?></span>
             <span class="download_decryption_disabled"><br/>{tr:file_encryption_disabled}</span>
@@ -145,12 +155,14 @@
                 {tr:archive_download}
             </a>
             </div>
+            <?php if($canDownloadAsTar) { ?>
             <div class="archive_tar_download_frame">
             <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_tar_download}
             </a>
             </div>
+            <?php } ?>    
             <span class="downloadprogress"/>
         </div>
     <?php } ?>    

--- a/www/js/crc32handler.js
+++ b/www/js/crc32handler.js
@@ -1,0 +1,78 @@
+//
+// This is the original comment.
+//
+// Note: we can't get significant speed boost here.
+// So write code to minimize size - no pregenerated tables
+// and array tools dependencies.
+
+// (C) 1995-2013 Jean-loup Gailly and Mark Adler
+// (C) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//   claim that you wrote the original software. If you use this software
+//   in a product, an acknowledgment in the product documentation would be
+//   appreciated but is not required.
+// 2. Altered source versions must be plainly marked as such, and must not be
+//   misrepresented as being the original software.
+// 3. This notice may not be removed or altered from any source distribution.
+
+//
+// The below is modified in this file in 2020.
+//
+// The original makeTable function and crcTable variable have been renamed
+// to include a prefix of crc32
+// The crc32 function is also attached to the DOM for other code to use.
+//
+
+// Use ordinary array, since untyped makes no boost here
+function crc32makeTable() {
+    var c, table = [];
+
+    for(var n =0; n < 256; n++){
+        c = n;
+        for(var k =0; k < 8; k++){
+            c = ((c&1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1));
+        }
+        table[n] = c;
+    }
+
+    return table;
+}
+
+// Create table on load. Just 255 signed longs. Not a problem.
+var crc32crcTable = crc32makeTable();
+
+
+function crc32(crc, buf, len, pos) {
+    var t = crc32crcTable, end = pos + len;
+
+    crc = crc ^ (-1);
+
+    for (var i = pos; i < end; i++ ) {
+        crc = (crc >>> 8) ^ t[(crc ^ buf[i]) & 0xFF];
+    }
+
+    return (crc ^ (-1)); // >>> 0;
+}
+
+
+//
+// Put this out there for other FileSender code to use
+//
+
+if (typeof window === 'undefined')
+    window = {}; // dummy window for use in webworkers
+
+if (!('filesender' in window))
+    window.filesender = {};
+
+window.filesender.crc32handler = crc32;
+

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -93,40 +93,120 @@ $(function() {
                     return;
                 }
 
-                var filename    = $($this).find("[data-id='" + ids[0] + "']").attr('data-name');
-                var filesize    = $($this).find("[data-id='" + ids[0] + "']").attr('data-size');
-                var encrypted_filesize=$($this).find("[data-id='" + ids[0] + "']").attr('data-encrypted-size');
-                var mime        = $($this).find("[data-id='" + ids[0] + "']").attr('data-mime');
-                var key_version = $($this).find("[data-id='" + ids[0] + "']").attr('data-key-version');
-                var salt        = $($this).find("[data-id='" + ids[0] + "']").attr('data-key-salt');
-                var password_version  = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-version');
-                var password_encoding = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-encoding');
-                var password_hash_iterations = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-hash-iterations');
-                var client_entropy = $($this).find("[data-id='" + ids[0] + "']").attr('data-client-entropy');
-                var fileiv   = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileiv');
-                var fileaead = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileaead');
-                if( fileaead.length ) {
-                    fileaead = atob(fileaead);
-                }
-
                 var crypto_app = window.filesender.crypto_app();
 
                 if( window.filesender.config.use_streamsaver ) {
                     var streamsaverenabled = page.find('#streamsaverenabled').is(':checked');
                     crypto_app.disable_streamsaver = !streamsaverenabled;
                 }
-                crypto_app.decryptDownload( filesender.config.base_path
-                                            + 'download.php?token=' + token
-                                            + '&files_ids=' + ids.join(','),
-                                            mime, filename, filesize, encrypted_filesize,
-                                            key_version, salt,
-                                            password_version, password_encoding,
-                                            password_hash_iterations,
-                                            client_entropy,
-                                            window.filesender.crypto_app().decodeCryptoFileIV(fileiv,key_version),
-                                            fileaead,
-                                            progress );
-            }else{
+
+                if( archive_format || ids.length > 1 ) {
+                    //
+                    // Stream encrypted files to browser and add the decrypted content
+                    // into a zip64 file in the browser.
+                    //
+                    var onFileOpen = function( blobSink, fileid )
+                    {
+                        var progress = $($this).find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        progress.html("");
+                        blobSink.progress = progress;
+
+                        var overall = $($this).find(".archive_message");
+
+
+                        var msg = lang.tr('encrypted_archive_download_overall_progress').r(
+                            {
+                                id: 0
+                                , currentfilenumber:    blobSink.currentFileNumber+1
+                                , totalfilestodownload: blobSink.totalFilesToDownload
+                            }).out();
+                        overall.html(msg);
+                    };
+                    var onFileClose = function( blobSink, fileid )
+                    {
+                        var progress = $($this).find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        progress.html(window.filesender.config.language.download_complete);
+                        
+                    };
+                    var onComplete = function( blobSink )
+                    {
+                        var overall = $($this).find(".archive_message");
+                        overall.html(window.filesender.config.language.download_complete);
+                    };
+
+                    // generate zip in browser from decrypted files.
+                    var selectedFiles = [];
+                    var i = 0;
+                    for(; i < ids.length; i++ ) {
+
+                        var fileaead = $($this).find("[data-id='" + ids[i] + "']").attr('data-fileaead');
+                        var key_version = $($this).find("[data-id='" + ids[i] + "']").attr('data-key-version');
+                        var fileivcoded = $($this).find("[data-id='" + ids[i] + "']").attr('data-fileiv');
+                        
+                        selectedFiles.push({
+                            fileid:ids[i]
+                            , filename:$($this).find("[data-id='" + ids[i] + "']").attr('data-name')
+                            , filesize:$($this).find("[data-id='" + ids[i] + "']").attr('data-size')
+                            , encrypted_filesize:$($this).find("[data-id='" + ids[i] + "']").attr('data-encrypted-size')
+                            , mime:$($this).find("[data-id='" + ids[i] + "']").attr('data-mime')
+                            , key_version:$($this).find("[data-id='" + ids[i] + "']").attr('data-key-version')
+                            , salt:$($this).find("[data-id='" + ids[i] + "']").attr('data-key-salt')
+                            , password_version:$($this).find("[data-id='" + ids[i] + "']").attr('data-password-version')
+                            , password_encoding:$($this).find("[data-id='" + ids[i] + "']").attr('data-password-encoding')
+                            , password_hash_iterations:$($this).find("[data-id='" + ids[i] + "']").attr('data-password-hash-iterations')
+                            , client_entropy:$($this).find("[data-id='" + ids[i] + "']").attr('data-client-entropy')
+                            , fileiv:window.filesender.crypto_app().decodeCryptoFileIV(fileivcoded,key_version)
+                            , fileaead:fileaead.length?atob(fileaead):null
+                        });
+
+                        // clear any previous progress message
+                        var progress = $($this).find("[data-id='" + ids[i] + "']").find('.downloadprogress');
+                        progress.html("");
+                    }
+                    crypto_app.decryptDownloadToZip( filesender.config.base_path
+                                                     + 'download.php?token=' + token
+                                                     + '&files_ids='
+                                                     , selectedFiles
+                                                     , progress
+                                                     , onFileOpen, onFileClose, onComplete
+                                                   );
+
+                    
+                }
+                else
+                {
+                    // single file download
+                    var filename    = $($this).find("[data-id='" + ids[0] + "']").attr('data-name');
+                    var filesize    = $($this).find("[data-id='" + ids[0] + "']").attr('data-size');
+                    var encrypted_filesize=$($this).find("[data-id='" + ids[0] + "']").attr('data-encrypted-size');
+                    var mime        = $($this).find("[data-id='" + ids[0] + "']").attr('data-mime');
+                    var key_version = $($this).find("[data-id='" + ids[0] + "']").attr('data-key-version');
+                    var salt        = $($this).find("[data-id='" + ids[0] + "']").attr('data-key-salt');
+                    var password_version  = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-version');
+                    var password_encoding = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-encoding');
+                    var password_hash_iterations = $($this).find("[data-id='" + ids[0] + "']").attr('data-password-hash-iterations');
+                    var client_entropy = $($this).find("[data-id='" + ids[0] + "']").attr('data-client-entropy');
+                    var fileiv   = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileiv');
+                    var fileaead = $($this).find("[data-id='" + ids[0] + "']").attr('data-fileaead');
+                    if( fileaead.length ) {
+                        fileaead = atob(fileaead);
+                    }
+                    
+                    crypto_app.decryptDownload( filesender.config.base_path
+                                                + 'download.php?token=' + token
+                                                + '&files_ids=' + ids.join(','),
+                                                mime, filename, filesize, encrypted_filesize,
+                                                key_version, salt,
+                                                password_version, password_encoding,
+                                                password_hash_iterations,
+                                                client_entropy,
+                                                window.filesender.crypto_app().decodeCryptoFileIV(fileiv,key_version),
+                                                fileaead,
+                                                progress );
+                }
+            }
+            else
+            {
                 var notify = false;
                 dlcb( notify ).call();
             }
@@ -162,9 +242,10 @@ $(function() {
         
         
         var transferid = $('.transfer').attr('data-id');
+        var encrypted = $('.transfer_is_encrypted').text()==1;
         
         filesender.client.getTransferOption(transferid, 'enable_recipient_email_download_complete', token, function(dl_complete_enabled){
-            dl(ids, dl_complete_enabled, null, null, archive_format );
+            dl(ids, dl_complete_enabled, encrypted, null, archive_format );
         });
         
         return false;

--- a/www/js/zip64handler.js
+++ b/www/js/zip64handler.js
@@ -1,0 +1,303 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+if (typeof window === 'undefined')
+    window = {}; // dummy window for use in webworkers
+
+if (!('filesender' in window))
+    window.filesender = {};
+
+///////
+// raw functions to write data of specific size
+// to Streams
+
+    var sswrite = async function (writer,data) {
+        await writer.write(data);
+    }
+
+    var sswritestr = async function (writer,data) {
+        await writer.write(window.filesender.crypto_common().convertStringToArrayBufferView(data));
+    }
+
+    var sswriteu64 = async function (writer,n) {
+        var lob = n & 0xFFFFFFFF;
+        var hib = n - lob;
+        await writer.write(new Uint8Array([(lob)&0xFF,(lob>>8)&0xFF,(lob>>16)&0xFF,(lob>>24)&0xFF,
+                                           (hib)&0xFF,(hib>>8)&0xFF,(hib>>16)&0xFF,(hib>>24)&0xFF]));
+    }
+    var sswriteu32 = async function (writer,n) {
+        await writer.write(new Uint8Array([(n)&0xFF,(n>>8)&0xFF,(n>>16)&0xFF,(n>>24)&0xFF]));
+    }
+    var sswriteu16 = async function (writer,n) {
+        await writer.write(new Uint8Array([(n)&0xFF,(n>>8)&0xFF]));
+    }
+
+///////
+
+
+window.filesender.zip64handler = function() {
+
+    return {
+        filename: '',
+        writer: null,
+        bytesProcessed: 0,
+        VERSION: 45,
+        crc: 0,
+        filesize: 0,
+        coffset: 0,
+        zip64_start_of_central_directory_record_offset: 0,
+        zip64_end_of_central_directory_record_offset: 0,
+        zip64_end_of_central_directory_record_offset2: 22,
+        zip64_central_directory_record_length: 0,
+        files: [],
+        
+        init: function( filename ) {
+            var $this = this;
+            this.filename = filename;
+            this.coffset = 0;
+
+            const ponyfill = window.WebStreamsPolyfill || {};
+            streamSaver.WritableStream = ponyfill.WritableStream;
+            streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
+            streamSaver.WritableStream = ponyfill.WritableStream;
+
+            streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
+            var fileStream = streamSaver.createWriteStream( filename );
+            $this.writer = fileStream.getWriter();
+
+            $this.files = [];
+        },
+
+        write: function (data) {
+            var $this = this;
+            sswrite( $this.writer, data );
+            this.coffset += data.length;
+            return this.coffset;
+        },
+
+        writestr: function (data) {
+            var $this = this;
+            sswritestr( $this.writer, data );
+            this.coffset += data.length;
+            return this.coffset;
+        },
+        
+        writeu64: function (n) {
+            var $this = this;
+            sswriteu64( $this.writer, n );
+            this.coffset += 8;
+            return this.coffset;
+        },
+        writeu32: function (n) {
+            var $this = this;
+            sswriteu32( $this.writer, n );
+            this.coffset += 4;
+            return this.coffset;
+        },
+        writeu16: function (n) {
+            var $this = this;
+            sswriteu16( $this.writer, n );
+            this.coffset += 2;
+            return this.coffset;
+        },
+
+        
+        // @param d is javascript Date object.
+        // @return 32bit dostime integer
+	dostime: function(d) {
+
+            var y = d.getFullYear();
+            if( y < 1980 ) {
+                d.setFullYear(1980);
+                d.setMonth(0);
+                d.setDate(0);
+            }
+            return(
+                (d.getFullYear()-1980)<<25
+                    | d.getMonth()   << 21
+                    | d.getDate()    << 16
+                    | d.getHours()   << 11
+                    | d.getMinutes() << 5
+                    | d.getSeconds() / 2
+            );
+        },
+        openFile: function(filename) {
+            var $this = this;
+
+            var genb = 0x0808;
+            var dts = $this.dostime(new Date());
+
+            var local_file_header_offset = $this.coffset;
+            // V = 32, v = 16
+            this.writeu32( 0x04034b50 );  // sig
+            this.writeu16( $this.VERSION );
+            this.writeu16( genb       );  // utf8 and crc and size in data descriptor following the data
+            this.writeu16( 0          );  // no compression
+            this.writeu32( dts );
+            this.writeu32( 0          );  // no crc-32 yet
+            this.writeu32( 0xFFFFFFFF );  // no size yet
+            this.writeu32( 0xFFFFFFFF );  // ...
+            this.writeu16( filename.length );
+            this.writeu16( 0          );  // no extra data
+
+            $this.writestr( filename );
+
+            $this.crc = 0;
+            $this.filesize = 0;
+
+            $this.files.push( { name: filename, filename: filename, size: 0,
+                                genb: genb, dts: dts, crc: 0, local_file_header_offset: local_file_header_offset } );
+
+        },
+        visit: function(data) {
+            var $this = this;
+            $this.write( data );
+            $this.crc = window.filesender.crc32handler( $this.crc, data, data.length, 0 );
+            $this.filesize += data.length;
+        },
+        closeFile: function() {
+            var $this = this;
+
+            $this.writeu32( 0x08074b50 );  // sig
+            $this.writeu32( $this.crc );
+            $this.writeu64( $this.filesize );
+            $this.writeu64( $this.filesize );
+
+            // update the size and crc info from the bytes written
+            this.files[this.files.length-1].crc  = $this.crc;
+            this.files[this.files.length-1].size = $this.filesize;
+        },
+        add_cdr_file: function(f) {
+            var $this = this;
+
+            var startOffset = this.coffset;
+            $this.writeu32( 0x02014b50 );  // sig
+            $this.writeu16( $this.VERSION );  
+            $this.writeu16( $this.VERSION );  
+            $this.writeu16( f.genb );  
+            $this.writeu16( 0 );           // compression
+            $this.writeu32( f.dts );       // dos time stamp
+            $this.writeu32( f.crc );
+            $this.writeu32( 0xFFFFFFFF );
+            $this.writeu32( 0xFFFFFFFF );
+            $this.writeu16( f.name.length );
+            $this.writeu16( 32 );          // extra data
+            $this.writeu16( 0 );           // comment
+            $this.writeu16( 0 );          
+            $this.writeu16( 0 );          
+            $this.writeu32( 0x20 );          
+            $this.writeu32( 0xFFFFFFFF );  // relative offset of local header (zip64 - look in extra)
+
+            
+
+            $this.writestr( f.name );
+
+            // extra data
+            $this.writeu16( 1 ); 
+            $this.writeu16( 28 ); 
+            $this.writeu64( f.size ); 
+            $this.writeu64( f.size ); 
+            $this.writeu64( f.local_file_header_offset ); 
+            $this.writeu32( 0 ); 
+
+            
+            var endOffset = this.coffset;
+            this.zip64_central_directory_record_length += (endOffset-startOffset);
+        },
+	add_cdr_eof_zip64: function() {
+            var $this = this;
+
+            var entryCount = this.files.length;
+            var cdr_ofs = 67;
+
+            $this.zip64_end_of_central_directory_record_offset = $this.coffset;
+            $this.writeu32( 0x06064b50 );  // sig
+            $this.writeu32( 44         );  // size
+            $this.writeu32( 0          );  // size hb
+            $this.writeu16( $this.VERSION );  
+            $this.writeu16( $this.VERSION );  
+            $this.writeu32( 0          );  
+            $this.writeu32( 0          );  
+            $this.writeu64( entryCount );  
+            $this.writeu64( entryCount );  
+            $this.writeu64( $this.zip64_central_directory_record_length );  
+            $this.writeu64( $this.zip64_start_of_central_directory_record_offset );  
+
+
+        },
+	add_cdr_eof_locator_zip64: function() {
+            var $this = this;
+
+            $this.writeu32( 0x07064b50 );  // sig
+            $this.writeu32( 0 );           // this disk number
+            $this.writeu64( $this.zip64_end_of_central_directory_record_offset );
+            $this.writeu32( 1 );           // number of disks
+        },
+        write_end_cdr_record: function() {
+            var $this = this;
+
+            var comment = 'created by FileSender';
+
+            $this.writeu32( 0x06054b50 );  // sig
+            $this.writeu16( 0xFFFF );
+            $this.writeu16( 0xFFFF );
+            $this.writeu16( 0xFFFF );
+            $this.writeu16( 0xFFFF );
+            $this.writeu32( 0xFFFFFFFF );
+            $this.writeu32( 0xFFFFFFFF );
+            $this.writeu16( comment.length );
+            $this.writestr( comment );
+        },
+        complete: function() {
+            var $this = this;
+
+            $this.zip64_start_of_central_directory_record_offset = $this.coffset;
+            for (let i = 0; i < this.files.length; i++) {
+                $this.add_cdr_file(this.files[i])
+            }            
+
+	    $this.add_cdr_eof_zip64();
+	    $this.add_cdr_eof_locator_zip64();
+            $this.write_end_cdr_record();
+            $this.writer.close();
+        },
+        abort: function() {
+            var $this = this;
+            $this.writer.abort();
+        },
+        lastfunc: function() {
+            var $this = this;
+        }
+    }
+};
+
+        


### PR DESCRIPTION
This patch allows the streaming download of one or more encrypted files into a generated zip64 archive. Note that the file content stored in the generated zip64 file is not encrypted any more. This mirrors the functionality of downloading a single file where the result is an unencrypted local file.

For an encrypted transfer, all of the files are encrypted in the browser before upload. This means that the server is unable to offer a zip or tar archive because it does not know how to decrypt any of the files. As encryption is end to end only the browser is able to decrypt any of the files.

This patch allows the browser to use streaming download of encrypted files and will generate a zip64 archive in the browser to stream files into. Decryption of each file happens in the browser just prior to saving files into the zip64 file. This allows a transfer with many files to be conveniently downloaded and extracted to obtain the original uploaded content.

This feature relies on the streaming download feature and is thus unavailable in browsers that do not support that feature such as IE11.

This has been tested in Chrome on Linux, Edge on Windows and Safari.  In Chome 4gb files have been transferred into a generated archive and the md5 of resulting files verified against the sources. There is a delay in Edge and Safari at the end of a download as the system is performing some verification.

