### PR TITLE
bootstrap: a new method to clean up the get a slicer process

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -788,7 +788,21 @@ window.filesender.ui = {
     setDateFromEpochData: function( w ) {
         w.datepicker('setDate', new Date(w.attr('data-epoch') * 1000 ));
     },
-    
+
+    /**
+     * As there are some browser dependant nasties about getting a
+     * slicer this method was made to sweep that away and also keep it
+     * in a single place if it needs updating in the future.
+     *
+     * As of March 2021 code should migrate over to using this instead
+     * of directly doing the multiple tests.
+     * 
+     * @param file to get a slicer for
+     */
+    makeBlobSlicer: function( file ) {
+        var slicer = file.blob.slice ? 'slice' : (file.blob.mozSlice ? 'mozSlice' : (file.blob.webkitSlice ? 'webkitSlice' : 'slice'));
+        return slicer;
+    },
 };
 
 $(function() {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -208,7 +208,7 @@ filesender.ui.files = {
         return node;
     },
 
-    addFileTryToReadAByte: async function( cid) {
+    addFileTryToReadAByte: async function( cid ) {
 
         var idx = filesender.ui.transfer.fileCIDToIndex( cid );
         if( idx != -1 ) {
@@ -216,7 +216,7 @@ filesender.ui.files = {
         
             // try to read a byte
             if( file.size >= 1 ) {
-                var slicer = file.blob.slice ? 'slice' : (file.blob.mozSlice ? 'mozSlice' : (file.blob.webkitSlice ? 'webkitSlice' : 'slice'));
+                var slicer = filesender.ui.makeBlobSlicer( file );
                 
                 var newblob = file.blob[slicer](0,1);
                 try


### PR DESCRIPTION
I have not migrated code widely as yet to help merging this into the main tree at some stage.