### PR TITLE
Add configurable email headers

### DIFF
--- a/classes/utils/ApplicationMail.class.php
+++ b/classes/utils/ApplicationMail.class.php
@@ -312,9 +312,15 @@ class ApplicationMail extends Mail
         }
         
         // Set context in headers so that it is returned along with bounces
+        $add_headers = Config::get('email_headers');
         if ($context) {
             $this->msg_id = '<'.$context.'-'.uniqid().'@filesender>';
             $this->addHeader('X-Filesender-Context', $context);
+            if (is_array($add_headers)) {
+                foreach ($add_headers as $key => $value) {
+                    $this->addHeader($key, $value);
+                }
+            }
         }
         
         // Send email

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -76,6 +76,7 @@ A note about colours;
 * [email_return_path](#email_return_path)
 * [email_use_html](#email_use_html)
 * [email_newline](#email_newline)
+* [email_headers](#email_headers)
 * [relay_unknown_feedbacks](#relay_unknown_feedbacks)
 
 ## General UI
@@ -714,6 +715,15 @@ User language detection is done in the following order:
 * __1.x name:__ crlf
 * __comment:__ the default value in version 1.x was "\n".
 * __comment:__ Make sure you use double quotes to configure this value in the config file.  If you use single quotes the \r and \n will NOT be interpreted!
+
+### email_headers
+
+* __description:__ specify additional RFC 822 (today RFC 5322) headers to be added to outgoing emails sent by FileSender.
+* __mandatory:__ no
+* __type:__ array of 2-tuples (header name, header value)
+* __default:__ false
+* __available:__ since version 2.x
+* __comment:__ E.g. add to your `$config['email_headers'] = array('Auto-Submitted' => 'auto-generated', 'X-Auto-Response-Suppress' => 'All');` to add these 2 headers with their respective values to all outgoing emails.
 
 ### relay_unknown_feedbacks
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -148,6 +148,7 @@ $default = array(
     'email_from' => 'sender',
     'email_return_path' => 'sender',
     'email_subject_prefix' => '{cfg:site_name}:',
+    'email_headers' => false,
     
     'report_bounces' => 'asap',
     'report_bounces_asap_then_daily_range' => 15 * 60,


### PR DESCRIPTION
Fixes #871 by making this a deployer choice, not a code decision (meaning we don't have to agree on the content of the additional headers). Though I'm not sure how you'd approach that (e.g. I'd default to an empty `array()`, not `false`, but `include/ConfigDefaults.php` had no such examples, etc.) and whether the proposed code/documentation suffices.  
My own config looks like this, though that may need some more tuning, depending on the brokenness of some mail systems:

```php
$config['email_headers'] = [
  'Auto-Submitted' => 'auto-generated',
  'X-Auto-Response-Suppress' => 'All'
];
```