### PR TITLE
Cast anonymous recipient identity to string

### DIFF
--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -315,11 +315,11 @@ class Recipient extends DBObject
         }
         
         if ($property == 'identity') {
-            return $this->email ? $this->email : Lang::tr('anonymous');
+            return $this->email ? $this->email : (string)Lang::tr('anonymous');
         }
         
         if ($property == 'name') {
-            $identity = $this->email ? explode('@', $this->email) : array(Lang::tr('anonymous'));
+            $identity = $this->email ? explode('@', $this->email) : array((string)Lang::tr('anonymous'));
             return $identity[0];
         }
         


### PR DESCRIPTION
Cast anonymous recipient identity to string to avoid it being rendered as "1" in templates