### PR TITLE
headers: set HSTS to 2 years by default

### DIFF
--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -59,7 +59,11 @@ class Security
         if( $v != 'none' ) {
             header( 'X-Frame-Options: ' . $v, false );
         }
-        
+
+        $v = Utilities::toInt(Config::get('header_add_hsts_duration'),0);
+        if( $v > 0 ) {
+            header( 'Strict-Transport-Security: max-age=' . $v . '; includeSubDomains', false );
+        }
     }
 
     private static $filesender_csrf_protector_logger = null;

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -444,6 +444,12 @@ class Utilities
         }
         return 'false';
     }
+    public static function toInt($v, $def) {
+        if(!is_numeric($v)) {
+            return $def;
+        }
+        return intval($v);
+    }
 
     /**
      * This is a wrapper around the PHP http_build_query with some

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -30,6 +30,7 @@ A note about colours;
 
 ## Security settings
 * [header_x_frame_options](#header_x_frame_options)
+* [header_add_hsts_duration](#header_add_hsts_duration)
 * [owasp_csrf_protector_enabled](#owasp_csrf_protector_enabled)
 
 ## Backend storage
@@ -376,6 +377,16 @@ A note about colours;
 * __default:__ sameorigin
 * __available:__ since version 2.7
 * __comment:__ Default should be ok. Can be 'deny' to disallow frames if you do not use them or 'none' to disable the feature (not recommended). Note that this setting will not override a setting that is already in place in your web server. This setting is mainly here as a second catch and for sites that can not configure their web server to install a site wide nominated value for X-Frame-Options.
+
+### header_add_hsts_duration
+
+* __description:__ Add Strict-Transport-Security header with the desired max-age
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 63072000
+* __available:__ since version 2.26
+* __comment:__ Set to 0 to disable. Default is 63072000 which is two years in seconds.
+
 
 
 * [owasp_csrf_protector_enabled](#owasp_csrf_protector_enabled)

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -250,6 +250,7 @@ $default = array(
     ),
 
     'header_x_frame_options' => 'sameorigin',
+    'header_add_hsts_duration' => 63072000,
     'owasp_csrf_protector_enabled' => false,
 
     'theme' => '',
@@ -288,7 +289,7 @@ $default = array(
 
     'allow_guest_expiry_date_extension' => 0,
     'allow_guest_expiry_date_extension_admin' => array(31, true),
-    
+
     
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
This can be disabled by setting the config to 0 if the web server itself is the desired way to set the parameter.