### PR TITLE
filesender.py: a more friendly message if deps are not installed

### DIFF
--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -712,6 +712,23 @@ Run:
 # chmod +x /etc/cron.daily/filesender
 ```
 
+# Step 10b - Install some python dependancies if you wish to use the filesender.py command line client
+
+The filesender.py script uses some extra libraries. These can be installed either
+through your distribution packages or directly with the pip command as shown below.
+
+```
+pip3 install requests urllib3
+```
+
+On a Fedora based distribution you might install these with:
+```
+dnf install python3-requests python3-urllib3
+```
+
+
+
+
 # Step 11 - Optional local about, help, and landing pages
 
 FileSender has provisions to allow you to have a local page for about,

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -726,6 +726,12 @@ On a Fedora based distribution you might install these with:
 dnf install python3-requests python3-urllib3
 ```
 
+On a Debian based distribution you might install these with:
+```
+apt-get install python3-requests python3-urllib3
+```
+
+
 
 
 

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -29,17 +29,29 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import requests
-import time
-from collections.abc import Iterable
-from collections.abc import MutableMapping
-import hmac
-import hashlib
-import urllib3
-import os
-import json
-import configparser
-from os.path import expanduser
+try:
+  import requests
+  import time
+  from collections.abc import Iterable
+  from collections.abc import MutableMapping
+  import hmac
+  import hashlib
+  import urllib3
+  import os
+  import json
+  import configparser
+  from os.path import expanduser
+except Exception as e:
+  print(type(e))
+  print(e.args)
+  print(e)
+  print('')
+  print('ERROR: A required dependency is not installed, please check your')
+  print('distribution packages or run something like the following')
+  print('')
+  print('pip3 install requests urllib3 ')
+  exit(1)
+  
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 


### PR DESCRIPTION
This was reported in issue https://github.com/filesender/filesender/issues/844. This PR tries to give more information about an import failure for two libraries that might need to be installed by pip or through platform packages.