### PR TITLE
ui: allow clicking headers in admin/transfers page

### DIFF
--- a/templates/admin_page.php
+++ b/templates/admin_page.php
@@ -7,9 +7,12 @@
         $sections[] = 'config';
     
     $section = 'transfers';
-    if(array_key_exists('as', $_REQUEST))
-        $section = $_REQUEST['as'];
-    
+    if(array_key_exists('as', $_REQUEST)) {
+        if( strlen($_REQUEST['as'])) {
+            $section = $_REQUEST['as'];
+        }
+    }
+
     if(!in_array($section, $sections)) throw new GUIUnknownAdminSectionException($section);
     
     ?>


### PR DESCRIPTION
This should fix the issue https://github.com/filesender/filesender/issues/889 which mentions that table headers to not work in the admin/transfers subpage.