### PR TITLE
ui: new option to allow admin to extend expire time on transfer

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1631,7 +1631,14 @@ class Transfer extends DBObject
      */
     public function expiryDateExtension($throw = true)
     {
-        $pattern = Config::get('allow_transfer_expiry_date_extension');
+        $pattern = null;
+        
+        if( Auth::isAdmin()) {
+            $pattern = Config::get('allow_transfer_expiry_date_extension_admin');
+        }
+        if( !$pattern ) {
+            $pattern = Config::get('allow_transfer_expiry_date_extension');
+        }
         
         if (!$pattern) {
             if ($throw) {
@@ -1643,11 +1650,12 @@ class Transfer extends DBObject
         if (!is_array($pattern)) {
             $pattern = array($pattern);
         }
-        
-        // Get nth
+
+       // Get nth
         $index = (int)$this->expiry_extensions;
         
-        if ($index < count($pattern)) {
+        Logger::error("admin " . Auth::isAdmin() . " index $index count-p " . count($pattern));
+         if ($index < count($pattern)) {
             $duration = (int)$pattern[$index];
         } else {
             $last = array_pop($pattern);

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1651,11 +1651,10 @@ class Transfer extends DBObject
             $pattern = array($pattern);
         }
 
-       // Get nth
+        // Get nth
         $index = (int)$this->expiry_extensions;
         
-        Logger::error("admin " . Auth::isAdmin() . " index $index count-p " . count($pattern));
-         if ($index < count($pattern)) {
+        if ($index < count($pattern) && (!is_bool($pattern[$index]))) {
             $duration = (int)$pattern[$index];
         } else {
             $last = array_pop($pattern);

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -104,6 +104,7 @@ A note about colours;
 * [default_transfer_days_valid](#default_transfer_days_valid)
 * [max_transfer_days_valid](#max_transfer_days_valid)
 * [allow_transfer_expiry_date_extension](#allow_transfer_expiry_date_extension)
+* [allow_transfer_expiry_date_extension_admin](#allow_transfer_expiry_date_extension_admin)
 * [force_legacy_mode](#force_legacy_mode)
 * [legacy_upload_progress_refresh_period](#legacy_upload_progress_refresh_period)
 * [max_legacy_file_size](#max_legacy_file_size)
@@ -940,7 +941,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 
 ### allow_transfer_expiry_date_extension
 
-* __description:__ allows a user to extend the expiry date.
+* __description:__ allows a user to extend the expiry date. See also allow_transfer_expiry_date_extension_admin to allow admins special extension ability.
 * __mandatory:__
 * __type:__ an array of integers containing possible extensions in days.
 * __default:__ - (= not activated)
@@ -953,6 +954,18 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 	$config['allow_transfer_expiry_date_extension'] = 5; // Same as above
 	$config['allow_transfer_expiry_date_extension'] = array(5, 3); // Allows 2 successive extensions, the first is by 5 days the second is by 3 days
 	$config['allow_transfer_expiry_date_extension'] = array(5, 3, 1, true); // Allows infinite extensions, the first is by 5 days the second is by 3 days, the third and above are by 1 day
+
+### allow_transfer_expiry_date_extension_admin
+
+* __description:__ allows an admin to extend the expiry date. This is similiar to allow_transfer_expiry_date_extension but is only used if you are logged in as an admin on the system. If you are an admin this schedule will overwrite the allow_transfer_expiry_date_extension for you. So you can set both and this will be used in preference if you are logged in as admin, otherwise allow_transfer_expiry_date_extension will be used if it is set. As you might only like to use this option and not allow users to extend transfers this option may offer a second UI element to allow extension, where there are two ways to extend a transfer they will both perform the same action and follow the admin configuration if you are logged in as admin.
+* __mandatory:__
+* __type:__ an array of integers containing possible extensions in days.
+* __default:__ - (= not activated)
+* __available:__ since version 2.21
+* __Examples:__
+
+        // Allows infinite extensions, the first is by 30 days then 90 days 
+	$config['allow_transfer_expiry_date_extension_admin'] = array(30, 90, true); 
 
 ## force_legacy_mode
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -615,3 +615,4 @@ $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at:
 $lang['sender_email_search'] = 'Sender email';
 $lang['search_transfer_by_sender_email_description'] = 'Search transfers by sender email address';
 $lang['generate_a_different_password'] = 'Generate a different password';
+$lang['extend_expires'] = 'Extend expires time';

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -272,7 +272,7 @@ if (!function_exists('clickableHeader')) {
                 <div style="margin:3px">
                     <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
                     <?php if($audit)   { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
-                    <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o" title="{tr:extend_expires}"></span><?php } ?>
+                    <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o adminaction" title="{tr:extend_expires}"></span><?php } ?>
                 </div>
             </td>
         </tr>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -17,9 +17,15 @@ if(!isset($trsort))  $nosort = true;
 
 
     $isAdmin = false;
+    $showAdminExtend = false;
     if (Auth::isAuthenticated()) {
         if (Auth::isAdmin()) {
+
             $isAdmin = true;
+            
+            if(Config::get('allow_transfer_expiry_date_extension_admin')) {
+                $showAdminExtend = true;
+            }
         }
     }
 
@@ -271,8 +277,8 @@ if (!function_exists('clickableHeader')) {
                 </div>
                 <div style="margin:3px">
                     <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
-                    <?php if($audit)   { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
-                    <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o adminaction" title="{tr:extend_expires}"></span><?php } ?>
+                    <?php if($audit)           { ?><span data-action="auditlog"      class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                    <?php if($showAdminExtend) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o adminaction" title="{tr:extend_expires}"></span><?php } ?>
                 </div>
             </td>
         </tr>
@@ -287,8 +293,8 @@ if (!function_exists('clickableHeader')) {
                     </div>
                     <div style="margin:3px">
                         <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
-                        <?php if($audit)   { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
-                        <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o" title="{tr:extend_expires}"></span><?php } ?>
+                        <?php if($audit)           { ?><span data-action="auditlog"      class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                        <?php if($showAdminExtend) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o" title="{tr:extend_expires}"></span><?php } ?>
                     </div>
                 </div>
                 

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -16,6 +16,15 @@ if(!isset($trsort))  $nosort = true;
     $havePrev = 0;
 
 
+    $isAdmin = false;
+    if (Auth::isAuthenticated()) {
+        if (Auth::isAdmin()) {
+            $isAdmin = true;
+        }
+    }
+
+
+
     $cgiuid = "";
     if (Auth::isAuthenticated()) {
         if (Auth::isAdmin()) {
@@ -262,7 +271,8 @@ if (!function_exists('clickableHeader')) {
                 </div>
                 <div style="margin:3px">
                     <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
-                    <?php if($audit) { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                    <?php if($audit)   { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                    <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o" title="{tr:extend_expires}"></span><?php } ?>
                 </div>
             </td>
         </tr>
@@ -277,7 +287,8 @@ if (!function_exists('clickableHeader')) {
                     </div>
                     <div style="margin:3px">
                         <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
-                        <?php if($audit) { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                        <?php if($audit)   { ?><span data-action="auditlog" class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                        <?php if($isAdmin) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o" title="{tr:extend_expires}"></span><?php } ?>
                     </div>
                 </div>
                 

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1550,6 +1550,10 @@ table.guests .guest .to .errors .details {
     display: none;
 }
 
+.adminaction {
+    background: #ffeeee;
+}
+
 #encryption_password_container_too_short_message {
     color: #f00;
 }

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -201,7 +201,7 @@ $(function() {
             })
         });
     }).on('click', function() {
-        extendExpires( $(this), 30 );
+        extendExpires( $(this) );
     });
     
 

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -129,7 +129,7 @@ $(function() {
     });
 
 
-    var extendExpires = function( self, durationOverride )
+    var extendExpires = function( self )
     {
         if(self.hasClass('disabled')) return;
         
@@ -139,9 +139,6 @@ $(function() {
         if(!id || isNaN(id)) return;
         
         var duration = parseInt(t.attr('data-expiry-extension'));
-        if( durationOverride ) {
-            duration = durationOverride;
-        }
         
         var extend = function(remind) {
             filesender.client.extendTransfer(id, remind, function(t) {

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -127,25 +127,21 @@ $(function() {
             });
         }
     });
-    
-    // Extend buttons
-    $('[data-expiry-extension="0"] [data-action="extend"]').addClass('disabled').attr({title: lang.tr('transfer_expiry_extension_count_exceeded')});
-    
-    $('[data-expiry-extension][data-expiry-extension!="0"] [data-action="extend"]').each(function() {
-        $(this).attr({
-            title: lang.tr('extend_expiry_date').r({
-                days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
-            })
-        });
-    }).on('click', function() {
-        if($(this).hasClass('disabled')) return;
+
+
+    var extendExpires = function( self, durationOverride )
+    {
+        if(self.hasClass('disabled')) return;
         
-        var t = $(this).closest('[data-transfer]');
+        var t = self.closest('[data-transfer]');
         
         var id = t.attr('data-id');
         if(!id || isNaN(id)) return;
         
         var duration = parseInt(t.attr('data-expiry-extension'));
+        if( durationOverride ) {
+            duration = durationOverride;
+        }
         
         var extend = function(remind) {
             filesender.client.extendTransfer(id, remind, function(t) {
@@ -161,7 +157,7 @@ $(function() {
                 } else {
                     $('[data-transfer][data-id="' + id + '"] [data-action="extend"]').attr({
                         title: lang.tr('extend_expiry_date').r({
-                            days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
+                            days: self.closest('[data-transfer]').attr('data-expiry-extension')
                         })
                     });
                 }
@@ -183,7 +179,32 @@ $(function() {
         buttons.cancel = false;
         
         filesender.ui.popup(lang.tr('confirm_dialog'), buttons).html(lang.tr('confirm_extend_expiry').r({days: duration}).out());
+    }
+    
+    // Extend buttons
+    $('[data-expiry-extension="0"] [data-action="extend"]').addClass('disabled').attr({title: lang.tr('transfer_expiry_extension_count_exceeded')});
+    
+    $('[data-expiry-extension][data-expiry-extension!="0"] [data-action="extend"]').each(function() {
+        $(this).attr({
+            title: lang.tr('extend_expiry_date').r({
+                days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
+            })
+        });
+    }).on('click', function() {
+        extendExpires( $(this) );
     });
+
+    $('[data-expiry-extension][data-expiry-extension!="-1"] [data-action="extendexpires"]').each(function() {
+        $(this).attr({
+            title: lang.tr('extend_expiry_date').r({
+                days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
+            })
+        });
+    }).on('click', function() {
+        extendExpires( $(this), 30 );
+    });
+    
+
     
     // Add recipient buttons
     $('[data-recipients-enabled=""] [data-action="add_recipient"]').addClass('disabled');


### PR DESCRIPTION
This is a new option `allow_transfer_expiry_date_extension_admin` which works much like `allow_transfer_expiry_date_extension` but is only in effect if you are an admin user. This allows you to set a different schedule for admins to be able to extend expire times without needing to allow normal users to be able to perform this task as well.

This should work in the admin/transfers page as well as in the my transfers page for an admin. The former being the more interesting option allowing an admin to extend the lifetime of a selected transfer.

This is for issue https://github.com/filesender/filesender/issues/875