### PR TITLE
ui: feedback for bad characters in file names during adding

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -173,7 +173,8 @@ $default = array(
     
     'report_format' => ReportFormats::INLINE,
 
-    'valid_filename_regex' => '^[ \\/\\p{L}\\p{N}_\\.,;:!@#$%^&*)(\\]\\[_-]+$',
+    // Note that this must not have a fixed end of string '$' as the last character in the match 
+    'valid_filename_regex' => '^[ \\/\\p{L}\\p{N}\\p{P}_\\.,;:!@#$%^&*)(\\]\\[_-]+',
     'message_can_not_contain_urls_regex' => '',
 //    'message_can_not_contain_urls_regex' => '(ftp:|http[s]*:|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})',
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -655,3 +655,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['starting_at'] = 'starting at';

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -407,9 +407,17 @@ window.filesender.transfer = function() {
 
         if (typeof filesender.config.valid_filename_regex == 'string') {
             var regexstr = filesender.config.valid_filename_regex;
-            if (!XRegExp(regexstr).test(file.name)) {
+            var r = XRegExp(regexstr,'g');
+            var testResult = r.test(file.name);
+            var lastIndex = r.lastIndex;
+            if (lastIndex != file.name.length) {
+                var badEnding = file.name.substring(lastIndex);
+                window.filesender.log("invalid_file_name error raised for file name " + file.name
+                                      + " with len " + file.name.length
+                                      + " got lastIndex of " + r.lastIndex 
+                                      + " badEnding will be " + badEnding );
                 errorhandler({ message: 'invalid_file_name',
-                               details: { filename: file.name }});
+                               details: { filename: file.name, badoffset: lastIndex, badEnding: badEnding }});
                 
                 return false;
             }

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -246,7 +246,7 @@ filesender.ui.files = {
                     node.addClass('invalid');
                     node.addClass(error.message);
                     $('<span class="invalid fa fa-exclamation-circle fa-lg" />').prependTo(node.find('.info'))
-                    $('<div class="invalid_reason" />').text(lang.tr(error.message)).appendTo(node);
+                    $('<div class="invalid_reason" />').text(lang.tr(error.message) + ' ' + lang.tr('starting_at') + ' ' + error.details.badEnding ).appendTo(node);
                 }, source_node);
                 
                 filesender.ui.nodes.files.clear.button('enable');

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -246,7 +246,11 @@ filesender.ui.files = {
                     node.addClass('invalid');
                     node.addClass(error.message);
                     $('<span class="invalid fa fa-exclamation-circle fa-lg" />').prependTo(node.find('.info'))
-                    $('<div class="invalid_reason" />').text(lang.tr(error.message) + ' ' + lang.tr('starting_at') + ' ' + error.details.badEnding ).appendTo(node);
+                    var invalidreason = lang.tr(error.message);
+                    if(error.message == 'invalid_file_name') {
+                        invalidreason += ' ' + lang.tr('starting_at') + ' ' + error.details.badEnding;
+                    }
+                    $('<div class="invalid_reason" />').text( invalidreason ).appendTo(node);
                 }, source_node);
                 
                 filesender.ui.nodes.files.clear.button('enable');


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/1032. The regex has to change to not explicitly match the end of string so we can see where the matching has failed during test(). The UI now presents to the user where the failure has started to happen to help them resolve the issue. I also extended the regex a little to allow quotes. 

Without `\p{P}` in the valid file names the single quote was considered invalid. Removing the added '\\p{P}' is handy for testing as it will give a known fail case.