### PR TITLE
i18n: new command line to upload newterms to poeditor

### DIFF
--- a/docs/v2.0/i18n/index.md
+++ b/docs/v2.0/i18n/index.md
@@ -715,7 +715,15 @@ cd scripts/language
 ./export-terms-to-new-and-deleted-lists.sh
 ```
 
-The newterms.json file can them be imported using the "Import terms"
+If you have setup ~/.filesender/poeditor-apikey to allow write access to poeditor
+then the newterms.json file can be imported using the command line. See the README.md file
+in scripts/language for information about setting up the ~/.filesender/poeditor-apikey file.
+
+```
+send-newterms-json-to-poeditor.sh 48000 /tmp/newterms.json
+```
+
+The newterms.json file can also be imported using the "Import terms"
 menu item on poeditor. This option is about the third icon on the
 right menu of the poeditor web site as of 2018. After selecting the
 newterms.json file you will see how many terms were parsed and how

--- a/scripts/language/send-newterms-json-to-poeditor.sh
+++ b/scripts/language/send-newterms-json-to-poeditor.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eou pipefail
+
+. ~/.filesender/poeditor-apikey
+
+
+projectid=${1:?supply poeditor project id as arg1. Main project is 48000 test project is 380345 };
+jsonfile=${2:?supply path to json file created with export-terms-to-new-and-deleted-lists.sh as arg2};
+
+curl -X POST https://api.poeditor.com/v2/terms/add \
+     -d api_token="$API_TOKEN" \
+     -d id="$projectid" \
+     --data-binary @$jsonfile
+
+
+


### PR DESCRIPTION
This avoids needing to switch to the browser to complete the newterms export.