### PR TITLE
core: encryption: do not base64 encrypted data during upload

### DIFF
--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -392,8 +392,11 @@ class RestEndpointFile extends RestEndpoint
             }
 
             if ($file->transfer->options['encryption']) {
+
                 // get rid of the base64
-                $data = base64_decode($data);
+                if(Utilities::isTrue(Config::get('encryption_encode_encrypted_chunks_in_base64_during_upload'))) {
+                    $data = base64_decode($data);
+                }
                 // Calculate the correct length
                 $chunkLength = strlen($data);
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -128,6 +128,7 @@ A note about colours;
 * [encryption_key_version_new_files](#encryption_key_version_new_files)
 * [encryption_random_password_version_new_files](#encryption_random_password_version_new_files)
 * [encryption_password_hash_iterations_new_files](#encryption_password_hash_iterations_new_files)
+* [encryption_encode_encrypted_chunks_in_base64_during_upload](#encryption_encode_encrypted_chunks_in_base64_during_upload)
 * [automatic_resume_number_of_retries](#automatic_resume_number_of_retries)
 * [automatic_resume_delay_to_resume](#automatic_resume_delay_to_resume)
 * [transfer_options_not_available_to_export_to_client](#transfer_options_not_available_to_export_to_client)
@@ -1252,6 +1253,15 @@ these iteration counts take to perform on your local machine.
 * __available:__ since version 2.9
 * __comment:__
 
+
+
+### encryption_encode_encrypted_chunks_in_base64_during_upload
+* __description:__ This allows fallback to the older base64 PUT that was used in version 2.22. The encoding is quite costly and if there are no issues this parameter together with the fallback to using base64 on the PUT contents will be removed in a future version. 
+* __mandatory:__ no 
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.23
+* __comment:__ This is to allow fallbacks to older code. The default should be left unless you experience issues. If this fallback is not needed it will be removed in a future release and the __default__ will become the only choice in the code.
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -104,6 +104,8 @@ $default = array(
     'encryption_password_must_have_special_characters' => false,
     'encryption_generated_password_length' => 30,
     'encryption_generated_password_encoding' => 'base64',
+    'encryption_encode_encrypted_chunks_in_base64_during_upload' => false,
+    
     'upload_crypted_chunk_padding_size' => 16 + 16, // CONST the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'upload_crypted_chunk_size' => 5 * 1024 * 1024 + 16 + 16, // the 2 times 16 are the padding added by the crypto algorithm, and the IV needed
     'crypto_iv_len' => 16, // i dont think this will ever change, but lets just leave it as a config

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -93,6 +93,7 @@ window.filesender.config = {
     encryption_key_version_new_files: '<?php echo Config::get('encryption_key_version_new_files') ?>',
     encryption_random_password_version_new_files: '<?php echo Config::get('encryption_random_password_version_new_files') ?>',
     encryption_password_hash_iterations_new_files: '<?php echo Config::get('encryption_password_hash_iterations_new_files') ?>',
+    encryption_encode_encrypted_chunks_in_base64_during_upload: <?php  echo value_to_TF(Config::get('encryption_encode_encrypted_chunks_in_base64_during_upload')) ?>,
     crypto_gcm_max_file_size: '<?php echo Config::get('crypto_gcm_max_file_size') ?>',
     crypto_gcm_max_chunk_size: '<?php echo Config::get('crypto_gcm_max_chunk_size') ?>',
     crypto_gcm_max_chunk_count: '<?php echo Config::get('crypto_gcm_max_chunk_count') ?>',

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -572,14 +572,16 @@ window.filesender.crypto_app = function () {
                         
                             var joinedData = window.filesender.crypto_common().joinIvAndData(iv, new Uint8Array(result));
 
-                        // this is the base64 variant. this will result in a larger string to send
-                            var btoaData = btoa(
-                                // This string contains all kind of weird characters
-                                window.filesender.crypto_common().convertArrayBufferViewtoString(
+                            var btoaData = joinedData;
+                            if( window.filesender.config.encryption_encode_encrypted_chunks_in_base64_during_upload ) {
+                                // this is the base64 variant. this will result in a larger string to send
+                                btoaData = btoa(
+                                    // This string contains all kind of weird characters
+                                    window.filesender.crypto_common().convertArrayBufferViewtoString(
                                         joinedData
                                     )
-                            );
-
+                                );
+                            }
                             callback(btoaData);
                         },
                     function (e) {

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -176,7 +176,7 @@ var terasender_worker = {
         xhr.setRequestHeader('csrfptoken', this.csrfptoken);
         
         try {
-            
+
 	    if (job.encryption) { //MD
 			var cryptedBlob = null;
 			var $this = this;


### PR DESCRIPTION
This is a huge bottleneck. Some empirical data to show just how large the impact is. The upload speed would ramp up slowly during an encrypted upload on a local connection and for large files (4gb) might get to 85mb/s at the end. Without the base64 encoding and decoding the speed goes over 200mb/s on upload. I am running with 12 terasender workers and 4mb chunk size for these numbers.

I have made a temporary config setting to allow enabling base64 for both local speed testing but mainly for backward compatibility if there are issues discovered in some installations and we need to support base64 on the PUT contents for some reason.
