### PR TITLE
avprograms: allow download again

### DIFF
--- a/scripts/dev/www-lib-update/update-library-versions-from-node_modules.php
+++ b/scripts/dev/www-lib-update/update-library-versions-from-node_modules.php
@@ -107,3 +107,6 @@ foreach( $packages as $pkg => $d ) {
         copy( $pathnew . '/' . $srcpath, $dstpath );
     }
 }
+
+
+

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -140,7 +140,7 @@ function presentAVName( $v )
         <div class="general2 box" data-transfer-size="<?php echo $transfer->size ?>">
             <div class="avdesc">{tr:av_results_description}
             <?php foreach($transfer->files as $file) { ?>
-                <div class="avfile" data-id="<?php echo $file->id ?>" >
+                <div class="avfile" data-avid="<?php echo $file->id ?>" >
                     <span class="name avheader<?php outputBool($file->av_all_good)?> "><?php echo Utilities::sanitizeOutput($file->path) ?></span>
                     <?php if(!$file->have_avresults) { ?>
                         <span class="desc">{tr:no_av_scans_performed}</span>


### PR DESCRIPTION
Some of the selectors were too general and were getting the avresults files entries instead of the ones from the table as expected.