### PR TITLE
Docker CI workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,5 +19,5 @@ jobs:
           tag_with_ref: true
           tag_with_sha: true
           path: docker
-          build_args: BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%Sz'),VCS_REF=${GITHUB_SHA:8}
+          build_args: BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%Sz'),VCS_REF=${GITHUB_SHA:8},REF=${GITHUB_REF}
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,23 @@
+name: Build docker images
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    name: Build docker image and push it to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: filesender/filesender
+          tag_with_ref: true
+          tag_with_sha: true
+          path: docker
+          build_args: BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%Sz'),VCS_REF=${GITHUB_SHA:8}
+


### PR DESCRIPTION
Adds a CI workflow that runs upon release.
The workflow builds dockerimage defined in /docker/Dockerfile (such as the one in #955 ), and then uploads it to dockerhub

Credentials for dockerhub are assumed to be available as a secret in the organisation or the repository