### PR TITLE
cookies: maybe bring forward session_start for sp auth

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -98,6 +98,20 @@ class Auth
     public static $authClassLoadingCount = 0;
 
     /**
+     * Ensure session_start is called if there is no session already.
+     * Note that self::$type must be guest or sp for this call to do anything.
+     *
+     * @return void
+     */
+    private static function ensure_php_session()
+    {
+        if ( self::isSessionStarted() === false ) {
+            session_start();
+        }
+    }
+    
+    
+    /**
      * Return current user if it exists.
      *
      * @return User instance or false
@@ -133,9 +147,20 @@ class Auth
                         }
                         self::$type = 'remote';
                     }
-                } elseif (AuthSP::isAuthenticated()) { // SP
-                    self::$attributes = AuthSP::attributes();
-                    self::$type = 'sp';
+                } else {
+                    
+                    // Note that AuthSP may use the SESSION which might start_session before we do
+                    // so we have to allow the sys admin to ensure the
+                    // session before letting AuthSP do anything in isAuthenticated().
+
+                    if( Utilities::isTrue(Config::get("auth_sp_force_session_start_first"))) {
+                        self::ensure_php_session();
+                    }
+                    
+                    if( AuthSP::isAuthenticated()) {
+                        self::$attributes = AuthSP::attributes();
+                        self::$type = 'sp';
+                    }
                 }
             } catch (Exception $e) {
                 self::$exception = $e;
@@ -144,8 +169,8 @@ class Auth
 
             // If no session has been made at this point, we make one ourselves.
             // Only types 'guest' and 'sp' are browsers.
-            if (in_array(self::$type, array('sp', 'guest')) && self::isSessionStarted() === false) {
-                session_start();
+            if (in_array(self::$type, array('sp', 'guest'))) {
+                self::ensure_php_session();
             }
             
             if (self::$attributes && array_key_exists('uid', self::$attributes)) {

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -179,6 +179,7 @@ A note about colours;
 ## Authentication
 
 * [auth_sp_type](#auth_sp_type)
+* [auth_sp_force_session_start_first](#auth_sp_force_session_start_first)
 * __SimpleSAMLphp__
 	* [auth_sp_saml_authentication_source](#auth_sp_saml_authentication_source)
 	* [auth_sp_saml_simplesamlphp_url](#auth_sp_saml_simplesamlphp_url)
@@ -1728,6 +1729,19 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ <span style="background-color:orange">to use type "fake" you need ...</span>
+
+
+### auth_sp_force_session_start_first
+
+* __description:__ Call php session_start to setup the session cookie before attempting auth authentication with the auth_sp_type.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __cookies:__ depending on php env this might set PHPSESSID cookie
+* __available:__ since version 2.26
+* __comment:__ Some of the auth_sp methods may use _SESSION or perform other actions that might alter how session_start() will work. If that is the case you can set this configuration to true and session_start() will be called before authentication is performed.
+
+
 
 ### session_cookie_path
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -61,6 +61,7 @@ $default = array(
     'auth_sp_shibboleth_email_attribute' => 'mail', // Get email attribute from authentification service
     'auth_sp_shibboleth_name_attribute' => 'cn', // Get name attribute from authentification service
     'auth_sp_shibboleth_uid_attribute' => 'eduPersonTargetedID', // Get uid attribute from authentification service
+    'auth_sp_force_session_start_first' => false,  // maybe move session_start() forward.
     
     'auth_remote_user_autogenerate_secret' => false,
     'auth_remote_signature_algorithm' => 'sha1',


### PR DESCRIPTION
Setting auth_sp_force_session_start_first to true will cause session_start to happen before auth. This might allow for the php session cookie to be sent to the client if the auth sp method is doing something that might make session_start behave differently.