### PR TITLE
security: allow long passphrases to have relaxed contents restrictions

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -275,6 +275,10 @@ class Config
         if (self::get('encryption_min_password_length') > self::get('encryption_generated_password_length')) {
             throw new ConfigBadParameterException('Generated password length must be equal or greater than encryption_min_password_length');
         }
+        if (self::get('encryption_password_text_only_min_password_length') > 0
+            && self::get('encryption_min_password_length') >= self::get('encryption_password_text_only_min_password_length') ) {
+            throw new ConfigBadParameterException('The encryption_password_text_only_min_password_length setting must be greater than encryption_min_password_length');
+        }
 
         // If the admin has very small chunks then they will have a smaller max file size.
         self::$parameters['crypto_gcm_max_file_size'] = 4294967296 * self::$parameters['upload_chunk_size'];

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -124,6 +124,7 @@ A note about colours;
 * [encryption_password_must_have_upper_and_lower_case](#encryption_password_must_have_upper_and_lower_case)
 * [encryption_password_must_have_numbers](#encryption_password_must_have_numbers)
 * [encryption_password_must_have_special_characters](#encryption_password_must_have_special_characters)
+* [encryption_password_text_only_min_password_length](#encryption_password_text_only_min_password_length)
 * [encryption_generated_password_length](#encryption_generated_password_length)
 * [encryption_key_version_new_files](#encryption_key_version_new_files)
 * [encryption_random_password_version_new_files](#encryption_random_password_version_new_files)
@@ -1178,6 +1179,17 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __default:__ false
 * __available:__ since version 2.23
 * __comment:__ 
+
+
+### encryption_password_text_only_min_password_length
+* __description:__ If this is set then a password can avoid the password_must_have checks if it is at least this long.
+* __mandatory:__ no 
+* __type:__ int
+* __default:__ 40
+* __available:__ since version 2.26
+* __comment:__ Set to 0 to disable. Using this setting allows a passphrase that might contain all human language words without numbers, special characters etc
+     but which is still difficult enough to guess by brute force due to it's length and thus combination of words.
+
 
 
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1188,7 +1188,9 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __default:__ 40
 * __available:__ since version 2.26
 * __comment:__ Set to 0 to disable. Using this setting allows a passphrase that might contain all human language words without numbers, special characters etc
-     but which is still difficult enough to guess by brute force due to it's length and thus combination of words.
+     but which is still difficult enough to guess by brute force due to it's length and thus combination of words. If this setting is set to say 40 then
+     a password that is 40+ characters long will be accepted even when the encryption_password_must_have directives are in use and the password does not have
+     the must_have constraints met.
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -102,6 +102,7 @@ $default = array(
     'encryption_password_must_have_upper_and_lower_case' => true,
     'encryption_password_must_have_numbers' => true,
     'encryption_password_must_have_special_characters' => true,
+    'encryption_password_text_only_min_password_length' => 40,
     'encryption_generated_password_length' => 30,
     'encryption_generated_password_encoding' => 'base64',
     'encryption_encode_encrypted_chunks_in_base64_during_upload' => false,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -656,4 +656,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
-$lang['encryption_password_container_can_have_text_only_min_password_length_message'] = 'If your password has more than {cfg:encryption_password_text_only_min_password_length} non repeating characters then there are fewer restrictions on the contents of your password.';
+$lang['encryption_password_container_can_have_text_only_min_password_length_message'] = 'If your password has more than {cfg:encryption_password_text_only_min_password_length} characters without significant repetition then there are fewer restrictions on the contents of your password.';

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -656,3 +656,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['encryption_password_container_can_have_text_only_min_password_length_message'] = 'If your password has more than {cfg:encryption_password_text_only_min_password_length} non repeating characters then there are fewer restrictions on the contents of your password.';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -219,6 +219,10 @@ if( $encryption_mandatory ) {
                         <div class="fieldcontainer" id="encryption_password_container_must_have_special_characters_message">
                             {tr:file_encryption_password_must_have_special_characters}
                         </div>
+                        <div class="fieldcontainer" id="encryption_password_container_can_have_text_only_min_password_length_message">
+                            {tr:encryption_password_container_can_have_text_only_min_password_length_message}
+                        </div>
+                        
                         <div class="fieldcontainer" id="encryption_password_container_generate">
                             <input id="encryption_use_generated_password"  name="encryption_use_generated_password" type="checkbox">  
                             <label for="encryption_use_generated_password" style="cursor: pointer;">{tr:file_encryption_generate_password}</label>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1542,6 +1542,7 @@ table.guests .guest .to .errors .details {
 #encryption_password_container_must_have_numbers_message,
 #encryption_password_container_must_have_upper_and_lower_case_message,
 #encryption_password_container_must_have_special_characters_message,
+#encryption_password_container_can_have_text_only_min_password_length_message,
 #encryption_password_container_generate,
 #encryption_password_container_generate_again,
 #encryption_password_show_container,
@@ -1563,6 +1564,10 @@ table.guests .guest .to .errors .details {
 #encryption_password_container_must_have_special_characters_message {
     color: #f00;
 }
+#encryption_password_container_can_have_text_only_min_password_length_message {
+    color: #0a0;
+}
+
 
 table.paginator .pageprev0 {
     width: 2em;

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -88,6 +88,7 @@ window.filesender.config = {
     
     encryption_enabled: '<?php echo Config::get('encryption_enabled') ?>',
     encryption_min_password_length: '<?php echo Config::get('encryption_min_password_length') ?>',
+    encryption_password_text_only_min_password_length: '<?php echo Config::get('encryption_password_text_only_min_password_length') ?>',
     encryption_generated_password_length: '<?php echo Config::get('encryption_generated_password_length') ?>',
     encryption_generated_password_encoding: '<?php echo Config::get('encryption_generated_password_encoding') ?>',
     encryption_key_version_new_files: '<?php echo Config::get('encryption_key_version_new_files') ?>',

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -550,36 +550,77 @@ filesender.ui.files = {
             }
         }
 
-        if( filesender.config.encryption_password_must_have_upper_and_lower_case ) {
-            var testInvalid = false;
-            if(!pass.match(/[A-Z]/g) || !pass.match(/[a-z]/g)) {
-                testInvalid = true;
-                invalid = true;
+        //
+        // Very long text passwords might be allowed by sys admin.
+        //
+        var phrasePass = false;
+        if( filesender.config.encryption_password_text_only_min_password_length > 0 ) {
+            var phraseLen = filesender.config.encryption_password_text_only_min_password_length;
+            if( pass ) {
+                var passNonRepeating = !(/^(.)\1+$/.test(pass));
+                
+                if( passNonRepeating && pass.length >= phraseLen ) {
+                    phrasePass = true;
+
+                    filesender.ui.files.updatePasswordMustHaveMessage(
+                        slideMessage, false,
+                        $('#encryption_password_container_can_have_text_only_min_password_length_message'));
+                    
+                    testInvalid = false;
+                    filesender.ui.files.updatePasswordMustHaveMessage(
+                        slideMessage, testInvalid,
+                        $('#encryption_password_container_must_have_upper_and_lower_case_message'));
+                    filesender.ui.files.updatePasswordMustHaveMessage(
+                        slideMessage, testInvalid,
+                        $('#encryption_password_container_must_have_numbers_message'));
+                    filesender.ui.files.updatePasswordMustHaveMessage(
+                        slideMessage, testInvalid,
+                        $('#encryption_password_container_must_have_special_characters_message'));
+                } else {
+                    filesender.ui.files.updatePasswordMustHaveMessage(
+                        slideMessage, true,
+                        $('#encryption_password_container_can_have_text_only_min_password_length_message'));
+                }
+            } else {
+                filesender.ui.files.updatePasswordMustHaveMessage(
+                    slideMessage, true,
+                    $('#encryption_password_container_can_have_text_only_min_password_length_message'));
             }
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, testInvalid,
-                $('#encryption_password_container_must_have_upper_and_lower_case_message'));
+        }
+
+        if( !phrasePass ) {
             
-        }
-        if( filesender.config.encryption_password_must_have_numbers ) {
-            var testInvalid = false;
-            if(!pass.match(/[0-9]/g)) {
-                testInvalid = true;
-                invalid = true;
+            if( filesender.config.encryption_password_must_have_upper_and_lower_case ) {
+                var testInvalid = false;
+                if(!pass.match(/[A-Z]/g) || !pass.match(/[a-z]/g)) {
+                    testInvalid = true;
+                    invalid = true;
+                }
+                filesender.ui.files.updatePasswordMustHaveMessage(
+                    slideMessage, testInvalid,
+                    $('#encryption_password_container_must_have_upper_and_lower_case_message'));
+                
             }
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, testInvalid,
-                $('#encryption_password_container_must_have_numbers_message'));
-        }
-        if( filesender.config.encryption_password_must_have_special_characters ) {
-            var testInvalid = false;
-            if(!pass.match(/[@#!$%^&*()\[\]<>?\/\\]/g)) {
-                testInvalid = true;
-                invalid = true;
+            if( filesender.config.encryption_password_must_have_numbers ) {
+                var testInvalid = false;
+                if(!pass.match(/[0-9]/g)) {
+                    testInvalid = true;
+                    invalid = true;
+                }
+                filesender.ui.files.updatePasswordMustHaveMessage(
+                    slideMessage, testInvalid,
+                    $('#encryption_password_container_must_have_numbers_message'));
             }
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, testInvalid,
-                $('#encryption_password_container_must_have_special_characters_message'));
+            if( filesender.config.encryption_password_must_have_special_characters ) {
+                var testInvalid = false;
+                if(!pass.match(/[@#!$%^&*()\[\]<>?\/\\]/g)) {
+                    testInvalid = true;
+                    invalid = true;
+                }
+                filesender.ui.files.updatePasswordMustHaveMessage(
+                    slideMessage, testInvalid,
+                    $('#encryption_password_container_must_have_special_characters_message'));
+            }
         }
         
         if( slideMessage ) {


### PR DESCRIPTION
This relates to a recommendation in 20100861-M1 for longer pass phrases.