### PR TITLE
bootstrap: skip stage2 for a transfer created with re-add

### DIFF
--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -176,13 +176,12 @@ class StorageFilesystem
                 $filesystems[$filesystem]['free_space'] -= $remaining_to_upload;
             }
         }
-        
         // Check if there is enough remaining space
         foreach ($filesystems as $filesystem => $info) {
             $required_space = array_sum(array_map(function ($file) {
                 return $file->size;
             }, $info['files']));
-            
+
             if ($required_space > $info['free_space']) {
                 return false;
             }

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -399,7 +399,7 @@ $displayoption = function($name, $cfg, $disable = false, $forcedOption = false) 
                     </td>
                 </tr>
 <?php if($show_get_a_link_or_email_choice) { ?>
-                <tr>
+                <tr id="get_a_link_or_email_choice">
                     <td colspan="2">
                         <h4>
                             <a               class="galmodelink  btn btn-primary">{tr:ui2_mode_link}</a>

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -65,6 +65,7 @@ function delayAndCallOnlyOnce(callback, ms) {
 }
 
 filesender.ui.stage = 1;
+filesender.ui.reuploading = false;
 
 jQuery.fn.extend({
     disable: function(state) {
@@ -1413,6 +1414,7 @@ $(function() {
             checkbox: form.find('input[name="get_a_link"]'),
             checkboxcontainer: form.find('.custom-control[data-option="get_a_link"]'),
         },
+        get_a_link_or_email_choice: form.find('#get_a_link_or_email_choice'),
         recipients: {
             input: form.find('input[name="to"]'),
             list: form.find('.recipients'),
@@ -1495,6 +1497,14 @@ $(function() {
 
     // move to stage2
     filesender.ui.nodes.stages.continue1.on('click',function() {
+
+        // The user can not change options for the transfer when they are
+        // sending the remains of the files to complete the upload.
+        if( filesender.ui.reuploading ) {
+            filesender.ui.nodes.stages.continue2.click();
+            return;
+        }
+        
         filesender.ui.stage = 2;
         filesender.ui.nodes.stage1hide.hide();
         filesender.ui.nodes.stage3hide.hide();
@@ -1542,9 +1552,11 @@ $(function() {
         if( filesender.ui.lasthash == "#uploading" && window.location.hash == "#uploading" ) {
             // ignore this case which is generated from the below reset.
         } else {
-            if( filesender.ui.lasthash == "#uploading" ) {
-                filesender.ui.nodes.buttons.stop.click();
-                window.location.hash = "#uploading";
+            if( !filesender.ui.reuploading ) {
+                if( filesender.ui.lasthash == "#uploading" ) {
+                    filesender.ui.nodes.buttons.stop.click();
+                    window.location.hash = "#uploading";
+                }
             }
         }
         filesender.ui.lasthash = document.location.hash;
@@ -2109,9 +2121,10 @@ $(function() {
                 $('#terasender_worker_count').prop('disabled', false);
                 filesender.ui.nodes.files.input.prop('disabled', false);
                 
-                // Setup restart button
-                filesender.ui.nodes.buttons.start.addClass('not_displayed');
-                filesender.ui.nodes.buttons.restart.removeClass('not_displayed');
+                // We do not show the stage2 page in this case as the options can
+                // not be changed for the transfer once it is created.
+                filesender.ui.nodes.stages.continue1.html( filesender.ui.nodes.stages.continue2.html() );
+                filesender.ui.reuploading = true;
             };
             
             var forget = function() {


### PR DESCRIPTION
When you are prompted about a previous failed transfer and elect to load the transfer to complete it you are not able to change any of the transfer options. Instead of showing the second page with options that are not able to be changed I think it makes more sense to just skip stage2 and start sending the files right from stage1.
