### PR TITLE
Don't set password input field readonly after generating password

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1467,7 +1467,6 @@ $(function() {
         var crypto = window.filesender.crypto_app();
         var encoded = crypto.generateRandomPassword();
         password = encoded.value;
-        filesender.ui.nodes.encryption.password.attr('readonly', true);
         filesender.ui.nodes.encryption.password.val(password);
         filesender.ui.transfer.encryption_password_encoding = encoded.encoding;
         filesender.ui.transfer.encryption_password_version  = encoded.version;


### PR DESCRIPTION
This change adds/restores the ability to edit/change/replace the password after having it generated, without having to restart the transfer from scratch (or changing that attribute in your browser using developer tools).

As long as people can set trivial passwords before/without ever selecting "generate password" preventing them from changing the generated password doesn't achieve much security-wise, I think.

There may of course be other reasons for setting the input field readonly I'm not aware of right now.

Should take care of one of the several issues raised in #880