### PR TITLE
bootstrap: improved handing of terasender_worker_count and its max setting

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -146,6 +146,7 @@ A note about colours;
 * [terasender_enabled](#terasender_enabled)
 * [terasender_advanced](#terasender_advanced)
 * [terasender_worker_count](#terasender_worker_count)
+* [terasender_worker_max_count](#terasender_worker_max_count)
 * [terasender_start_mode](#terasender_start_mode)
 * [terasender_worker_max_chunk_retries](#terasender_worker_max_chunk_retries)
 * [stalling_detection](#stalling_detection)
@@ -1419,6 +1420,15 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __available:__ since version 1.6
 * __1.x name:__ terasender_workerCount
 * __comment:__ <span style="background-color:orange">we need to check maximum webworker counts for standard browsers and possibly increase the default number</span>
+
+### terasender_worker_max_count
+
+* __description:__ Max value that terasender_worker_count can ever have if user set.
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 30
+* __available:__ since version 2.23
+* __comment:__ 
 
 ### terasender_start_mode
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -115,6 +115,7 @@ $default = array(
     'terasender_disableable' => true,
     'terasender_start_mode' => 'multiple',
     'terasender_worker_count' => 6,
+    'terasender_worker_max_count' => 30,
     'terasender_worker_max_chunk_retries' => 20,    
     'terasender_worker_xhr_timeout' => 3600000, // in ms, 1 hour for a chunk to complete by default.
     'terasender_worker_start_must_complete_within_ms' => 180000, // in ms, 3 minutes by default.

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -107,6 +107,7 @@ window.filesender.config = {
     terasender_enabled: <?php  echo value_to_TF(Config::get('terasender_enabled')) ?>,
     terasender_advanced: <?php echo value_to_TF(Config::get('terasender_advanced')) ?>,
     terasender_worker_count: <?php echo Config::get('terasender_worker_count') ?>,
+    terasender_worker_max_count: <?php echo Config::get('terasender_worker_max_count') ?>,
     terasender_start_mode: '<?php echo Config::get('terasender_start_mode') ?>',
     terasender_worker_file: 'js/terasender/terasender_worker.js',
     terasender_upload_endpoint: '<?php echo Config::get('site_url') ?>rest.php/file/{file_id}/chunk/{offset}',

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -558,9 +558,24 @@ window.filesender.terasender = {
         this.transfer = transfer;
 
         // Safety
+        if(isNaN(parseInt(filesender.config.terasender_worker_max_count))) {
+            // clamp the max to the default
+            filesender.config.terasender_worker_max_count = 30;
+        }
         var wcnt = parseInt(filesender.config.terasender_worker_count);
-        if(isNaN(wcnt) || wcnt < 1 || wcnt > 30)
+        if(isNaN(wcnt)) {
+            // Bad setting is set to something that will work
+            // ( 3 was the previous default in this case )
             wcnt = 3;
+        }
+        if( wcnt < 1 ) {
+            // too low is set to the min
+            wcnt = 1;
+        }
+        if( wcnt > filesender.config.terasender_worker_max_count ) {
+            // clamp this to the desired max_count
+            wcnt = filesender.config.terasender_worker_max_count;
+        }
         filesender.config.terasender_worker_count = wcnt;
         
         // Work out if we have less chunks to upload than the wcnt value.

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1213,11 +1213,15 @@ filesender.ui.startUpload = function() {
     var twc = $('#terasender_worker_count');
     if(twc.length) {
         twc = parseInt(twc.val());
-        if(!isNaN(twc) && twc > 0 && twc <= 30) {
-		if (this.transfer.encryption)
-			twc = Math.max(Math.round(twc/2),3);
-		filesender.config.terasender_worker_count = twc;
-	}
+        if(!isNaN(twc)) {
+            if( twc > filesender.config.terasender_worker_max_count ) {
+                // clamp to max value rather than ignore change
+                twc = filesender.config.terasender_worker_max_count;
+            }
+            if( twc > 0 && twc <= filesender.config.terasender_worker_max_count) {
+	        filesender.config.terasender_worker_count = twc;
+            }
+        }
     }
     
     filesender.ui.nodes.files.list.find('.file').addClass('uploading');


### PR DESCRIPTION
In particular there was a setting to `Math.max(Math.round(twc/2),3)` if encryption was enabled. I do not think this is still a valid thing to do with multi cpu core machines which may handle encrypting multiple chunks more readily than before. In any case these clamps should be done via configuration settings so they are no surprise to the system admin and an explicit policy choice.

There is a new `terasender_worker_max_count` config which sets the max for terasender workers explicitly (was always 30 but done in the code hard wired in places).
