### PR TITLE
Add info to help failure investigations

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1353,7 +1353,7 @@ class Transfer extends DBObject
             $this->recipientsCache[$recipient->id] = $recipient;
         }
         
-        Logger::info($recipient.' added to '.$this);
+        Logger::info($recipient.' added to '.$this.' with token '.$recipient->token);
         
         return $recipient;
     }


### PR DESCRIPTION
Add recipient token to "recipient added to transfer" log entries so that it is possible to link token related exception to transfer data using logs only. Use case is when somebody use a very old download link (after audit expiration) or one to a deleted transfer. In such case log tells about a "recipient not found" along with used token, but we are not able to get anymore info as the data isn't in the database anymore, so when the user contact the hotline we are unable to tell her/him whether she/he was too late, or if the transfer owner deleted it ... This new log line format ties the recipient id and token in the logs so data aggregation becomes possible0