### PR TITLE
bootstrap: default choice is more restrictive, this is closer to current dev

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -62,9 +62,10 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 }
 
 if(Auth::isGuest()) {
+    $show_get_a_link_or_email_choice = false;
+    
     if($guest->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME)) {
         $guest_can_only_send_to_creator = true;
-        $show_get_a_link_or_email_choice = false;
     }
 }
 


### PR DESCRIPTION
Trying to loosen these restrictions bumps up against some other assumptions in the code. This should be closer to the current release where the person inviting the guest can choose one of
```
only send to me
must get a link
must send to emails
```
and the later two can not be changed by the guest.
