### PR TITLE
bootstrap ui: safari pbkdf2 dialog race

### DIFF
--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -131,6 +131,10 @@ window.filesender.pbkdf2dialog = {
         window.filesender.log("BBB pbkdf2dialog onPBKDF2Over()");
         $this.already_complete = true;
         if( $this.dialog ) {
+            var d = $this.dialog;
+            window.setTimeout(function() {
+                filesender.ui.closeDialog( d );
+            }, 1000 );
             filesender.ui.closeDialog( $this.dialog );
             $this.dialog = null;
         }


### PR DESCRIPTION
This may manifest elsewhere but I have been able to trigger it more frequently in safari on m1 silicon. The pbkdf2 process on that device is fast which can lead to hashing completing at around the same time as the dialog appears. I have tried hooking into the onshown() for the dialog but it may be that safari just doesn't like the event ordering here. The dialog goes away if there is a 100 or 1000ms delay for the timer based closing.