### PR TITLE
cookie: updates to default config and install guide

### DIFF
--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -1,7 +1,7 @@
 Alias /simplesaml /opt/filesender/simplesaml/www
 <Directory "/opt/filesender/simplesaml/www">
         Header always append X-Frame-Options SAMEORIGIN
-        Header always edit Set-Cookie (.*) "$1; SameSite=Strict"
+        Header always edit Set-Cookie (.*) "$1; SameSite=Strict; HttpOnly; "
 
         Options -Indexes
 	Options None
@@ -12,7 +12,8 @@ Alias /simplesaml /opt/filesender/simplesaml/www
 Alias /filesender /opt/filesender/filesender/www
 <Directory "/opt/filesender/filesender/">
         Header always append X-Frame-Options SAMEORIGIN
-        Header always edit Set-Cookie (.*) "$1; SameSite=Strict"
+        Header always edit Set-Cookie "^((?!csrfptoken).)+$" "$0; HttpOnly"
+        Header always edit Set-Cookie (.*) "$1; SameSite=Strict "
         
 	Options SymLinksIfOwnerMatch
         Options -Indexes

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -31,7 +31,7 @@ you can report issues with and update the documentation.
 
 ### Dependencies
 
-* Apache (or nginx) and PHP version 7.2 or later.
+* Apache (or nginx) and PHP version 7.3 or later.
 * A PostgreSQL or MariaDB database (10.0 or above, 10.2 or later recommended).
 * A big filesystem (or cloud backed).
 * [SimpleSamlPhp](https://simplesamlphp.org/download) 1.17.1 or newer.

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -277,7 +277,11 @@ edit config/config.php
   'showerrors' => false,
   'errorreporting' => false,
    ...
-  'session.cookie.secure' => true, // https site only!
+  'session.cookie.secure' => true,        // https site only!
+  'session.cookie.samesite' => 'Strict',  // cookie option SameSite=Strict
+  'session.phpsession.httponly' => true,  // cookie option HttpOnly
+  
+  
    ...
   'admin.protectindexpage' => true,
   'admin.protectmetadata' => true,

--- a/lib/README.md
+++ b/lib/README.md
@@ -2,3 +2,6 @@
 Since some files like javascript need to be served to the user, they need to be in ../www/js
 the run-this-after-composer-to-update-files.sh script is intended to be run after a composer
 update to copy javascript and css files to ../www/js to make it easy for people to update
+
+Note that csrf-protector-php was updated locally to set SameSite=Strict. This is intended to be
+pushed upstream.

--- a/lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php
+++ b/lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php
@@ -413,13 +413,27 @@ if (!defined('__CSRF_PROTECTOR__')) {
                 self::$cookieConfig = new csrfpCookieConfig(self::$config['cookieConfig']);
             }
 
+            /* setcookie(
+             *     self::$config['CSRFP_TOKEN'], 
+             *     $token,
+             *     self::$cookieConfig->expire ? (time() + self::$cookieConfig->expire) : self::$cookieConfig->expire,
+             *     self::$cookieConfig->path,
+             *     self::$cookieConfig->domain,
+             *     (bool) self::$cookieConfig->secure);
+             */
+
+            // PHP 7.3 only. Adds SameSite = Strict.
             setcookie(
                 self::$config['CSRFP_TOKEN'], 
                 $token,
-                self::$cookieConfig->expire ? (time() + self::$cookieConfig->expire) : self::$cookieConfig->expire,
-                self::$cookieConfig->path,
-                self::$cookieConfig->domain,
-                (bool) self::$cookieConfig->secure);
+                [
+                    'expires' => self::$cookieConfig->expire ? (time() + self::$cookieConfig->expire) : self::$cookieConfig->expire,
+                    'path'    => self::$cookieConfig->path,
+                    'domain'  => self::$cookieConfig->domain,
+                    'secure'  => (bool) self::$cookieConfig->secure,
+                    'httponly' => false,
+                    'samesite' => 'Strict',
+                ]);
         }
 
         /*


### PR DESCRIPTION
The SimpleSAMLphp part of the installation did not take advantage of some of the options for SimpleSAMLphp for the default configuration settings. This introduces a recommendation to use SimpleSAMLphp configuration options that will result in SameSite=Strict and HttpOnly being used to protect the auth cookies.

The OWASP CSRF file was updated to use SameSite=Strict but can not use HttpOnly as the cookie must be explicitly accessed from javascript.

The apache overrides recommendations have also been updated if that is the method an admin wishes to add these cookie options to their environment.

This relates to 20100861-L1 and 20100861-N1
