### PR TITLE
admin: allow a guest expires time to be set on a per user basis

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -110,6 +110,12 @@ class User extends DBObject
             'size' => 'big',
             'null' => true
         ),
+        'guest_expiry_default_days' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'null' => true,
+            'default' => null
+        ),
     );
 
 
@@ -153,6 +159,7 @@ class User extends DBObject
     protected $auth_secret = null;
     protected $auth_secret_created = null;
     protected $quota = 0;
+    protected $guest_expiry_default_days = null;
 
     private $eventcount = 0;
     
@@ -627,6 +634,7 @@ class User extends DBObject
             'auth_secret_created',
             'transfer_preferences', 'guest_preferences', 'frequent_recipients', 'created', 'last_activity',
             'email_addresses', 'name', 'quota', 'authid'
+          , 'guest_expiry_default_days'
         ))) {
             return $this->$property;
         }
@@ -708,6 +716,11 @@ class User extends DBObject
             $this->quota = (int)$value;
         } elseif ($property == 'eventcount') {
             $this->eventcount = (int)$value;
+        } elseif ($property == 'guest_expiry_default_days') {
+            $this->guest_expiry_default_days = (int)$value;
+            if( $this->guest_expiry_default_days == 0 ) {
+                $this->guest_expiry_default_days = null;
+            }
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -245,12 +245,17 @@ class RestEndpointGuest extends RestEndpoint
         $guest->transfer_options = $transfer_options;
         
         // Set expiry date
-        $expires = $data->expires ? $data->expires : Guest::getDefaultExpire();
+        $expires = $guest->getDefaultExpire();
+        if( $data->expires ) {
+            $expires = max( $expires, $data->expires );
+        }
         $guest->expires = $expires;
-        
+
         if($guest->does_not_expire) {
             $guest->expires = null;
         }
+
+
         
         // Make guest available, this saves the object and send email to the guest
         $guest->makeAvailable();

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -334,10 +334,6 @@ class RestEndpointUser extends RestEndpoint
             $user->transfer_preferences = null;
             $user->save();
         }
-        if( $data->clear_user_transfer_preferences ) {
-            $user->transfer_preferences = null;
-            $user->save();
-        }
         if( $data->exists('guest_expiry_default_days')) {
             if (!Auth::isAdmin()) {
                 throw new RestAdminRequiredException();

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -334,7 +334,18 @@ class RestEndpointUser extends RestEndpoint
             $user->transfer_preferences = null;
             $user->save();
         }
-        
+        if( $data->clear_user_transfer_preferences ) {
+            $user->transfer_preferences = null;
+            $user->save();
+        }
+        if( $data->exists('guest_expiry_default_days')) {
+            if (!Auth::isAdmin()) {
+                throw new RestAdminRequiredException();
+            }
+            $user->guest_expiry_default_days = $data->guest_expiry_default_days;
+            $user->save();
+            
+        }
         return true;
     }
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -633,3 +633,6 @@ $lang['expiry_extension_count_exceeded'] = 'Expiry date extension maximum reache
 $lang['expiry_extension_not_allowed'] = 'Expiry date extension is not allowed';
 $lang['extended'] = 'Expiry date extended until {expires}';
 $lang['extended_reminded'] = 'Expiry date extended until {expires}, a reminder was sent to recipients';
+$lang['set_default_guest_expire_days'] = 'Overwrite guest expire days';
+$lang['reset_per_user_guest_expire_setting'] = 'Set to 0 to disable any specific setting for this User.';
+$lang['set_user_guest_expiry_default_days'] = 'how many days new guests are live for this user';

--- a/templates/admin_users_section.php
+++ b/templates/admin_users_section.php
@@ -109,6 +109,7 @@
 <?php if( Config::get('using_local_saml_dbauth')) : ?>
             <input type="button" data-action="set-local-authdb-password" value="{tr:change_password}" />
 <?php endif; ?>
+            <input type="button" data-action="set-default-guest-expires" value="{tr:set_default_guest_expire_days}" />
         </td>
     </tr>
 </table>

--- a/www/js/admin_users.js
+++ b/www/js/admin_users.js
@@ -109,6 +109,13 @@ $(function() {
 
             filesender.client.changeLocalAuthDBPassword( saml_id );
         });
+        u.find('[data-action="set-default-guest-expires"]').on('click', function() {
+            var id = $(this).closest('.user').attr('data-id');
+            filesender.client.setUserSpecificExpireDaysForNewGuesst(
+                id, function() {
+                    filesender.ui.notify('success', lang.tr('preferences_updated'));
+                });
+        });
     };
 
     section.find('[data-action="all-delete-api-secret"]').on('click', function() {

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -797,4 +797,23 @@ window.filesender.client = {
         return this.put('/transfer/' + id, {'optionremove':true, option: tropt}, callback);
     },
 
+
+    setUserSpecificExpireDaysForNewGuesst: function(id,callback) {
+
+        var $this = this;
+        var prompt = window.filesender.ui.prompt(
+            lang.tr('set_user_guest_expiry_default_days'),
+            function (obj) {
+                var expires = $(this).find('input').val();
+
+                var data = {guest_expiry_default_days: expires};
+                return $this.put('/user/' + id, data, callback);
+            });
+        
+        // Add a field to the prompt
+        var input = $('<input type="text" class="wide" />').appendTo(prompt);
+        $('<p>' + lang.tr('reset_per_user_guest_expire_setting') + '</p>').appendTo(prompt);
+        input.focus();
+    },
+    
 };


### PR DESCRIPTION
A new button is now available in admin/users when you search for a user by user ID. This button allows you to overwrite the guest expire days for newly created guests for specific users. The same button can also be used (as described in the dialog) to set 0 to remove the setting for the guest.

When I user has a higher default guest expire days then new guests that they create will have an expire time different to the system default. This allows specific privileged users to be able to make guests that last longer than the system normally allows.

This relates to https://github.com/filesender/filesender/issues/966.
