### PR TITLE
admin: allow guest expires to be extended

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -110,7 +110,12 @@ class Guest extends DBObject
         'last_reminder' => array(
             'type' => 'datetime',
             'null' => true
-        )
+        ),
+        'expiry_extensions' => array(
+            'type' => 'uint',
+            'size' => 'small',
+            'default' => 0
+        ),
     );
 
     public static function getViewMap()
@@ -128,6 +133,11 @@ class Guest extends DBObject
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a );
     }
+
+    /**
+     * Config variables
+     */
+    const OBJECT_EXPIRY_DATE_EXTENSION_CONFIGKEY = "allow_guest_expiry_date_extension";
 
     /**
      * Set selectors
@@ -160,6 +170,7 @@ class Guest extends DBObject
     protected $last_activity = 0;
     protected $reminder_count = 0;
     protected $last_reminder = 0;
+    protected $expiry_extensions = 0;
 
     /**
      * Cache
@@ -661,6 +672,7 @@ class Guest extends DBObject
         if (in_array($property, array(
             'id', 'user_email', 'token', 'email', 'transfer_count',
             'subject', 'message', 'options', 'transfer_options', 'status', 'created', 'expires', 'last_activity', 'userid'
+            , 'expiry_extensions'
         ))) {
             return $this->$property;
         }
@@ -713,6 +725,10 @@ class Guest extends DBObject
             return $identity[0];
         }
 
+        if ($property == 'expiry_date_extension') {
+            return $this->getObjectExpiryDateExtension(false);
+        } // No throw
+        
         //
         // Simple access to $this->options 
         //

--- a/classes/exceptions/GuestExceptions.class.php
+++ b/classes/exceptions/GuestExceptions.class.php
@@ -157,3 +157,35 @@ class GuestExpiredException extends GuestException
         parent::__construct($guest, 'expired');
     }
 }
+
+/**
+ * Expiry extension not allowed
+ */
+class GuestExpiryExtensionNotAllowedException extends GuestException
+{
+    /**
+     * Constructor
+     *
+     * @param Transfer $transfer
+     */
+    public function __construct($transfer)
+    {
+        parent::__construct($transfer, 'expiry_extension_not_allowed');
+    }
+}
+
+/**
+ * Expiry extension count exceeded
+ */
+class GuestExpiryExtensionCountExceededException extends GuestException
+{
+    /**
+     * Constructor
+     *
+     * @param Transfer $transfer
+     */
+    public function __construct($transfer)
+    {
+        parent::__construct($transfer, 'expiry_extension_count_exceeded');
+    }
+}

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -63,6 +63,7 @@ class RestEndpointGuest extends RestEndpoint
             'created' => RestUtilities::formatDate($guest->created),
             'expires' => RestUtilities::formatDate($guest->expires),
             'upload_url' => $guest->upload_link,
+            'expiry_date_extension' => $guest->expiry_date_extension,
             'errors' => array_values(array_map(function ($error) {
                 return array(
                     'type' => $error->type,
@@ -305,6 +306,16 @@ class RestEndpointGuest extends RestEndpoint
         if ($data->remind) {
             $guest->remind();
         }
+
+        // Need to extend expiry date
+        if ($data->extend_expiry_date) {
+            if( !Auth::isAdmin()) {
+                throw new RestAdminRequiredException();
+            }
+            $guest->extendObjectExpiryDate();
+            return self::cast($guest);
+        }
+        
         
         return true;
     }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -171,6 +171,8 @@ A note about colours;
 * [user_can_only_view_guest_transfers_shared_with_them](#user_can_only_view_guest_transfers_shared_with_them)
 * [guest_create_limit_per_day](#guest_create_limit_per_day)
 * [guest_reminder_limit_per_day](#guest_reminder_limit_per_day)
+* [allow_guest_expiry_date_extension](#allow_guest_expiry_date_extension)
+* [allow_guest_expiry_date_extension_admin](#allow_guest_expiry_date_extension_admin)
 
 ## Authentication
 
@@ -1655,6 +1657,31 @@ This is only for old, existing transfers which have no roundtriptoken set.
   If the user tries to send a reminder to a specific guest more than this number of times a day then
   the action will be denied and logged. Note that this is an inclusive value, for example, a setting of 5
   will allow 5 reminders to be sent to a guest but not 6.
+
+
+### allow_guest_expiry_date_extension
+
+* __description:__ This is an untested matching config option to allow_guest_expiry_date_extension_admin. It is best to reserve this config keyword now to allow future versions to allow some users to extend their guests if desired. Extending guest expire time is only available via the admin page as at release 2.23.
+* __mandatory:__
+* __type:__ an array of integers containing possible extensions in days.
+* __default:__ - (= not activated)
+* __available:__ since version 2.23
+* __1.x name:__
+* __comment:__
+* __Examples:__
+
+
+### allow_guest_expiry_date_extension_admin
+
+* __description:__ allows an admin to extend the expiry date of a guest. This is only used if you are logged in as an admin on the system. If you are an admin this schedule will overwrite the allow_guest_expiry_date_extension for you. 
+* __mandatory:__
+* __type:__ an array of integers containing possible extensions in days.
+* __default:__ array(31, true)
+* __available:__ since version 2.23
+* __Examples:__
+
+        // Allows infinite extensions, the first is by 30 days then 90 days 
+	$config['allow_guest_expiry_date_extension_admin'] = array(30, 90, true); 
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -276,6 +276,9 @@ $default = array(
 
     'data_protection_user_frequent_email_address_disabled' => false,
     'data_protection_user_transfer_preferences_disabled' => false,
+
+    'allow_guest_expiry_date_extension' => 0,
+    'allow_guest_expiry_date_extension_admin' => array(31, true),
     
     
     'transfer_options' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -628,3 +628,8 @@ $lang['file_encryption_password_must_have_numbers'] = 'Password must contain at 
 $lang['file_encryption_password_must_have_upper_and_lower_case'] = 'Password must contain UPPER and lower case characters';
 $lang['file_encryption_password_must_have_special_characters'] = 'Password must contain at least one special character such as !@#$%^&*()<>';
 $lang['transfer_must_be_encrypted'] = 'This transfer must be encrypted';
+
+$lang['expiry_extension_count_exceeded'] = 'Expiry date extension maximum reached';
+$lang['expiry_extension_not_allowed'] = 'Expiry date extension is not allowed';
+$lang['extended'] = 'Expiry date extended until {expires}';
+$lang['extended_reminded'] = 'Expiry date extended until {expires}, a reminder was sent to recipients';

--- a/templates/guests_table.php
+++ b/templates/guests_table.php
@@ -19,7 +19,10 @@
     
     </tbody>
         <?php foreach($guests as $guest) { ?>
-        <tr class="guest" data-id="<?php echo $guest->id ?>" data-errors="<?php echo count($guest->errors) ? '1' : '' ?>">
+            <tr class="guest objectholder"
+                data-id="<?php echo $guest->id ?>" 
+                data-expiry-extension="<?php echo $guest->expiry_date_extension ?>"
+                data-errors="<?php echo count($guest->errors) ? '1' : '' ?>">
             <td class="to">
                 <a href="mailto:<?php echo Template::sanitizeOutputEmail($guest->email) ?>"><?php echo Template::sanitizeOutputEmail($guest->email) ?></a>
                 
@@ -48,7 +51,9 @@
             
             <td class="created"><?php echo Utilities::formatDate($guest->created) ?></td>
             
-            <td class="expires"><?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires) ?></td>
+            <td class="expires" data-rel="expires">
+                <?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires) ?>
+            </td>
             
             <td class="actions"></td>
         </tr>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -191,7 +191,7 @@ if (!function_exists('clickableHeader')) {
     
     <tbody>
         <?php foreach($transfers as $transfer) { ?>
-        <tr class="transfer" id="transfer_<?php echo $transfer->id ?>"
+        <tr class="transfer objectholder" id="transfer_<?php echo $transfer->id ?>"
             data-id="<?php echo $transfer->id ?>"
             data-recipients-enabled="<?php echo $transfer->getOption(TransferOptions::GET_A_LINK) ? '' : '1' ?>"
             data-errors="<?php echo count($transfer->recipients_with_error) ? '1' : '' ?>"

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -525,6 +525,15 @@ window.filesender.client = {
         
         return this.put('/transfer/' + id, data, callback);
     },
+
+    extendObject: function(className, id, remind, callback) {
+        var data = {extend_expiry_date: true};
+        if(remind) data.remind = true;
+        return this.put('/' + className + '/' + id, data, callback);
+    },
+    extendGuest: function( id, remind, callback ) {
+        return this.extendObject('guest',id,remind, callback);
+    },
     
     /**
      * Close a transfer

--- a/www/js/guests_table.js
+++ b/www/js/guests_table.js
@@ -62,6 +62,21 @@ $(function() {
                     });
                 });
             });
+
+            if(table.is('[data-mode="admin"]')) {
+                var days = $(this).closest('.objectholder').attr('data-expiry-extension');
+                if( days > 0 ) {
+                    var extend = $('<span data-action="extendexpires" class="extend adminaction clickable fa fa-lg fa-clock-o" />');
+                    extend.appendTo(td).attr({
+                        title: lang.tr('extend_expiry_date').r({
+                            days: $(this).closest('.objectholder').attr('data-expiry-extension')
+                        })
+                        
+                    }).on('click', function() {
+                        filesender.ui.extendExpires( extend, 'guest' );
+                    });
+                }
+            }
             
             if(table.is('[data-mode="user"]')) {
                 // Send reminder button

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -552,6 +552,57 @@ window.filesender.ui = {
     setDateFromEpochData: function( w ) {
         w.datepicker('setDate', new Date(w.attr('data-epoch') * 1000 ));
     },
+
+
+    extendExpires: function(self,className)
+    {
+        if(self.hasClass('disabled')) return;
+        
+        var t = self.closest('.objectholder');
+        var id = t.attr('data-id');
+        if(!id || isNaN(id)) return;
+        
+        var duration = parseInt(t.attr('data-expiry-extension'));
+        
+        var extend = function(remind) {
+            filesender.client.extendObject(className,id, remind, function(t) {
+                $('.objectholder[data-id="' + id + '"]').attr('data-expiry-extension', t.expiry_date_extension);
+                if( !t.expiry_date_extension ) {
+                    self.addClass('disabled');
+                }
+                $('.objectholder[data-id="' + id + '"] [data-rel="expires"]').text(t.expires.formatted);
+                
+                if(!t.expiry_date_extension) {
+                    $('.objectholder[data-id="' + id + '"] [data-action="extend"]').addClass('disabled').attr({
+                        title: lang.tr('expiry_extension_count_exceeded')
+                    });
+                    
+                } else {
+                    $('.objectholder[data-id="' + id + '"] [data-action="extend"]').attr({
+                        title: lang.tr('extend_expiry_date').r({
+                            days: self.closest('.objectholder').attr('data-expiry-extension')
+                        })
+                    });
+                }
+                
+                filesender.ui.notify('success', lang.tr(remind ? 'extended_reminded' : 'extended').r({expires: t.expires.formatted}));
+            });
+        };
+        
+        var buttons = {};
+        
+        buttons.extend = function() {
+            extend(false);
+        };
+        
+        if(t.attr('data-recipients-enabled')) buttons.extend_and_remind = function() {
+            extend(true);
+        };
+        
+        buttons.cancel = false;
+        
+        filesender.ui.popup(lang.tr('confirm_dialog'), buttons).html(lang.tr('confirm_extend_expiry').r({days: duration}).out());
+    },
     
 };
 


### PR DESCRIPTION
This abstracts some of the "expires" functionality from transfers to dbobject on the server side and filesender.ui on the client side. The new abstracted code is used to allow the admin/guests page to extend the expire time for a guest. This relates to https://github.com/filesender/filesender/issues/966.
