### PR TITLE
bootstrap: no my transfers button for all guests

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -210,7 +210,7 @@ $displayoption = function($name, $cfg, $disable = false, $forcedOption = false) 
                     <p></p>
                 </div>
 
-<?php if(!$guest_can_only_send_to_creator) { ?>
+<?php if(!Auth::isGuest()) { ?>
                 <div class="row">
                     <div class="col-3">
                     </div>


### PR DESCRIPTION
If a guest can not go to the my transfers page then there isn't much point in offering it.