### PR TITLE
avprograms: new option to check MIME type 

### DIFF
--- a/classes/avprograms/AVProgram.class.php
+++ b/classes/avprograms/AVProgram.class.php
@@ -47,6 +47,7 @@ abstract class AVProgram
     protected $name = "";
     protected $url  = "";
     protected $matchlist = array();
+    protected $bytesToConsider = 8*1024;
 
     public static function getActiveProgramList()
     {
@@ -81,6 +82,12 @@ abstract class AVProgram
                             if( array_key_exists('matchlist',$a)) {
                                 $obj->matchlist = $a['matchlist'];
                             }
+                            if( array_key_exists('bytesToConsider',$a)) {
+                                // Get bytesToConsider with explicit min value.
+                                $obj->bytesToConsider = Utilities::clampMin($a['bytesToConsider'],
+                                                                            $obj->bytesToConsider);
+                            }
+                            echo " bytesToConsider  $obj->bytesToConsider \n";
                         }
                     }
                     self::$programList[] = $obj;

--- a/classes/avprograms/AVProgram.class.php
+++ b/classes/avprograms/AVProgram.class.php
@@ -46,7 +46,7 @@ abstract class AVProgram
 
     protected $name = "";
     protected $url  = "";
-    
+    protected $matchlist = array();
 
     public static function getActiveProgramList()
     {
@@ -61,6 +61,7 @@ abstract class AVProgram
                 DBConstantAVProgram::ALWAYS_ERROR => new AVProgramAlwaysError(),
                 DBConstantAVProgram::URL          => new AVProgramURL(),
                 DBConstantAVProgram::TOOBIG       => new AVProgramTooBig(),
+                DBConstantAVProgram::MIME         => new AVProgramMIME(),
             );
         }
         if( !self::$programList ) {
@@ -76,6 +77,9 @@ abstract class AVProgram
                             }
                             if( array_key_exists('url',$a)) {
                                 $obj->url = $a['url'];
+                            }
+                            if( array_key_exists('matchlist',$a)) {
+                                $obj->matchlist = $a['matchlist'];
                             }
                         }
                     }

--- a/classes/avprograms/AVProgramMIME.class.php
+++ b/classes/avprograms/AVProgramMIME.class.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ */
+class AVProgramMIME extends AVProgram
+{
+    public function inspect( $file )
+    {
+        $appid = DBConstantAVProgram::lookup( DBConstantAVProgram::URL );
+        echo "AVProgramURL on file " . $file->id . " size " . $file->size . " \n";
+        $passes = false;
+        $error = false;
+        $emsg = "";
+
+
+        $iss = $file->getStream();
+        $data = fread( $iss, 8*1024 );
+        $finfo = new finfo(FILEINFO_MIME);
+        $mt = $finfo->buffer($data);
+        $mt = preg_replace('/;.*/', '', $mt);        
+        echo "mt $mt \n";
+        if( in_array( $mt, $this->matchlist )) {
+            $passes = true;
+        } else {
+            $emsg = "invalid MIME type " . $mt;
+        }
+        
+        echo "adding result " . $file->id . " $appid $passes $error $emsg \n";
+        $result = AVResult::create( $file, $appid, $this->name, $passes, $error, $emsg );
+    }
+    
+};
+

--- a/classes/avprograms/AVProgramMIME.class.php
+++ b/classes/avprograms/AVProgramMIME.class.php
@@ -49,7 +49,7 @@ class AVProgramMIME extends AVProgram
 
 
         $iss = $file->getStream();
-        $data = fread( $iss, 8*1024 );
+        $data = fread( $iss, $this->bytesToConsider );
         $finfo = new finfo(FILEINFO_MIME);
         $mt = $finfo->buffer($data);
         $mt = preg_replace('/;.*/', '', $mt);        

--- a/classes/data/constants/DBConstantAVProgram.class.php
+++ b/classes/data/constants/DBConstantAVProgram.class.php
@@ -49,6 +49,7 @@ class DBConstantAVProgram extends DBConstant
     const ALWAYS_ERROR   = 'always_error';
     const URL            = 'url';
     const TOOBIG         = 'toobig';
+    const MIME           = 'mime';
     
     protected function getEnum()
     {
@@ -59,6 +60,7 @@ class DBConstantAVProgram extends DBConstant
             self::ALWAYS_ERROR  => 4,
             self::URL           => 5,
             self::TOOBIG        => 6,
+            self::MIME          => 7,
         );
     }
 

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -701,4 +701,11 @@ class Utilities
         return $ret;
     }
 
+    public static function clampMin( $v, $min ) 
+    {
+        $v = self::toInt($v,$min);
+        if( $v < $min ) 
+            return $min;
+        return $v;
+    }
 }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -422,9 +422,14 @@ A note about colours;
 * __comment:__ This is a list of the classes to use to check for bad content. They can only run on non encrypted files as the
                server does not have access otherwise. The URL module accepts a parameter 'url' which is the url to send the
                file content to for scanning. It is expected that the reply is JSON with a passes, error, and reason property.
+               The mime AV program takes an array of MIME types that the content MUST be in using the matchlist parameter.
 
 ```
 $config['avprogram_list'] = array( 'always_pass',
+                                   'mime' => array(
+                                       'name' => 'Check for valid MIME type',
+                                       'matchlist' => array('image/jpeg', 'text/plain')
+                                   ),
                                    'url' => array(
                                        'name' => 'Foo',
                                        'url' => 'http://localhost/foo/scanforfoo.php'

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -423,11 +423,14 @@ A note about colours;
                server does not have access otherwise. The URL module accepts a parameter 'url' which is the url to send the
                file content to for scanning. It is expected that the reply is JSON with a passes, error, and reason property.
                The mime AV program takes an array of MIME types that the content MUST be in using the matchlist parameter.
+               The mime AV program defaults to using the first 8k of content to determine the MIME type, use bytesToConsider
+               to change this. Setting bytesToConsider to values below 8k will have no effect.
 
 ```
 $config['avprogram_list'] = array( 'always_pass',
                                    'mime' => array(
                                        'name' => 'Check for valid MIME type',
+                                       'bytesToConsider' => 8*1024,
                                        'matchlist' => array('image/jpeg', 'text/plain')
                                    ),
                                    'url' => array(


### PR DESCRIPTION
This allows a passing list to be used to explicitly validate uploaded content to be certain MIME types. This may be useful if the server is used to exchange only some mime types to warn users that the file might not be what is expected.
