### PR TITLE
i18n: add new terms before trying to update translations

### DIFF
--- a/scripts/language/README.md
+++ b/scripts/language/README.md
@@ -61,6 +61,8 @@ might like to first use the number 380345 which will upload to the
 without impacting existing real translations.
 
 ```
+# commentline    main project = 48000    test project = 380345
+
 ./send-json-translations-for-language-to-poeditor.sh 48000 en-au /tmp/test.json
 ```
 

--- a/scripts/language/send-json-translations-for-language-to-poeditor.sh
+++ b/scripts/language/send-json-translations-for-language-to-poeditor.sh
@@ -8,6 +8,11 @@ projectid=${1:?supply poeditor project id as arg1. Main project is 48000 test pr
 langcode=${2:?supply poeditor language code as arg2};
 jsonfile=${3:?supply path to json file created with convert-php-to-poeditor-json.php as arg3};
 
+curl -X POST https://api.poeditor.com/v2/terms/add \
+     -d api_token="$API_TOKEN" \
+     -d id="$projectid" \
+     --data-binary @$jsonfile
+
 curl -X POST https://api.poeditor.com/v2/languages/update \
      -d api_token="$API_TOKEN" \
      -d id="$projectid" \


### PR DESCRIPTION
I think it makes it simpler to create the new terms via the API first.