### PR TITLE
ui: allow going back from generated to user selected password

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -614,4 +614,4 @@ $lang['you_can_send_client_logs'] = 'In order to help your support team to find 
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
 $lang['sender_email_search'] = 'Sender email';
 $lang['search_transfer_by_sender_email_description'] = 'Search transfers by sender email address';
-
+$lang['generate_a_different_password'] = 'Generate a different password';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -199,7 +199,14 @@ if(Auth::isGuest()) {
                             {tr:file_encryption_password_too_short}
                         </div>
                         <div class="fieldcontainer" id="encryption_password_container_generate">
-                            <a id='encryption_generate_password' href="#">{tr:file_encryption_generate_password}</a>
+                            <input id="encryption_use_generated_password"  name="encryption_use_generated_password" type="checkbox">  
+                            <label for="encryption_use_generated_password" style="cursor: pointer;">{tr:file_encryption_generate_password}</label>
+                            
+                        </div>
+                        <div class="fieldcontainer" id="encryption_password_container_generate_again">
+                            <a href="#" id="encryption_generate_password" class="">
+                                <span class="fa fa-refresh"></span>&nbsp;{tr:generate_a_different_password}
+                            </a>
                         </div>
                         <div class="fieldcontainer" id="encryption_password_show_container">  
                             <input id="encryption_show_password" name="encryption_show_password" type="checkbox">  

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1540,6 +1540,7 @@ table.guests .guest .to .errors .details {
 #encryption_password_container,
 #encryption_password_container_too_short_message,
 #encryption_password_container_generate,
+#encryption_password_container_generate_again,
 #encryption_password_show_container,
 #encryption_description_container_disabled,
 #encryption_description_not_supported,

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1199,10 +1199,12 @@ $(function() {
         from: form.find('select[name="from"]'),
         subject: form.find('input[name="subject"]'),
         encryption: {
-                toggle: form.find('input[name="encryption"]'),
-                password: form.find('input[name="encryption_password"]'),
-                show_hide: form.find('#encryption_show_password'),
-                generate: form.find('#encryption_generate_password')
+            toggle: form.find('input[name="encryption"]'),
+            password: form.find('input[name="encryption_password"]'),
+            show_hide: form.find('#encryption_show_password'),
+            generate:      form.find('#encryption_generate_password'),
+            use_generated: form.find('#encryption_use_generated_password'),
+            generate_again: form.find('#encryption_password_container_generate_again')
         },
         uploading_actions_msg:form.find('.uploading_actions .msg'),
         auto_resume_timer:form.find('.uploading_actions .auto_resume_timer'),
@@ -1465,13 +1467,34 @@ $(function() {
         
         return false;
     });
+
+    filesender.ui.nodes.encryption.use_generated.on('change', function() {
+        var v = filesender.ui.nodes.encryption.use_generated.is(':checked');
+        console.log("AAA v " + v );
+        if( v ) {
+            filesender.ui.nodes.encryption.generate_again.show();
+            
+            filesender.ui.nodes.encryption.password.attr('readonly', true);
+            filesender.ui.nodes.encryption.generate.click();
+        } else {
+            filesender.ui.nodes.encryption.generate_again.hide();
+            $('#encryption_password_show_container').show();
+            filesender.ui.nodes.encryption.password.attr('readonly', false);
+            
+            // plain text passwords have a specific version
+            // and encoding which may be used by key generation
+            // so we must reset that here if the user starts modifying the password.
+            filesender.ui.transfer.encryption_password_version = crypto.crypto_password_version_constants.v2018_text_password;
+            filesender.ui.transfer.encryption_password_encoding = 'none';            
+        }
+       
+    });
     
     filesender.ui.nodes.encryption.generate.on('click', function() {
 
         var crypto = window.filesender.crypto_app();
         var encoded = crypto.generateRandomPassword();
         password = encoded.value;
-        filesender.ui.nodes.encryption.password.attr('readonly', true);
         filesender.ui.nodes.encryption.password.val(password);
         filesender.ui.transfer.encryption_password_encoding = encoded.encoding;
         filesender.ui.transfer.encryption_password_version  = encoded.version;

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1470,7 +1470,6 @@ $(function() {
 
     filesender.ui.nodes.encryption.use_generated.on('change', function() {
         var v = filesender.ui.nodes.encryption.use_generated.is(':checked');
-        console.log("AAA v " + v );
         if( v ) {
             filesender.ui.nodes.encryption.generate_again.show();
             


### PR DESCRIPTION
Allow the user to go back to user selected password when they currently have a generated password on the upload page. Generated passwords are treated slightly differently to user entered passwords as the generated ones are more likely to use the full entropy of each byte. This can have an impact when password hashing is used on user entered passwords.

To get around the user modifying a generated password they are set to read only. To go back to a user entered password the selection has become a checkbox with the generation of new passwords moved to a second button which is only available when generated passwords are used. I think retaining the generate button is good because the user might feel better about the appearance of some passwords over others.

This is related to https://github.com/filesender/filesender/pull/885.