### PR TITLE
ui: maybe do not allow punctuation by default. Return to how it was before

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -174,7 +174,7 @@ $default = array(
     'report_format' => ReportFormats::INLINE,
 
     // Note that this must not have a fixed end of string '$' as the last character in the match 
-    'valid_filename_regex' => '^[ \\/\\p{L}\\p{N}\\p{P}_\\.,;:!@#$%^&*)(\\]\\[_-]+',
+    'valid_filename_regex' => '^[ \\/\\p{L}\\p{N}_\\.,;:!@#$%^&*)(\\]\\[_-]+',
     'message_can_not_contain_urls_regex' => '',
 //    'message_can_not_contain_urls_regex' => '(ftp:|http[s]*:|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})',
 


### PR DESCRIPTION
This takes the used regex back to what it was before https://github.com/filesender/filesender/pull/1033. Should file names allow quotes is the main question....