### PR TITLE
the dollar was removed from the default, add it here

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -170,7 +170,7 @@ class Utilities
      */
     public static function isValidFileName($filename)
     {
-        return preg_match('/' .  Config::get('valid_filename_regex') . '/u', $filename);
+        return preg_match('/' .  Config::get('valid_filename_regex') . '$/u', $filename);
     }
 
     


### PR DESCRIPTION
The regex lost the trailing '$' in https://github.com/filesender/filesender/pull/1033 so it is added on the server side test again here. We don't really care where the file name fails that regex on the server we just want complete match or failure.
