### PR TITLE
bootstrap: show the download link when re-adding files and gal

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -619,7 +619,7 @@ window.filesender.transfer = function() {
             files: [],
             file_index: 0,
             guest_token: null,
-            download_link: null,
+            download_link: this.download_link,
             roundtriptoken: this.roundtriptoken
         };
         
@@ -700,6 +700,7 @@ window.filesender.transfer = function() {
             case 'files': break;
             default: this[prop] = tracker[prop];
         }
+        this.download_link = tracker.download_link;
         
         this.failed_transfer_restart = true;
         

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -489,7 +489,7 @@ filesender.ui.files = {
     },
     
     update_crust_meter: function( file ) {
-        window.filesender.log("AAAAAAAAAAA update_crust_meter(top) status " +  filesender.ui.transfer.status );
+//        window.filesender.log("AAAAAAAAAAA update_crust_meter(top) status " +  filesender.ui.transfer.status );
         if (!filesender.config.upload_display_per_file_stats) {
             return;
         }
@@ -530,7 +530,7 @@ filesender.ui.files = {
             if( i < offending.length ) {
                 b = offending[i];
             }
-            console.log("AAAAAAA file " + file + " i " + i + " v " + v + " b " + b );
+//            console.log("AAAAAAA file " + file + " i " + i + " v " + v + " b " + b );
             filesender.ui.files.update_crust_meter_for_worker( file, i, v, b );
 
             // calculate stats across all workers
@@ -588,8 +588,8 @@ filesender.ui.files = {
         filesender.ui.nodes.stats.number_of_files.hide().find('.value').text('');
         filesender.ui.nodes.stats.size.hide().find('.value').text('');
 
-        filesender.ui.nodes.stats.filecount.text('AAA');
-        filesender.ui.nodes.stats.sendingsize.text('BBB');
+        filesender.ui.nodes.stats.filecount.text('');
+        filesender.ui.nodes.stats.sendingsize.text('');
         console.log(filesender.ui.nodes.stats.filecount);
         filesender.ui.evalUploadEnabled();
         this.updateStatsAndClearAll();


### PR DESCRIPTION
Scenario:
* start an upload with get a link = true and then navigate away from the page.
* go back to upload page and see the dialog mentioning the previous failed upload
* elect to continue the upload
* re-add the files again
* click send and finish the transfer
* Previously the link was not shown on the completion dialog. 

This is a bug which is also present in the current release of filesender.