### PR TITLE
bootstrap: if get a link is not to be available then hide the choice

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -59,7 +59,19 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
     
     if($name == TransferOptions::GET_A_LINK)
         $allow_recipients = false;
+
 }
+
+// If get a link is not available to the user then
+// there is no real point showing the big choice to the
+// user at the top of the page.
+foreach(Transfer::allOptions() as $name => $dfn)  {
+    if($dfn['available']) continue;
+    if($name == TransferOptions::GET_A_LINK) {
+        $show_get_a_link_or_email_choice = false;
+    }
+}
+
 
 if(Auth::isGuest()) {
     $show_get_a_link_or_email_choice = false;


### PR DESCRIPTION
This is to handle the case where an admin has set get_a_link to not available (ie, they wish to force a choice for the user). In this case the default of true or false will select what elements are shown in stage2 but the choice of (get a link or send by email) is not presented to the user. It is as if there is only one choice. It doesn't seem to add value to show the choice if the user is unable to make it.

```
$config['transfer_options'] = array(
...
        'get_a_link' => array(
            'available' => false,
            'advanced' => false,
            'default' => true
	),
...
);
```