### PR TITLE
PHP Notice Undefined variable/index

### DIFF
--- a/classes/utils/Archiver.class.php
+++ b/classes/utils/Archiver.class.php
@@ -144,7 +144,7 @@ class Archiver
             $file = $data['data'];
             $fileopts = array();
             $transfer = $file->transfer;
-            if( !$archivedName ) {
+            if( (!isset($archivedName)) ) {
                 $archivedName = $this->getArchivedFileName( $file );
             }
 
@@ -275,7 +275,7 @@ class Archiver
     {
         $fileopts = array();
         $transfer = $file->transfer;
-        if( !$archivedName ) {
+        if( (!isset($archivedName)) ) {
             $archivedName = $this->getArchivedFileName( $file );
         }
         

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -83,13 +83,17 @@ class GUI
 
     public static function browser_is_ie11()
     {
-        return preg_match("@MSIE@i", $_SERVER['HTTP_USER_AGENT'] )
-          ||   preg_match("@Trident/@i", $_SERVER['HTTP_USER_AGENT'] );
+        if (isset($_SERVER['HTTP_USER_AGENT'])) {
+            return preg_match("@MSIE@i", $_SERVER['HTTP_USER_AGENT'] )
+              ||   preg_match("@Trident/@i", $_SERVER['HTTP_USER_AGENT'] );
+        }
     }
     
     public static function browser_is_edge()
     {
-        return preg_match("@ Edge/@i", $_SERVER['HTTP_USER_AGENT'] );
+        if (isset($_SERVER['HTTP_USER_AGENT'])) {
+            return preg_match("@ Edge/@i", $_SERVER['HTTP_USER_AGENT'] );
+        }
     }
 
     public static function use_webasm_pbkdf2_implementation()


### PR DESCRIPTION
Silence warnings in the logs, possibly from random requests over the Internet.  
(Each commit contains the full log message.)