### PR TITLE
docs: update that encryption_generated_password_length is deprecated

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1256,7 +1256,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 
 
 ### encryption_generated_password_encoding
-* __description:__ which encoding to use to encode generated passwords. Since the random information obtained during password generation is completely random it is useful to encode that into text characters, for example in the range a,b,c etc. By doing this one single byte of random data (0 to 255 inclusive) will likely be encoded to more than one character of output. The base64 encoding turns x bytes of input into 1.33 times as long output. Because ascii85 uses more possible characters it turns each 4 bytes into 5 bytes. This means that for the same length of encoded string the ascii85 will have more entropy. Note that the ascii85 used is the Z85 from ZeroMQ to avoid the use of the quote character in output.
+* __description:__ It is highly recommended to leave the default value. Which encoding to use to encode generated passwords. Since the random information obtained during password generation is completely random it is useful to encode that into text characters, for example in the range a,b,c etc. By doing this one single byte of random data (0 to 255 inclusive) will likely be encoded to more than one character of output. The base64 encoding turns x bytes of input into 1.33 times as long output. Because ascii85 uses more possible characters it turns each 4 bytes into 5 bytes. This means that for the same length of encoded string the ascii85 will have more entropy. Note that the ascii85 used is the Z85 from ZeroMQ to avoid the use of the quote character in output.
 * __mandatory:__ no 
 * __type:__ string
 * __default:__ base64

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -130,7 +130,6 @@ A note about colours;
 * [encryption_password_must_have_numbers](#encryption_password_must_have_numbers)
 * [encryption_password_must_have_special_characters](#encryption_password_must_have_special_characters)
 * [encryption_password_text_only_min_password_length](#encryption_password_text_only_min_password_length)
-* [encryption_generated_password_length](#encryption_generated_password_length)
 * [encryption_key_version_new_files](#encryption_key_version_new_files)
 * [encryption_random_password_version_new_files](#encryption_random_password_version_new_files)
 * [encryption_password_hash_iterations_new_files](#encryption_password_hash_iterations_new_files)
@@ -248,6 +247,9 @@ A note about colours;
 
 * [data_protection_user_frequent_email_address_disabled](#data_protection_user_frequent_email_address_disabled)
 * [data_protection_user_transfer_preferences_disabled](#data_protection_user_transfer_preferences_disabled)
+
+## Deprecated settings
+* [encryption_generated_password_length](#encryption_generated_password_length)
 
 ---
 
@@ -1261,13 +1263,6 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __available:__ since version 2.1
 * __comment:__ either base64 or ascii85 
 
-### encryption_generated_password_length
-* __description:__ The exact number of characters used in a generated password for encryption. This must be equal or greater than encryption_min_password_length.
-* __mandatory:__ no 
-* __type:__ int
-* __default:__ encryption_min_password_length
-* __available:__ since version 2.0
-* __comment:__
 
 
 ### encryption_key_version_new_files

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1256,7 +1256,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 
 
 ### encryption_generated_password_encoding
-* __description:__ It is highly recommended to leave the default value. Which encoding to use to encode generated passwords. Since the random information obtained during password generation is completely random it is useful to encode that into text characters, for example in the range a,b,c etc. By doing this one single byte of random data (0 to 255 inclusive) will likely be encoded to more than one character of output. The base64 encoding turns x bytes of input into 1.33 times as long output. Because ascii85 uses more possible characters it turns each 4 bytes into 5 bytes. This means that for the same length of encoded string the ascii85 will have more entropy. Note that the ascii85 used is the Z85 from ZeroMQ to avoid the use of the quote character in output.
+* __description:__ It is highly recommended to leave the default value (ie not set in your config.php). Which encoding to use to encode generated passwords. Since the random information obtained during password generation is completely random it is useful to encode that into text characters, for example in the range a,b,c etc. By doing this one single byte of random data (0 to 255 inclusive) will likely be encoded to more than one character of output. The base64 encoding turns x bytes of input into 1.33 times as long output. Because ascii85 uses more possible characters it turns each 4 bytes into 5 bytes. This means that for the same length of encoded string the ascii85 will have more entropy. Note that the ascii85 used is the Z85 from ZeroMQ to avoid the use of the quote character in output.
 * __mandatory:__ no 
 * __type:__ string
 * __default:__ base64


### PR DESCRIPTION
Since FileSender 2.9 (released Oct 5, 2019) encryption_random_password_version_new_files has been 2 which is v2019_generated_password_that_is_full_256bit (from crypto_app.js). This password handling has many advantages such as generating a string that contains the entropy that the system desires and also being a password format known to be generated this way it may skip password hashing.

As the encryption_generated_password_length only applies to v2018_text_password I am deprecating it here. Unless you are setting encryption_random_password_version_new_files to 1 explicitly and then looking to set the max length this setting would have no effect. It is strongly recommended to use the default encryption_random_password_version_new_files=2 (or leaving that setting unset to get the default) as introduced in FileSender 2.9 (released Oct 5, 2019).
