### PR TITLE
i18n: break out language download script so that convert-php-to-poeditor-json.php can use it

### DIFF
--- a/scripts/language/README.md
+++ b/scripts/language/README.md
@@ -80,3 +80,13 @@ php convert-php-to-poeditor-json.php \
        en_AU /tmp/test.json '/.*/' 0 \
        /tmp/filesender-poeditor-imports-wmsnC/FileSender_2.0_English_AU.php
 ```
+
+To generate the FileSender_2.0_English_AU.php file from the current data on poeditor
+one can use the below. See import-all-from-poeditor.sh for a list of poeditor language codes
+that are currently imported in bulk.
+
+```
+mkdir -p /tmp/filesender-poeditor-imports-wmsnC
+download-language-from-poeditor.sh "en-au" "English_AU" /tmp/filesender-poeditor-imports-wmsnC
+```
+

--- a/scripts/language/download-language-from-poeditor.sh
+++ b/scripts/language/download-language-from-poeditor.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eou pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ~/.filesender/poeditor-apikey
+
+LANG=${1:?Supply poeditor language as arg1};
+PHPFILE=${2:?Supply path to php file as arg2};
+dirname=${3:?Supply directory path to use to store files as arg3};
+
+echo "Downloading LANG  : $LANG "
+echo "into directory at : $dirname "
+cd "$dirname"
+    
+data=$(curl -s -X POST https://api.poeditor.com/v2/projects/export \
+            -d api_token="$API_TOKEN" \
+            -d id="$PROJECT_ID" \
+            -d language="$LANG" \
+            -d type="json"
+    );
+
+if [ 'success' != "$(echo $data | jq -r .response.status)" ]; then
+    echo "$data"
+    echo ""
+    echo "BAD SERVER RESPONSE FOR LANG $LANG"
+    exit 1
+fi
+
+earl="$(echo $data | jq -r .result.url)";
+curl  "$earl" --output "FileSender_2.0_$LANG.json"
+php "$SCRIPTDIR/convert-poeditor-json-to-php.php" "FileSender_2.0_$LANG.json" "FileSender_2.0_$PHPFILE.php"
+

--- a/scripts/language/import-all-from-poeditor.sh
+++ b/scripts/language/import-all-from-poeditor.sh
@@ -1,57 +1,29 @@
 #!/bin/bash
+set -eou pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 . ~/.filesender/poeditor-apikey
 
-
-function downloadAndConvert {
-    LANG=$1
-    PHPFILE=$2
-    dirname=$3
-
-    echo "LANG $LANG "
-    echo "dir $dirname "
-    
-    data=$(curl -s -X POST https://api.poeditor.com/v2/projects/export \
-                -d api_token="$API_TOKEN" \
-                -d id="$PROJECT_ID" \
-                -d language="$LANG" \
-                -d type="json"
-        );
-
-    if [ 'success' != "$(echo $data | jq -r .response.status)" ]; then
-        echo "$data"
-        echo ""
-        echo "BAD SERVER RESPONSE FOR LANG $LANG"
-        exit 1
-    fi
-
-    earl="$(echo $data | jq -r .result.url)";
-    curl  "$earl" --output "FileSender_2.0_$LANG.json"
-    php "$SCRIPTDIR/convert-poeditor-json-to-php.php" "FileSender_2.0_$LANG.json" "FileSender_2.0_$PHPFILE.php"
-}
-
 dirname=$(mktemp -d "/tmp/filesender-poeditor-imports-XXXXX");
 cd "$dirname"
 echo "Creating downloaded files in $dirname"
 
-
-downloadAndConvert "cs" "Czech"     $dirname
-downloadAndConvert "da" "Danish"    $dirname
-downloadAndConvert "nl" "Dutch"     $dirname
-downloadAndConvert "en-au" "English_AU" $dirname
-downloadAndConvert "et" "Estonian"  $dirname
-downloadAndConvert "fi" "Finnish"   $dirname
-downloadAndConvert "de" "German"    $dirname
-downloadAndConvert "it" "Italian"   $dirname
-downloadAndConvert "fa" "Persian"   $dirname
-downloadAndConvert "pl" "Polish"    $dirname
-downloadAndConvert "ru" "Russian"   $dirname
-downloadAndConvert "sl" "Slovenian" $dirname
-downloadAndConvert "es" "Spanish"   $dirname
-downloadAndConvert "fr" "French"    $dirname
-downloadAndConvert "sr" "Serbian"   $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "cs"    "Czech"      $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "da"    "Danish"     $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "nl"    "Dutch"      $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "en-au" "English_AU" $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "et"    "Estonian"   $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "fi"    "Finnish"    $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "de"    "German"     $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "it"    "Italian"    $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "fa"    "Persian"    $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "pl"    "Polish"     $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "ru"    "Russian"    $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "sl"    "Slovenian"  $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "es"    "Spanish"    $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "fr"    "French"     $dirname
+$SCRIPTDIR/download-language-from-poeditor.sh "sr"    "Serbian"    $dirname
 
 
 

--- a/scripts/language/send-json-translations-for-language-to-poeditor.sh
+++ b/scripts/language/send-json-translations-for-language-to-poeditor.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+set -eou pipefail
 
 . ~/.filesender/poeditor-apikey
+
 
 projectid=${1:?supply poeditor project id as arg1. Main project is 48000 test project is 380345 };
 langcode=${2:?supply poeditor language code as arg2};


### PR DESCRIPTION
This moves a bash function to a script so it can be used to generate the existing term list for convert-php-to-poeditor-json.php for use with new pull requests.