### PR TITLE
Add Docker image for FileSender with SimpleSamlPHP

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+FROM php:7.4-fpm-buster
+
+ENV FILESENDER_VERSION=2.22 \
+    FILESENDER_SUM="ef6da83e7ac46303e5f8d620f6858565fd746d7c4b054a12439a561d79b515a2" \
+    SSP_VERSION=1.19.0 \
+    SSP_SUM="2111129787a4baf27a51e52bda660c56d069f167354800bffc72440dcacb3a6f" 
+
+RUN cd /opt && mkdir filesender && \
+    cd /opt/filesender && \
+    curl -kL https://github.com/filesender/filesender/archive/master-filesender-${FILESENDER_VERSION}.tar.gz | tar xz && \
+    ln -s filesender-master-filesender-${FILESENDER_VERSION} filesender && \
+    curl -L https://github.com/simplesamlphp/simplesamlphp/releases/download/v${SSP_VERSION}/simplesamlphp-${SSP_VERSION}.tar.gz | tar xz && \
+    ln -s simplesamlphp-${SSP_VERSION} simplesamlphp
+
+RUN cd /opt/filesender/filesender && \
+    cp config/config_sample.php config/config.php && \
+    mkdir -p tmp files log && \
+    chmod o-rwx tmp files log config/config.php && \
+    chown www-data:www-data tmp files log && \
+    chgrp www-data config/config.php && \
+    cd /opt/filesender/simplesamlphp && \
+    cp -r config-templates/*.php config/ && \
+    cp -r metadata-templates/*.php metadata/
+
+RUN mkdir -p /config/fpm /config/filesender /config/simplesamlphp/config /config/simplesamlphp/metadata && \
+    mv -f /usr/local/etc/php-fpm.d/www.conf /config/fpm/www.conf && \
+    mv -f /opt/filesender/filesender/config/config.php /config/filesender/config.php && \
+    mv -f /opt/filesender/simplesamlphp/config/*.php /config/simplesamlphp/config/ && \
+    mv -f /opt/filesender/simplesamlphp/metadata/*.php /config/simplesamlphp/metadata/ && \
+    ln -s /config/fpm/www.conf /usr/local/etc/php-fpm.d/filesender.conf && \
+    ln -s /config/filesender/config.php /opt/filesender/filesender/config/config.php && \
+    ln -s /config/simplesamlphp/config/acl.php /opt/filesender/simplesamlphp/config/acl.php && \
+    ln -s /config/simplesamlphp/config/authsource.php /opt/filesender/simplesamlphp/config/authsource.php && \
+    ln -s /config/simplesamlphp/config/config.php /opt/filesender/simplesamlphp/config/config.php && \
+    ln -s /config/simplesamlphp/metadata/active.php /opt/filesender/simplesamlphp/metadata/active.php
+ 
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends nginx runit && \
+    apt-get autoremove -y && \
+    apt-get clean && \ 
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY assets /
+    
+VOLUME ["/opt/filesender", "/config/fpm", "/config/filesender", "/config/simplesamlphp/config", "/config/simplesamlphp/metadata", "/opt/filesender/data"]
+EXPOSE 80 443
+
+CMD ["/usr/local/sbin/runsvdir-init"]
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL maintainer="Nils Vogels <n.vogels@aves-it.nl>" \
+      org.label-schema.build-date="${BUILD_DATE}" \
+      org.label-schema.docker.dockerfile="/docker/Dockerfile" \
+      org.label-schema.license="BSD3" \
+      org.label-schema.name="Filesender and SimpleSamlPHP on php7-fpm" \
+      org.label-schema.vendor="filesender" \
+      org.label-schema.url="https://filesender.org" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/filesender/filesender.git" \
+      org.label-schema.vcs-type="Git" \
+      org.label-schema.version="2.22" \
+      org.label-schema.schema-version="1.0"

--- a/docker/Dockerfile.bootstrap
+++ b/docker/Dockerfile.bootstrap
@@ -1,0 +1,56 @@
+FROM php:7.4-fpm-buster
+LABEL version="0.1.0" \
+      license="BSD3" \
+      maintainer="Nils Vogels <n.vogels@aves-it.nl>" \
+      description="Filesender and simplesamlphp based on php7-fpm" \
+      documentation="https://docs.filesender.org"
+
+ENV FILESENDER_VERSION=bootstrap \
+    FILESENDER_BRANCH=2021/bootstrap \
+    FILESENDER_SUM="ef6da83e7ac46303e5f8d620f6858565fd746d7c4b054a12439a561d79b515a2" \
+    SSP_VERSION=1.19.0 \
+    SSP_SUM="2111129787a4baf27a51e52bda660c56d069f167354800bffc72440dcacb3a6f" 
+
+RUN cd /opt && mkdir filesender && \
+    cd /opt/filesender && \
+    curl -kL https://github.com/filesender/filesender/archive/${FILESENDER_BRANCH}.tar.gz | tar xz && \
+    FS_DEST=`ls -1` && \
+    ln -s ${FS_DEST} filesender && \
+    curl -L https://github.com/simplesamlphp/simplesamlphp/releases/download/v${SSP_VERSION}/simplesamlphp-${SSP_VERSION}.tar.gz | tar xz && \
+    ln -s simplesamlphp-${SSP_VERSION} simplesamlphp
+
+RUN cd /opt/filesender/filesender && \
+    cp config/config_sample.php config/config.php && \
+    mkdir -p tmp files log && \
+    chmod o-rwx tmp files log config/config.php && \
+    chown www-data:www-data tmp files log && \
+    chgrp www-data config/config.php && \
+    cd /opt/filesender/simplesamlphp && \
+    cp -r config-templates/*.php config/ && \
+    cp -r metadata-templates/*.php metadata/
+
+RUN mkdir -p /config/fpm /config/filesender /config/simplesamlphp/config /config/simplesamlphp/metadata && \
+    mv -f /usr/local/etc/php-fpm.d/www.conf /config/fpm/www.conf && \
+    mv -f /opt/filesender/filesender/config/config.php /config/filesender/config.php && \
+    mv -f /opt/filesender/simplesamlphp/config/*.php /config/simplesamlphp/config/ && \
+    mv -f /opt/filesender/simplesamlphp/metadata/*.php /config/simplesamlphp/metadata/ && \
+    ln -s /config/fpm/www.conf /usr/local/etc/php-fpm.d/filesender.conf && \
+    ln -s /config/filesender/config.php /opt/filesender/filesender/config/config.php && \
+    ln -s /config/simplesamlphp/config/acl.php /opt/filesender/simplesamlphp/config/acl.php && \
+    ln -s /config/simplesamlphp/config/authsource.php /opt/filesender/simplesamlphp/config/authsource.php && \
+    ln -s /config/simplesamlphp/config/config.php /opt/filesender/simplesamlphp/config/config.php && \
+    ln -s /config/simplesamlphp/metadata/active.php /opt/filesender/simplesamlphp/metadata/active.php
+ 
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y --no-install-recommends nginx runit && \
+    apt-get autoremove -y && \
+    apt-get clean && \ 
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY assets /
+    
+VOLUME ["/opt/filesender", "/config/fpm", "/config/filesender", "/config/simplesamlphp/config", "/config/simplesamlphp/metadata", "/opt/filesender/data"]
+EXPOSE 80 443
+
+CMD ["/usr/local/sbin/runsvdir-init"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,44 @@
+# filesender-phpfpm
+
+- [Introduction](#introduction)
+- [Dependencies](#dependencies)
+- [Environment Variables](#environment-variables)
+- [Deployment](#deployment)
+  - [simplesamlphp](#simplesamlphp)
+
+## Introduction
+[Docker](https://www.docker.com/what-docker) image of [filesender](https://filesender.org) ran within [php-fpm](https://php-fpm.org/), especially tuned for consumption into Kubernetes. All images are based off of [debian](https://www.debian.org/) stable.
+
+This is a follow-up of [ualibraries](https://github.com/ualibraries/filesender-phpfpm). Automated builds will be available at Docker hub.
+
+This [release](https://github.com/filesender/filesender) of filesender can use [simplesamlphp](https://simplesamlphp.org/) or [shibboleth-sp](https://www.shibboleth.net/products/service-provider) for authentication. 
+Questions directly related on using or configuring filesender should get posted to it's [mailinglist](https://sympa.uninett.no/lists/filesender.org/lists).
+
+This docker image is not meant to run on its own, as it has some dependencies missing. Especially, this image only provides PHP-FPM with simplesamlphp and filesender installed.
+A seperate web-server is required to run this in production. For Kubernetes, this is embedded in the Ingress Controllers.
+
+## Dependencies
+This container image of filesender requires the following dependencies:
+
+###  Environmental dependencies
+1. An (external) IP address
+2. A (public) DNS entry
+3. Sufficient storage capacity to store uploaded files for their lifetime`
+
+### External services
+1. An [smtp](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol) server to send emails. For example a third party SMTP service or a company email server could be used.
+2. A [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) that can handle FPM. Haproxy or Nginx would be suitable candidates
+3. An [SSL certificate](https://nl.wikipedia.org/wiki/Transport_Layer_Security) to make the service available via https/ssl
+4. A [database engine](https://en.wikipedia.org/wiki/Database_engine) to store application data in. Currently supported is mysql/pgsql.
+
+All dependencies are provided using the [helm](https://helm.sh/) chart located in TODO
+
+## Environment Variables
+
+The following environment variables control the container setup:
+
+TODO - list environment variables honored
+
+## Configuration
+
+The container has it's configuration for Filesender, fpm and SimpleSAMLphp in /config. Here you can adjust the default config files, or place your own

--- a/docker/assets/etc/nginx/fastcgi_params
+++ b/docker/assets/etc/nginx/fastcgi_params
@@ -1,0 +1,25 @@
+fastcgi_param  QUERY_STRING       $query_string;
+fastcgi_param  REQUEST_METHOD     $request_method;
+fastcgi_param  CONTENT_TYPE       $content_type;
+fastcgi_param  CONTENT_LENGTH     $content_length;
+
+fastcgi_param  SCRIPT_FILENAME    $request_filename;
+fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+fastcgi_param  REQUEST_URI        $request_uri;
+fastcgi_param  DOCUMENT_URI       $document_uri;
+fastcgi_param  DOCUMENT_ROOT      $document_root;
+fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  REQUEST_SCHEME     $scheme;
+fastcgi_param  HTTPS              $https if_not_empty;
+
+fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+fastcgi_param  REMOTE_ADDR        $remote_addr;
+fastcgi_param  REMOTE_PORT        $remote_port;
+fastcgi_param  SERVER_ADDR        $server_addr;
+fastcgi_param  SERVER_PORT        $server_port;
+fastcgi_param  SERVER_NAME        $server_name;
+
+# PHP only, required if PHP was built with --enable-force-cgi-redirect
+fastcgi_param  REDIRECT_STATUS    200;

--- a/docker/assets/etc/nginx/nginx.conf
+++ b/docker/assets/etc/nginx/nginx.conf
@@ -1,0 +1,23 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+daemon off;
+events {
+        worker_connections 1024;
+        use epoll;
+}
+http {
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+        gzip on;
+        gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}

--- a/docker/assets/etc/nginx/sites-available/default
+++ b/docker/assets/etc/nginx/sites-available/default
@@ -1,0 +1,38 @@
+server {
+        add_header X-Frame-Options sameorigin always;
+        client_body_buffer_size 256k;
+        client_max_body_size 32m;
+        server_name _;
+        index index.php;
+        error_page 500 502 503 504 /50x.html;
+        root /opt/filesender/filesender/www;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+        location / {
+            try_files $uri $uri/ /index.php?args;
+        }
+        location ~ [^/]\.php(/|$) {
+            fastcgi_split_path_info  ^(.+\.php)(/.+)$;
+            fastcgi_pass  localhost:9000;
+            include       fastcgi_params;
+            fastcgi_intercept_errors on;
+            fastcgi_param PATH_INFO       $fastcgi_path_info;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        }
+        location ^~ /simplesamlphp {
+            alias /opt/filesender/simplesamlphp/saml/www;
+            location ~ ^(?<prefix>/saml)(?<phpfile>.+?\.php)(?<pathinfo>/.*)?$ {
+                include fastcgi_params;
+                fastcgi_pass  localhost:9000;
+                fastcgi_param SCRIPT_FILENAME $document_root$phpfile;
+                fastcgi_param PATH_INFO       $pathinfo if_not_empty;
+            }
+        }
+        location ~* \.(ico|docx|doc|xls|xlsx|rar|zip|jpg|jpeg|txt|xml|pdf|gif|png|css|js)$ {
+            root   /opt/filesender/filesender/www/;
+        }
+        location ~ /\. {
+                deny all;
+        }
+}

--- a/docker/assets/etc/nginx/sites-enabled/default
+++ b/docker/assets/etc/nginx/sites-enabled/default
@@ -1,0 +1,1 @@
+../sites-available/default

--- a/docker/assets/etc/service/nginx/run
+++ b/docker/assets/etc/service/nginx/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+exec 2>&1
+source /usr/local/etc/envvars
+exec /usr/sbin/nginx

--- a/docker/assets/etc/service/php-fpm/run
+++ b/docker/assets/etc/service/php-fpm/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+exec 2>&1
+source /usr/local/etc/envvars
+php-fpm-env > /usr/local/etc/php-fpm-env.conf
+exec /usr/local/sbin/php-fpm --nodaemonize

--- a/docker/assets/usr/local/bin/docker-php-ext-configure
+++ b/docker/assets/usr/local/bin/docker-php-ext-configure
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+ext="$1"
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" -o ! -d "$extDir" ]; then
+	echo >&2 "usage: $0 ext-name [configure flags]"
+	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
+	echo >&2
+	echo >&2 'Possible values for ext-name:'
+	echo >&2 $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
+	exit 1
+fi
+shift
+
+set -x
+cd "$extDir"
+phpize
+./configure "$@"

--- a/docker/assets/usr/local/bin/docker-php-ext-install
+++ b/docker/assets/usr/local/bin/docker-php-ext-install
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+cd /usr/src/php/ext
+
+usage() {
+	echo "usage: $0 ext-name [ext-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
+	echo
+	echo 'Possible values for ext-name:'
+	echo $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
+}
+
+exts=()
+while [ $# -gt 0 ]; do
+	ext="$1"
+	shift
+	if [ -z "$ext" ]; then
+		continue
+	fi
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $(pwd -P)/$ext does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	exts+=( "$ext" )
+done
+
+if [ "${#exts[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for ext in "${exts[@]}"; do
+	(
+		cd "$ext"
+		[ -e Makefile ] || docker-php-ext-configure "$ext"
+		make
+		make install
+		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+		for module in modules/*.so; do
+			if [ -f "$module" ]; then
+				if grep -q zend_extension_entry "$module"; then
+					# https://wiki.php.net/internals/extensions#loading_zend_extensions
+					line="zend_extension=$(basename "$module")"
+				else
+					line="extension=$(basename "$module")"
+				fi
+				if ! grep -q "$line" "$ini"; then
+					echo "$line" >> "/usr/local/etc/php/conf.d/ext-$ext.ini"
+				fi
+			fi
+		done
+		make clean
+	)
+done

--- a/docker/assets/usr/local/etc/php/conf.d/opcache.ini
+++ b/docker/assets/usr/local/etc/php/conf.d/opcache.ini
@@ -1,0 +1,3 @@
+zend_extension=opcache.so
+opcache.enable=On
+opcache.validate_timestamps=0

--- a/docker/assets/usr/local/lib/php-fpm-env/PhpFpmEnvironment.php
+++ b/docker/assets/usr/local/lib/php-fpm-env/PhpFpmEnvironment.php
@@ -1,0 +1,103 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Allows to get the content of a php-fpm environment configuration file
+ */
+class PhpFpmEnvironment {
+    /**
+     * The temporary directory, used in TMP, TEMP and TMPDIR environment variables
+     * @var string
+     */
+    const TMP = '/tmp';
+
+    /**
+     * The path where to find executables, where sbin should be excluded if you don't run PHP as root.
+     * @var string
+     */
+    const PATH = '/usr/local/bin:/usr/bin:/bin';
+
+    /**
+     * The environment variables to discard
+     * @var Array
+     */
+    const VARIABLES_TO_DISCARD = [
+        '_',           // The caller executable script, not pertinent
+        'HOME',        // Set correctly by php-fpm
+        'TERM',        // Not pertinent in server context
+        'MYSQL_ENV_MYSQL_ROOT_PASSWORD', // from --link …:mysql
+    ];
+
+    /**
+     * Gets an environment array from the current process environment,
+     * with PATH and temp variablesfiltered.
+     *
+     * @return Array
+     */
+    public static function getEnvironmentVariables () {
+        $variables = [];
+
+        foreach ($_ENV as $key => $value) {
+            if (!static::mustIgnoreVariable($key)) {
+	            $variables[$key] = $value;
+            }
+        }
+
+        static::addHardcodedEnvironmentVariables($variables);
+
+        return $variables;
+    }
+
+    /**
+     * Adds hardcoded and always wanted environment variables
+     * (path, temporary directory) to the specified array.
+     *
+     * @paran array $variables the array to add the variables to
+     */
+    public static function addHardcodedEnvironmentVariables (&$variables) {
+        static::addTempEnvironmentVariables ($variables);
+        static::addPathEnvironmentVariables ($variables);
+    }
+
+    /**
+     * Adds temporary directory environment variables to the specified array.
+     *
+     * @paran array $variables the array to add the variables to
+     */
+    public static function addTempEnvironmentVariables (&$variables) {
+        $variables['TMP'] = static::TMP;
+        $variables['TEMP'] = static::TMP;
+        $variables['TMPDIR'] = static::TMP;
+    }
+
+    /**
+     * Adds temporary directory environment variables to the specified array.
+     *
+     * @paran array $variables the array to add the variables to
+     */
+    public static function addPathEnvironmentVariables (&$variables) {
+        $variables['PATH'] = static::PATH;
+    }
+
+    /**
+     * Determines if the variable name must be ignored
+     *
+     * @return bool true if the variable must be ignored; otherwise, false.
+     */
+    public static function mustIgnoreVariable ($variableName) {
+        return in_array($variableName, static::VARIABLES_TO_DISCARD);
+    }
+
+    /**
+     * Prints the environment
+     */
+    public static function printConfig () {
+        $variables = static::getEnvironmentVariables();
+
+        foreach ($variables as $key => $value) {
+            echo 'env["', $key, '"] = "', $value, '"', PHP_EOL;
+        }
+    }
+}
+
+PhpFpmEnvironment::printConfig();

--- a/docker/assets/usr/local/sbin/php-fpm-env
+++ b/docker/assets/usr/local/sbin/php-fpm-env
@@ -1,0 +1,1 @@
+../lib/php-fpm-env/PhpFpmEnvironment.php

--- a/docker/assets/usr/local/sbin/runsvdir-init
+++ b/docker/assets/usr/local/sbin/runsvdir-init
@@ -1,0 +1,3 @@
+#!/bin/bash
+export > /usr/local/etc/envvars
+exec /usr/bin/runsvdir /etc/service


### PR DESCRIPTION
Added: Dockerfile  and releated files for a docker image for filesender installs with simplesamlphp.
Fixes: #929

This is an opinionated Docker image, using filesender, simplesamlphp and php-fpm. It makes some assumptions that work nicely in a Kubernetes world, and is based on the work of [ualibraries](https://github.com/ualibraries/filesender-phpfpm) with some influences of [bitnami](https://github.com/bitnami/) as well.

Configuration of this image is done by filling the various /config volumes with real-life configurations.

Feel free to contact me for questions, remarks, etc, or place comments in the PR.

