### PR TITLE
move transfers to use the new shared code for expire updates

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -252,6 +252,11 @@ class Transfer extends DBObject
     );
 
     /**
+     * Config variables
+     */
+    const OBJECT_EXPIRY_DATE_EXTENSION_CONFIGKEY = "allow_transfer_expiry_date_extension";
+    
+    /**
      * Set selectors
      */
     const UPLOADING = "status = 'uploading' ORDER BY created DESC";
@@ -1054,7 +1059,7 @@ class Transfer extends DBObject
         }
         
         if ($property == 'expiry_date_extension') {
-            return $this->expiryDateExtension(false);
+            return $this->getObjectExpiryDateExtension(false);
         } // No throw
         
         if ($property == 'made_available_time') {
@@ -1619,82 +1624,6 @@ class Transfer extends DBObject
         Logger::info($this.' upload started');
     }
     
-    /**
-     * Check if transfer expiry date can be extended
-     *
-     * @param bool $throw throw on error
-     *
-     * @return int number of days the transfer expiry date can be extended by
-     *
-     * @throws TransferExpiryExtensionNotAllowedException
-     * @throws TransferExpiryExtensionCountExceededException
-     */
-    public function expiryDateExtension($throw = true)
-    {
-        $pattern = null;
-        
-        if( Auth::isAdmin()) {
-            $pattern = Config::get('allow_transfer_expiry_date_extension_admin');
-        }
-        if( !$pattern ) {
-            $pattern = Config::get('allow_transfer_expiry_date_extension');
-        }
-        
-        if (!$pattern) {
-            if ($throw) {
-                throw new TransferExpiryExtensionNotAllowedException($this);
-            }
-            return 0;
-        }
-        
-        if (!is_array($pattern)) {
-            $pattern = array($pattern);
-        }
-
-        // Get nth
-        $index = (int)$this->expiry_extensions;
-        
-        if ($index < count($pattern) && (!is_bool($pattern[$index]))) {
-            $duration = (int)$pattern[$index];
-        } else {
-            $last = array_pop($pattern);
-            
-            if (count($pattern) && is_bool($last) && $last) {
-                $duration = array_pop($pattern);
-            } else {
-                if ($throw) {
-                    throw new TransferExpiryExtensionCountExceededException($this);
-                }
-                return 0;
-            }
-        }
-        
-        if ((count($pattern) == 2) && is_bool($pattern[0]) && $pattern[0]) { // Infinite
-            return (int)$pattern[1];
-        }
-            
-        return $duration;
-    }
-    
-    /**
-     * Extend transfer expiry date (if enabled)
-     *
-     * @throws TransferExpiryExtensionNotAllowedException
-     */
-    public function extendExpiryDate()
-    {
-        $duration = $this->expiryDateExtension(); // throws
-        
-        if (!$duration) { // Should not happend unless config is garbled
-            throw new TransferExpiryExtensionNotAllowedException($this);
-        }
-        
-        $this->expires += $duration * 24 * 3600;
-        
-        $this->expiry_extensions++;
-        
-        $this->save();
-    }
     
     /**
      * Send message to recipient, handling options

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -816,7 +816,7 @@ class RestEndpointTransfer extends RestEndpoint
             
             // Need to extend expiry date
             if ($data->extend_expiry_date) {
-                $transfer->extendExpiryDate();
+                $transfer->extendObjectExpiryDate();
             }
             
             // Need to remind the transfer's availability to its recipients ?

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -283,7 +283,7 @@ if (!function_exists('clickableHeader')) {
             </td>
         </tr>
         
-        <tr class="transfer_details" data-id="<?php echo $transfer->id ?>">
+        <tr class="transfer_details objectholder" data-id="<?php echo $transfer->id ?>">
             <td colspan="8">
                 <div class="actions">
                     <div style="margin:3px">

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -129,54 +129,6 @@ $(function() {
     });
 
 
-    var extendExpires = function( self )
-    {
-        if(self.hasClass('disabled')) return;
-        
-        var t = self.closest('[data-transfer]');
-        
-        var id = t.attr('data-id');
-        if(!id || isNaN(id)) return;
-        
-        var duration = parseInt(t.attr('data-expiry-extension'));
-        
-        var extend = function(remind) {
-            filesender.client.extendTransfer(id, remind, function(t) {
-                $('[data-transfer][data-id="' + id + '"]').attr('data-expiry-extension', t.expiry_date_extension);
-                
-                $('[data-transfer][data-id="' + id + '"] [data-rel="expires"]').text(t.expires.formatted);
-                
-                if(!t.expiry_date_extension) {
-                    $('[data-transfer][data-id="' + id + '"] [data-action="extend"]').addClass('disabled').attr({
-                        title: lang.tr('transfer_expiry_extension_count_exceeded')
-                    });
-                    
-                } else {
-                    $('[data-transfer][data-id="' + id + '"] [data-action="extend"]').attr({
-                        title: lang.tr('extend_expiry_date').r({
-                            days: self.closest('[data-transfer]').attr('data-expiry-extension')
-                        })
-                    });
-                }
-                
-                filesender.ui.notify('success', lang.tr(remind ? 'transfer_extended_reminded' : 'transfer_extended').r({expires: t.expires.formatted}));
-            });
-        };
-        
-        var buttons = {};
-        
-        buttons.extend = function() {
-            extend(false);
-        };
-        
-        if(t.attr('data-recipients-enabled')) buttons.extend_and_remind = function() {
-            extend(true);
-        };
-        
-        buttons.cancel = false;
-        
-        filesender.ui.popup(lang.tr('confirm_dialog'), buttons).html(lang.tr('confirm_extend_expiry').r({days: duration}).out());
-    }
     
     // Extend buttons
     $('[data-expiry-extension="0"] [data-action="extend"]').addClass('disabled').attr({title: lang.tr('transfer_expiry_extension_count_exceeded')});
@@ -188,7 +140,7 @@ $(function() {
             })
         });
     }).on('click', function() {
-        extendExpires( $(this) );
+        filesender.ui.extendExpires( $(this), 'transfer');
     });
 
     $('[data-expiry-extension][data-expiry-extension!="-1"] [data-action="extendexpires"]').each(function() {
@@ -198,7 +150,7 @@ $(function() {
             })
         });
     }).on('click', function() {
-        extendExpires( $(this) );
+        filesender.ui.extendExpires( $(this), 'transfer');
     });
     
 


### PR DESCRIPTION
Now that there is a common use version of this code in DBObject and ui.js the old version of this code should really be removed from use in Transfer management. This has both Guest and Transfer use the same new code that is based on and extended from the old code. Having two code paths around is a bad idea for maintenance.