### PR TITLE
crypto: log decrypt failures to allow for abuse detection

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -515,6 +515,17 @@ class Auth
     }
 
     /**
+     * The user or the guest current performing the action 
+     */
+    public static function actor()
+    {
+        if( self::isGuest() ) {
+            return AuthGuest::getGuest();
+        }
+        return self::User();
+    }
+
+    /**
      * Tells if a session is started.
      *
      * @return bool

--- a/classes/constants/LogEventTypes.class.php
+++ b/classes/constants/LogEventTypes.class.php
@@ -75,6 +75,7 @@ class LogEventTypes extends Enum
    const TRANSFER_EXPIRED         = 'transfer_expired';       // Transfer expired
    const TRANSFER_CLOSED          = 'transfer_closed';        // Transfer closed
    const TRANSFER_DELETED         = 'transfer_deleted';       // Transfer deleted
+   const TRANSFER_DECRYPT_FAILED  = 'transfer_decrypt_failed';// Transfer decrypt failed at client
    
    /* UPLOAD */
     const UPLOAD_STARTED           = 'upload_started';   // Upload stated

--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -634,14 +634,14 @@ class AuditLog extends DBObject
         }
         $created = time() - $secondsAgo;
 
-        $sql  = '( select *,count(*) as count ';
+        $sql  = '( select MAX(id) as id, event, MAX(target_type) as target_type, MAX(target_id) as target_id, author_type, author_id, MAX(ip) as ip, MAX(created) as created,count(*) as count ';
         $sql .= ' from ' . self::getDBTable();
         $sql .= ' where ';
         $sql .=    self::FROM_TARGET_TYPE_SINCE;
         $sql .= ' and author_id is not null ';
         $sql .= ' group by event,author_type,author_id ) ';
         $sql .= ' UNION ';
-        $sql .= '( select *,count(*) as count ';
+        $sql .= '( select MAX(id) as id, event, MAX(target_type) as target_type, MAX(target_id) as target_id, author_type, author_id, ip, MAX(created) as created,count(*) as count ';
         $sql .= ' from ' . self::getDBTable();
         $sql .= ' where ';
         $sql .=    self::FROM_TARGET_TYPE_SINCE;

--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -132,6 +132,7 @@ class AuditLog extends DBObject
     const FROM_AUTHOR = 'author_type = :type AND author_id = :id ORDER BY created ASC, id ASC';
     const FROM_TARGET_AND_AUTHOR = 'event = :event AND target_type = :ttype AND target_id = :tid AND author_type = :atype AND author_id = :aid ORDER BY created DESC limit 10 ';
     const FROM_TARGET_AND_AUTHOR_SINCE = 'created > :created AND event = :event AND target_type = :ttype AND target_id = :tid AND author_type = :atype AND author_id = :aid ';    
+    const FROM_TARGET_TYPE_SINCE = 'created > :created AND event = :event AND target_type = :ttype  ';    
     const FIND_USERS_SINCE = array( 'select' => 'max(id) as id,target_id',
                                     'where' => 'created > :created AND event = :event AND target_type = :ttype ',
                                     'group' => 'target_id' );
@@ -494,7 +495,7 @@ class AuditLog extends DBObject
      *
      * @return array of AuditLog
      */
-    public static function fromTransfer(Transfer $transfer, $event = null)
+    public static function fromTransfer(Transfer $transfer, $event = null, $since = null )
     {
         if (
             !is_object($transfer)
@@ -534,6 +535,15 @@ class AuditLog extends DBObject
         if ($event && LogEventTypes::isValidValue($event)) {
             $logs = array_filter($logs, function ($log) use ($event) {
                 return $log->event == $event;
+            });
+        }
+
+        // Filter out older events.
+        if( $since ) {
+            $cutoff = time() - $since;
+            
+            $logs = array_filter($logs, function ($log) use ($cutoff) {
+                return $log->created >= $cutoff;
             });
         }
         
@@ -615,4 +625,37 @@ class AuditLog extends DBObject
     public function createdWithinLastDay() {
         return $this->created > (time() - 24*3600);
     }
+
+
+    public static function getUsersForTargetTypeSince($logEvent, $ttype, $secondsAgo = null )
+    {
+        if(!$secondsAgo) {
+            $secondsAgo = 24*3600;
+        }
+        $created = time() - $secondsAgo;
+
+        $sql = 'select *,count(*) as count '
+             . ' from ' . self::getDBTable()
+             . ' where '
+             .   self::FROM_TARGET_TYPE_SINCE
+             . ' group by event,author_type,author_id ';
+        $statement = DBI::prepare($sql);
+        $statement->execute(array(
+            'created' => date('Y-m-d H:0:0', $created),
+            'event' => $logEvent,
+            'ttype' => $ttype
+        ));
+
+        $records = $statement->fetchAll();
+        $ret = array();
+        foreach ($records as $r) {
+            $u = User::fromId($r['author_id']);
+            $u->eventcount = $r['count'];
+            $u->eventip    = $r['ip'];
+            $ret[] = $u;
+        }
+        return $ret;
+        
+    }
+
 }

--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -638,7 +638,8 @@ class AuditLog extends DBObject
              . ' from ' . self::getDBTable()
              . ' where '
              .   self::FROM_TARGET_TYPE_SINCE
-             . ' group by event,author_type,author_id ';
+             . ' group by event,author_type,author_id,ip '
+             . ' order by count desc ';       
         $statement = DBI::prepare($sql);
         $statement->execute(array(
             'created' => date('Y-m-d H:0:0', $created),

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1709,4 +1709,5 @@ class Transfer extends DBObject
                $this->status == TransferStatuses::STARTED ||
                $this->status == TransferStatuses::UPLOADING;
     }
+
 }

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -161,7 +161,12 @@ class User extends DBObject
     protected $quota = 0;
     protected $guest_expiry_default_days = null;
 
+    /** 
+     * These are not real properties and are used by queries in the
+     * system to return additional data about a user from the query.
+     */
     private $eventcount = 0;
+    private $eventip = 0;
     
     /**
      * From Auth if it makes sense
@@ -663,6 +668,9 @@ class User extends DBObject
         if ($property == 'eventcount') {
             return $this->eventcount;
         }
+        if ($property == 'eventip') {
+            return $this->eventip;
+        }
         
         throw new PropertyAccessException($this, $property);
     }
@@ -716,6 +724,8 @@ class User extends DBObject
             $this->quota = (int)$value;
         } elseif ($property == 'eventcount') {
             $this->eventcount = (int)$value;
+        } elseif ($property == 'eventip') {
+            $this->eventip = $value;
         } elseif ($property == 'guest_expiry_default_days') {
             $this->guest_expiry_default_days = (int)$value;
             if( $this->guest_expiry_default_days == 0 ) {

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -193,7 +193,7 @@ class RestEndpointTransfer extends RestEndpoint
         
         // Get current user
         $user = Auth::user();
-        
+      
         if (is_numeric($id)) {
             // Getting data about a specific transfer
             $transfer = Transfer::fromId($id);
@@ -791,6 +791,13 @@ class RestEndpointTransfer extends RestEndpoint
         if (($security == 'auth') && !Auth::isAuthenticated()) {
             throw new RestAuthenticationRequiredException();
         }
+
+        $data = $this->request->input;
+        if( $data->decryptfailed ) {
+            $transfer = Transfer::fromId($id);
+            Logger::logActivity(LogEventTypes::TRANSFER_DECRYPT_FAILED, $transfer, Auth::actor());
+            return array();
+        }
         
         // Get transfer to update and current user
         $transfer = Transfer::fromId($id);
@@ -857,6 +864,7 @@ class RestEndpointTransfer extends RestEndpoint
                     $transfer->save();
                 }
             }
+
         }
         
         // Need to make the transfer available (sends email to recipients) ?

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -62,6 +62,7 @@ class RestEndpointUser extends RestEndpoint
             'lang' => $user->lang,
             'frequent_recipients' => $user->frequent_recipients,
             'eventcount' => $user->eventcount,
+            'eventip' => $user->eventip
         );
     }
     
@@ -131,6 +132,7 @@ class RestEndpointUser extends RestEndpoint
         }
         
         $user = Auth::user();
+
         
         // Check ownership
         if ($id && $id != '@me') {
@@ -172,6 +174,15 @@ class RestEndpointUser extends RestEndpoint
                 return array_map(function ($user) {
                     return self::cast($user);
                 }, array_values(AuditLog::findUsersOrderedByCount($s,'User',$since)));
+            }
+            if (array_key_exists('decryptfailed', $_REQUEST)) {
+                $s = Utilities::sanitizeInput($_REQUEST['decryptfailed']);
+
+                $logs = AuditLog::getUsersForTargetTypeSince( LogEventTypes::TRANSFER_DECRYPT_FAILED, 'Transfer', $since );
+
+                return array_map(function ($user) {
+                    return self::cast($user);
+                }, array_values( $logs ));
             }
             
             if (!array_key_exists('match', $_REQUEST)) {

--- a/templates/admin_users_section.php
+++ b/templates/admin_users_section.php
@@ -68,8 +68,16 @@
         <input type="button" class="ab_guests_del" value="{tr:oneweek}"         data-since="604800" />
         <input type="button" class="ab_guests_del" value="{tr:twoeightdays}"    data-since="2419200" />
     </td></tr>
+    <tr><td>{tr:most_failed_decryptions}</td><td>
+        <input type="button" class="ab_decryptfailed" value="{tr:oneday}"          data-since="86400" />
+        <input type="button" class="ab_decryptfailed" value="{tr:oneweek}"         data-since="604800" />
+        <input type="button" class="ab_decryptfailed" value="{tr:twoeightdays}"    data-since="2419200" />
+    </td></tr>
+    
 </table>
 </fieldset>
+
+
 
 <h2>{tr:search_user}</h2>
 <fieldset class="search">
@@ -84,14 +92,15 @@
         <th>{tr:user_id}</th>
         <th>{tr:last_activity}</th>
         <th>{tr:event_count}</th>
+        <th>{tr:ip}</th>
         <th>&nbsp;</th>
     </tr>
     
     <tr class="searching">
-        <td colspan="4">{tr:searching}</td>
+        <td colspan="5">{tr:searching}</td>
     </tr>
     <tr class="no_results">
-        <td colspan="4">{tr:no_results}</td>
+        <td colspan="5">{tr:no_results}</td>
     </tr>
     
     <tr class="tpl">
@@ -99,6 +108,7 @@
         <td class="saml_id"></td>
         <td class="last_activity"></td>
         <td class="event_count"></td>
+        <td class="ip"></td>
         
         <td>
 <?php if( Config::get('admin_can_view_user_transfers_page')) : ?>

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -126,6 +126,7 @@
              data-client-entropy="<?php echo $transfer->client_entropy; ?>"
              data-fileiv="<?php echo $file->iv; ?>"
              data-fileaead="<?php echo $file->aead; ?>"
+             data-transferid="<?php echo $transfer->id ?>"
         >
             
             <?php if($canDownloadArchive) { ?>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -440,6 +440,7 @@ if (!function_exists('clickableHeader')) {
                              data-client-entropy="<?php echo $transfer->client_entropy; ?>"
                              data-fileiv="<?php echo $file->iv; ?>"
                              data-fileaead="<?php echo $file->aead; ?>"
+                             data-transferid="<?php echo $transfer->id; ?>"
                         >
                             <?php echo Template::sanitizeOutput($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo count($file->downloads) ?> {tr:downloads}
                             
@@ -460,7 +461,7 @@ if (!function_exists('clickableHeader')) {
                                         data-client-entropy="<?php echo $transfer->client_entropy; ?>"
                                         data-fileiv="<?php echo $file->iv; ?>"
                                         data-fileaead="<?php echo $file->aead; ?>"
-                                      
+                                        data-transferid="<?php echo $transfer->id; ?>"
                                 ></span>
                                         
                                 <?php } else {?>

--- a/www/js/admin_users.js
+++ b/www/js/admin_users.js
@@ -79,8 +79,8 @@ $(function() {
         u.find('.saml_id').text(user.saml_id);
         u.find('.last_activity').text(user.last_activity.formatted);
         u.find('.event_count').text(user.eventcount);
+        u.find('.ip').text(user.eventip);
         u.appendTo(results);
-
         u.find('[data-action="show-transfers"]').on('click', function() {
             var id = $(this).closest('.user').attr('data-id');
             filesender.ui.redirect( filesender.config.base_path
@@ -183,6 +183,24 @@ $(function() {
         });
     }
 
+    var search_decryptfailed = function( since ) {
+        results.removeClass('no_results').addClass('searching');
+
+        filesender.client.get('/user', function(matches) {
+            clean_users();
+
+            results.toggleClass('no_results', !matches.length);
+
+            for(var i=0; i<matches.length; i++)
+                add_user(matches[i]);
+
+            results.removeClass('searching');
+        }, {
+            args: { decryptfailed:true, since:since }
+        });
+    }
+
+    
     section.find('.search [class="ab_hit_create_total_limit"]').on('click', function() {
         search_potential_abuse('guest_created_lh','','User',$(this).attr('data-since'));
     });
@@ -198,6 +216,9 @@ $(function() {
     });
     section.find('.search [class="ab_guests_del"]').on('click', function() {
         search_potential_abuse('','guest_closed','User',$(this).attr('data-since'));
+    });
+    section.find('.search [class="ab_decryptfailed"]').on('click', function() {
+        search_decryptfailed($(this).attr('data-since'));
     });
 
 

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -549,6 +549,19 @@ window.filesender.client = {
         
         return this.put('/transfer/' + id, {closed: true}, callback, opts);
     },
+
+    /**
+     * Decryption failed for a transfer, possibly by bad password
+     * 
+     * @param object transfer
+     */
+    decryptionFailedForTransfer: function(transfer) {
+        var id = (typeof transfer == 'object') ? transfer.id : transfer;
+        var opts = {};
+        var callback = function() {} ;
+        return this.put('/transfer/' + id, {decryptfailed: true}, callback, opts);
+    },
+
     
     /**
      * Delete a transfer (admin / owner if in early statuses)

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -94,6 +94,8 @@ window.filesender.crypto_app = function () {
         // for example, to respect a checkbox from the UI
         disable_streamsaver: false,
 
+
+
         /**
          * This turns a filesender chunkid into a 4 byte array
          * that can be used in GCM encryption. 
@@ -715,6 +717,7 @@ window.filesender.crypto_app = function () {
                         window.filesender.log(e);
                         if (!wrongPassword) {
                             wrongPassword=true;
+                            filesender.client.decryptionFailedForTransfer( encryption_details.transferid );
                             callbackError(e);
                         }
                     }
@@ -938,7 +941,7 @@ window.filesender.crypto_app = function () {
          * 
          * @param fileiv is the decoded fileiv. Decoding can be done with decodeCryptoFileIV()
          */
-        decryptDownloadToBlobSink: function (blobSink, pass,
+        decryptDownloadToBlobSink: function (blobSink, pass, transferid,
                                              link, mime, name, filesize, encrypted_filesize,
                                              key_version, salt,
                                              password_version, password_encoding, password_hash_iterations,
@@ -957,7 +960,8 @@ window.filesender.crypto_app = function () {
                                        password_hash_iterations: password_hash_iterations,
                                        client_entropy:    client_entropy,
                                        fileiv:            fileiv,
-                                       fileaead:          fileaead
+                                       fileaead:          fileaead,
+                                       transferid:        transferid
                                      };
             // For GCM this will be the fileiv (96 bits of fixed entropy).
             encryption_details.expected_fixed_chunk_iv = new Uint8Array(16);
@@ -1108,7 +1112,7 @@ window.filesender.crypto_app = function () {
                 );
  
         },
-        decryptDownload: function (link, mime, name, filesize, encrypted_filesize,
+        decryptDownload: function (link, transferid, mime, name, filesize, encrypted_filesize,
                                    key_version, salt,
                                    password_version, password_encoding, password_hash_iterations,
                                    client_entropy, fileiv, fileaead,
@@ -1185,7 +1189,7 @@ window.filesender.crypto_app = function () {
             var prompt = window.filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();
             
-                $this.decryptDownloadToBlobSink( blobSink, pass,
+                $this.decryptDownloadToBlobSink( blobSink, pass, transferid,
                                                  link, mime, name, filesize, encrypted_filesize,
                                                  key_version, salt,
                                                  password_version, password_encoding, password_hash_iterations,
@@ -1221,7 +1225,7 @@ window.filesender.crypto_app = function () {
                 + "." + archiveFormat;
             return archiveName;
         },
-        decryptDownloadToZip: function(link,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
+        decryptDownloadToZip: function(link,transferid,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
 
             var $this = this;
 
@@ -1238,7 +1242,7 @@ window.filesender.crypto_app = function () {
                 var pass = $(this).find('input').val();
 
                 var archiveName = $this.getArchiveFileName(link,selectedFiles,"zip");
-                blobSinkStreamed = window.filesender.streamsaver_sink_zip64( $this, link, archiveName, pass, selectedFiles, callbackError );
+                blobSinkStreamed = window.filesender.streamsaver_sink_zip64( $this, link, transferid, archiveName, pass, selectedFiles, callbackError );
                 blobSink = blobSinkStreamed;
                 blobSink.init();
                 blobSink.progress = progress;

--- a/www/js/crypter/streamsaver_sink.js
+++ b/www/js/crypter/streamsaver_sink.js
@@ -83,7 +83,7 @@ window.filesender.streamsaver_sink = function ( arg_name, arg_expected_size, arg
 
 
 
-window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, archiveName, pass, selectedFiles, arg_callbackError ) {
+window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferid, archiveName, pass, selectedFiles, arg_callbackError ) {
     return {
         complete: false,
         // keep a tally of bytes processed to make sure we get everything.
@@ -94,6 +94,7 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, archiveNa
         selectedFiles: selectedFiles,
         cryptoapp: cryptoapp,
         link: link,
+        transferid: transferid,
         pass: pass,
         activeFileID: null,
         progress: null,
@@ -157,7 +158,7 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, archiveNa
                 var f = $this.selectedFiles.shift();
                 window.filesender.log("blobSinkStreamedzip64 adding next file with name " + f.filename );
                 $this.openFile(f.filename,f.fileid);
-                $this.cryptoapp.decryptDownloadToBlobSink( $this, pass,
+                $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,
                                                            $this.link+f.fileid,
                                                            f.mime, f.filename, f.filesize, f.encrypted_filesize,
                                                            f.key_version, f.salt,

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -142,6 +142,7 @@ $(function() {
                         var fileaead = $($this).find("[data-id='" + ids[i] + "']").attr('data-fileaead');
                         var key_version = $($this).find("[data-id='" + ids[i] + "']").attr('data-key-version');
                         var fileivcoded = $($this).find("[data-id='" + ids[i] + "']").attr('data-fileiv');
+                        var transferid = $('.transfer').attr('data-id');
                         
                         selectedFiles.push({
                             fileid:ids[i]
@@ -157,6 +158,7 @@ $(function() {
                             , client_entropy:$($this).find("[data-id='" + ids[i] + "']").attr('data-client-entropy')
                             , fileiv:window.filesender.crypto_app().decodeCryptoFileIV(fileivcoded,key_version)
                             , fileaead:fileaead.length?atob(fileaead):null
+                            , transferid:transferid
                         });
 
                         // clear any previous progress message
@@ -166,6 +168,7 @@ $(function() {
                     crypto_app.decryptDownloadToZip( filesender.config.base_path
                                                      + 'download.php?token=' + token
                                                      + '&files_ids='
+                                                     , transferid
                                                      , selectedFiles
                                                      , progress
                                                      , onFileOpen, onFileClose, onComplete
@@ -176,6 +179,7 @@ $(function() {
                 else
                 {
                     // single file download
+                    var transferid  = $('.transfer').attr('data-id');
                     var filename    = $($this).find("[data-id='" + ids[0] + "']").attr('data-name');
                     var filesize    = $($this).find("[data-id='" + ids[0] + "']").attr('data-size');
                     var encrypted_filesize=$($this).find("[data-id='" + ids[0] + "']").attr('data-encrypted-size');
@@ -195,6 +199,7 @@ $(function() {
                     crypto_app.decryptDownload( filesender.config.base_path
                                                 + 'download.php?token=' + token
                                                 + '&files_ids=' + ids.join(','),
+                                                transferid,
                                                 mime, filename, filesize, encrypted_filesize,
                                                 key_version, salt,
                                                 password_version, password_encoding,

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -349,6 +349,7 @@ $(function() {
             return;
         }
         
+        var transferid = $(this).attr('data-transferid');
         var id = $(this).attr('data-id');
         var encrypted = $(this).attr('data-encrypted');
         var filename = $(this).attr('data-name');
@@ -373,6 +374,7 @@ $(function() {
         
         window.filesender.crypto_app().decryptDownload(
             filesender.config.base_path + 'download.php?files_ids=' + id.join(','),
+            transferid,
             mime, filename,
             filesize, encrypted_filesize,
             key_version, salt,


### PR DESCRIPTION
Because decryption is done client side it is hard to install brute force mitigation because the client code can always be modified. This code sends information to the server when decryption has failed. If an abusive user has not taken other measures then the server will rack up many failed decrypt messages for that user and they can be seen by the system admin for whatever action might be desired.

There is a new button on the admin/users page to allow searching for users with most_failed_decryptions. Guests or not logged in users are also shown but with less information.

This relates to 20100861-N2.