### PR TITLE
make this error soft, no need to stop everything

### DIFF
--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -189,7 +189,15 @@ class RestEndpointUser extends RestEndpoint
         }
         
         if ($property == 'frequent_recipients') {
-            throw new RestUsePOSTException();
+            // Throwing an exception for this bad access case is
+            // a bit of overkill, frequent_recipients are not a
+            // critical feature so it might be better to fallback
+            // to just offering nothing if they access things via
+            // GET instead of POST.
+            return array(
+                'path' => '/user/user',
+                'data' => ''
+            );
         }
         
         if ($property == 'quota') {


### PR DESCRIPTION
The GET method should not be being used here. If it is somehow then maybe we should just return no data and allow the show to go on. If frequent recipients returns nothing it is not ideal but it should probably not stop everything.
