### PR TITLE
Update to user_can_only_view_guest_transfers_shared_with_them for wider scope

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -683,6 +683,16 @@ class Transfer extends DBObject
         
         Logger::info($this.' deleted');
     }
+
+    public function userCanSeeTransfer()
+    {
+        if( !$this->guest_id )
+            return true;
+        if( $this->guest_transfer_shown_to_user_who_invited_guest ) {
+            return true;
+        }
+        return false;
+    }
     
     /**
      * Close the transfer
@@ -734,7 +744,7 @@ class Transfer extends DBObject
         }
         
         // Send notification to owner
-        if( !$this->guest_id || $this->guest_transfer_shown_to_user_who_invited_guest ) {            
+        if( $this->userCanSeeTransfer() ) {
             if ($this->getOption(TransferOptions::EMAIL_ME_ON_EXPIRE)) {
                 TranslatableEmail::quickSend($manualy ? 'transfer_deleted_receipt' : 'transfer_expired_receipt', $this->owner, $this);
             }
@@ -1588,7 +1598,7 @@ class Transfer extends DBObject
 
             // no not leak this transfer in a reminder if the system wants
             // private guests
-            if( $transfer->$guest_id && !$transfer->guest_transfer_shown_to_user_who_invited_guest ) {
+            if( !$transfer->userCanSeeTransfer()) {
                 $send_owner_autoreminder = false;
             }
 

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -155,6 +155,13 @@ class Transfer extends DBObject
             'size'    => '44',
             'null'    => true,
         ),
+
+        'guest_transfer_hidden_from_user_who_invited_guest' => array(
+            'type'    => 'bool',
+            'null'    => false,
+            'default' => false,
+        ),
+        
     );
 
     /**
@@ -272,8 +279,8 @@ class Transfer extends DBObject
     const UPLOADING_NO_ORDER = "status = 'uploading' ";
     const AVAILABLE_NO_ORDER = "status = 'available' ";
     const CLOSED_NO_ORDER = "status = 'closed' ";
-    const FROM_USER_NO_ORDER = "userid = :userid AND status='available' ";
-    const FROM_USER_CLOSED_NO_ORDER = "userid = :userid AND status='closed' ";
+    const FROM_USER_NO_ORDER        = "userid = :userid AND status='available' and ( guest_id is null or guest_transfer_hidden_from_user_who_invited_guest = false ) ";
+    const FROM_USER_CLOSED_NO_ORDER = "userid = :userid AND status='closed'    and ( guest_id is null or guest_transfer_hidden_from_user_who_invited_guest = false ) ";
 
     const ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT = 16;
     
@@ -302,6 +309,7 @@ class Transfer extends DBObject
     protected $password_hash_iterations = 150000;
     protected $client_entropy = '';
     protected $roundtriptoken = '';
+    protected $guest_transfer_hidden_from_user_who_invited_guest = false;
     
     /**
      * Related objects cache
@@ -981,7 +989,7 @@ class Transfer extends DBObject
             'subject', 'message', 'created', 'made_available',
             'expires', 'expiry_extensions', 'options', 'lang', 'key_version', 'userid',
             'password_version', 'password_encoding', 'password_encoding_string', 'password_hash_iterations'
-            , 'client_entropy', 'roundtriptoken'
+            , 'client_entropy', 'roundtriptoken', 'guest_transfer_hidden_from_user_who_invited_guest'
         ))) {
             return $this->$property;
         }
@@ -1183,6 +1191,8 @@ class Transfer extends DBObject
             $this->password_hash_iterations = $value;
         } elseif ($property == 'client_entropy') {
             $this->client_entropy = $value;
+        } elseif ($property == 'guest_transfer_hidden_from_user_who_invited_guest') {
+            $this->guest_transfer_hidden_from_user_who_invited_guest = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -791,7 +791,7 @@ class User extends DBObject
         // My transfers
         //
         $ret['transfers'] = array();
-        $statement = DBI::prepare('SELECT * FROM '.Transfer::getDBTable().' WHERE userid = :id');
+        $statement = DBI::prepare('SELECT * FROM '.Transfer::getDBTable().' WHERE userid = :id and ( guest_id is null or guest_transfer_shown_to_user_who_invited_guest )');
         $statement->execute(array(':id' => $user->id));
         $records = $statement->fetchAll();
         foreach ($records as $r) {

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -598,7 +598,7 @@ class RestEndpointTransfer extends RestEndpoint
 
             // See if the user who invited this guest should be able to see
             // this particular transfer from the guest.
-            $guest_transfer_hidden_from_user_who_invited_guest = false;
+            $guest_transfer_shown_to_user_who_invited_guest = true;
             if (Auth::isGuest()) {
 
                 $user_can_only_view_guest_transfers_shared_with_them = Config::get('user_can_only_view_guest_transfers_shared_with_them');
@@ -611,7 +611,7 @@ class RestEndpointTransfer extends RestEndpoint
                                 break;
                             }
                         }
-                        $guest_transfer_hidden_from_user_who_invited_guest = !$user_who_invited_guest_in_recipients;
+                        $guest_transfer_shown_to_user_who_invited_guest = $user_who_invited_guest_in_recipients;
                     }
                 }
             }
@@ -621,7 +621,7 @@ class RestEndpointTransfer extends RestEndpoint
             $expires = $data->expires ? $data->expires : Transfer::getDefaultExpire();
             $transfer = Transfer::create($expires, $guest ? $guest->email : $data->from);
 
-            $transfer->guest_transfer_hidden_from_user_who_invited_guest = $guest_transfer_hidden_from_user_who_invited_guest;
+            $transfer->guest_transfer_shown_to_user_who_invited_guest = $guest_transfer_shown_to_user_who_invited_guest;
             
             // Set additional data
             if ($data->subject) {

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -1,4 +1,7 @@
 <?php
+
+$user_can_only_view_guest_transfers_shared_with_them = Config::get('user_can_only_view_guest_transfers_shared_with_them');
+
 $nosort = false;
 if(!isset($trsort))  $nosort = true;
 

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -1,7 +1,4 @@
 <?php
-
-$user_can_only_view_guest_transfers_shared_with_them = Config::get('user_can_only_view_guest_transfers_shared_with_them');
-
 $nosort = false;
 if(!isset($trsort))  $nosort = true;
 


### PR DESCRIPTION
This is to address https://github.com/filesender/filesender/issues/1000. I have also looked at the emails that are sent though it is possible that this PR does not catch all "guest emails" that might also trigger an email to the user who invited the guest.

Because this test is needed in multiple locations I have created a new `$guest_transfer_shown_to_user_who_invited_guest` column in the Transfers table. This allows SQL to check and also the code to directly check if an email should be sent.

The `$guest_transfer_shown_to_user_who_invited_guest` is set in RestEndpointTransfer.class.php when a transfer is created and remains the same thereafter. The default is to show transfers to the user who owns them. Guest transfers are owned by the user who created them. So this whole config option is trying to hide some transfers from a user with the userid who owns some transfers because those transfers are from a guest of the user.
