### PR TITLE
pbkdf2: dismiss the pbkdf2 dialog on a progress message from terasender

### DIFF
--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -124,6 +124,15 @@ window.filesender.pbkdf2dialog = {
         };
     },
 
+    /*
+     * This will call onPBKDF2AllEnded() if it has not already been called.
+     **/
+    ensure_onPBKDF2AllEnded: function() {
+        if( $this.already_complete && !$this.dialog ) {
+            return;
+        }
+        window.filesender.onPBKDF2AllEnded();
+    },
 
     onPBKDF2Over: function() {
         $this = this;

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -411,6 +411,7 @@ window.filesender.terasender = {
                 this.log('Worker job progressed', 'worker:' + worker_id);
                 this.transfer.recordUploadProgressInWatchdog('worker:' + worker_id,data.fine_progress);
                 this.evalProgress(worker_id, data);
+                window.filesender.ensure_onPBKDF2AllEnded();
                 break;
                 
             case 'jobExecuted' :


### PR DESCRIPTION
When terasender_worker sends some data back we know that at least one web worker has started uploading and so we can go ahead and dismiss the pbkdf2 informational window if it is up.
