### PR TITLE
Always show page header when an exception is thrown

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -2,13 +2,13 @@
 
 /*
  * FileSender www.filesender.org
- * 
+ *
  * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * *    Redistributions of source code must retain the above copyright
  *  notice, this list of conditions and the following disclaimer.
  * *    Redistributions in binary form must reproduce the above copyright
@@ -17,7 +17,7 @@
  * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
  *  names of its contributors may be used to endorse or promote products
  *  derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -32,45 +32,54 @@
 
 try {
     require_once('../includes/init.php');
-    
+
     Logger::setProcess(ProcessTypes::GUI);
-    
+
     try { // At that point we can render exceptions using nice html
-        Auth::isAuthenticated(); // Preload auth state
+        $pre_header_template_exception = null;
+        try {
+            Auth::isAuthenticated(); // Preload auth state
+            // Security that applies to all page requests
+            Security::addHTTPHeaders();
 
-        // Security that applies to all page requests
-        Security::addHTTPHeaders();
-
-        // if configured, ensure no nasty CSRF is going on
-        Security::validateAgainstCSRF();
-        
-        
+            // if configured, ensure no nasty CSRF is going on
+            Security::validateAgainstCSRF();
+        } catch (Exception $e) {
+            // Catch any of these exceptions so we can still print
+            // the page header template before throwing the exception
+            $pre_header_template_exception = $e;
+        }
         Template::display('!!header');
-        
+
+        if ($pre_header_template_exception !== null) {
+            // Throw any exception that occurred before the page header
+            throw $pre_header_template_exception;
+        }
+
         $page = GUI::currentPage();
         $vars = array();
-        
+
         if(!GUI::isUserAllowedToAccessPage($page)) {
             if(Auth::isAuthenticated())
                 throw new GUIAccessForbiddenException($page);
-        
+
             GUI::currentPage('logon');
             $vars['access_forbidden'] = true;
-            
+
             if(Config::get('auth_sp_autotrigger')) AuthSP::trigger();
         }
-        
+
         if(!in_array($page, array('download', 'maintenance')))
             Template::display('menu');
-        
+
         Template::display('page', array('vars' => $vars));
-        
+
     } catch(Exception $e) {
         Template::display('exception', array('exception' => $e));
     }
-    
+
     Template::display('!!footer');
-    
+
 } catch(Exception $e) {
     // If all exceptions are catched as expected we should not get there
     die('An exception happened : '.$e->getMessage());


### PR DESCRIPTION
The page header template is not printed to the user if an exception is thrown in the Auth or Security functions before it. This results in a "plain text" error message being printed (see below).

![image](https://user-images.githubusercontent.com/3529874/97501065-c687b900-19c4-11eb-8be2-6778d5ffeb37.png)

This pull request stores the exception in a variable and re-throws it after the page header is printed.

I was able to replicate this by:
1. Creating a new voucher
2. Modify the expiry date in the database to be in the past
3. Try and load the voucher link.

You will get a `GuestExpiredException`  from `Auth::isAuthenticated()`.