### PR TITLE
i18n: optional ability to filter terms to upload using existing terms

### DIFF
--- a/scripts/language/README.md
+++ b/scripts/language/README.md
@@ -63,3 +63,20 @@ without impacting existing real translations.
 ```
 ./send-json-translations-for-language-to-poeditor.sh 48000 en-au /tmp/test.json
 ```
+
+
+Another useful code flow is to use the import-all-from-poeditor.sh script to download
+the translations for all terms for every language and use those files to only export
+translations from local files that are not already on poeditor.
+
+The below uses a permissive regex and a 0 term max and explicitly passes the English_AU
+translations that poeditor knows in order to not export existing terms. This should create
+a file with only translations in your ../language/en_AU directory that are not known
+to poeditor. Handy for sending terms from a pull request to poeditor for example. The
+output can be sent using send-json-translations-for-language-to-poeditor.sh as detailed above.
+
+```
+php convert-php-to-poeditor-json.php \
+       en_AU /tmp/test.json '/.*/' 0 \
+       /tmp/filesender-poeditor-imports-wmsnC/FileSender_2.0_English_AU.php
+```

--- a/scripts/language/common.php
+++ b/scripts/language/common.php
@@ -12,25 +12,32 @@ $warningAboutChangingFile .= "// \n";
 $warningAboutChangingFile .= "// \n";
 $warningAboutChangingFile .= "?>\n";
 
-function loadLang( $code ) {
+function loadLangFile( $infilepath ) {
     global $BASE;
     $n = 0; $kn = 0;
     $keys = array();
-    echo "reading $BASE/language/$code/lang.php", "\n";
-    foreach(explode("\n", file_get_contents("$BASE/language/$code/lang.php")) as $line) {
+    echo "reading $infilepath", "\n";
+    foreach(explode("\n", file_get_contents("$infilepath")) as $line) {
         $n++;
-        
         if(!preg_match('`\$lang\[[\'"]([^\'"]+)[\'"]\]\s*=\s*[\'"](.*)[\'"];`', $line, $m)) continue;
         $kn++;
         $k = $m[1];
         $v = $m[2];
-        echo "$k \n";
+//        echo "$k \n";
         if(array_key_exists($m[1], $keys)) {
             echo $m[1].' ('.$n.') already found at '.$keys[$m[1]]."\n";
         } else {
             $keys[$m[1]] = $v;
         }
     }
+    return $keys;
+}
+
+function loadLang( $code ) {
+    global $BASE;
+    $n = 0; $kn = 0;
+    $keys = array();
+    $keys = loadLangFile("$BASE/language/$code/lang.php");
     return $keys;
 }
 

--- a/scripts/language/convert-php-to-poeditor-json.php
+++ b/scripts/language/convert-php-to-poeditor-json.php
@@ -11,9 +11,15 @@ function usage() {
       . " arg1 is the language to export (see ./language/ in the main repository)\n"
       . " arg2 is the file to write the json into\n"
       . " arg3 optional is preg_match() regex to select only matching terms. eg. '/^about.*/' \n"
-      . " arg4 optional is max number of terms to select\n"
+      . " arg4 optional is max number of terms to select (0 for no max)\n"
+      . " arg5 optional file path for downloaded and converted php from poeditor for terms to skip\n"
+      . "                  the expected format is that which is created \n"
+      . "                  for all languages with import-all-from-poeditor.sh \n"
       . "\n"
-      . "For example:  convert-php-to-poeditor-json  en_AU  /tmp/filesender-english-aus-translations.json "
+      . "Note that each optional parameter requires all previous ones to be passed.\n"
+      . "For example, to use the arg4 max you must pass a regex as arg3.\n"
+      . "\n"
+      . "For example:  convert-php-to-poeditor-json  en_AU  /tmp/filesender-english-aus-translations.json\n\n"
     );
 }
 
@@ -28,6 +34,7 @@ $filesenderLang = $argv[1];
 $outputFilename = $argv[2];
 $termregex = ".*";
 $max = 0;
+$skipTermFilePath = "";
 $count = 0;
 if( $argc >= 4 ) {
     $termregex = $argv[3];
@@ -35,7 +42,9 @@ if( $argc >= 4 ) {
 if( $argc >= 5 ) {
     $max = $argv[4];
 }
-
+if( $argc >= 6 ) {
+    $skipTermFilePath = $argv[5];
+}
 
 $allterms = array();
 
@@ -52,12 +61,36 @@ $code = $filesenderLang;
 $lang = loadLang( $filesenderLang );
 $langdir = loadLangDirectory( $filesenderLang );
 $langdir = resolveLangDirectoryReferences( $langdir, $filesenderLang );
+$skiplang = array();
+if( strlen($skipTermFilePath)) {
+    include_once($skipTermFilePath);
+    $skiplang = $LANG;
+    $LANG = array();
+}
+
+function isInSkipLang($term) {
+    global $skiplang;
+    foreach($skiplang as $ti => $t) {
+        $skipterm = $t['term'];
+        if( $skipterm == $term ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+echo "skiplang:  \n";
+var_dump($skiplang);
 
 foreach ($lang as $key => $value) {
     if( $max > 0 && $count >= $max ) {
         break;
     }
     $count++;
+
+    if( isInSkipLang($key)) {
+        continue;
+    }
 
     if( preg_match($termregex, $key )) {
         $t = array( 'term' => $key, 'translation' => array('content'=>$value,'fuzzy'=>0));
@@ -70,6 +103,10 @@ foreach ($langdir as $key => $value) {
         break;
     }
     $count++;
+
+    if( isInSkipLang($key)) {
+        continue;
+    }
     
     if( preg_match($termregex, $key )) {
         $t = array( 'term' => $key, 'translation' => array('content'=>$value,'fuzzy'=>0));


### PR DESCRIPTION
This extends convert-php-to-poeditor-json.php to be able to skip language translations that are already on poeditor and only export new translations. This should help to avoid overwriting existing work on poeditor. 

Also very handy for new translations that might be added in a pull request, the script can export only terms that are in the local git checkout but not already on poeditor.