### PR TITLE
pbkdf2: force the dialog to close on really small fast xfers

### DIFF
--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -411,7 +411,7 @@ window.filesender.terasender = {
                 this.log('Worker job progressed', 'worker:' + worker_id);
                 this.transfer.recordUploadProgressInWatchdog('worker:' + worker_id,data.fine_progress);
                 this.evalProgress(worker_id, data);
-                window.filesender.ensure_onPBKDF2AllEnded();
+                window.filesender.pbkdf2dialog.ensure_onPBKDF2AllEnded();
                 break;
                 
             case 'jobExecuted' :

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1058,6 +1058,7 @@ filesender.ui.startUpload = function() {
     this.transfer.oncomplete = function(time) {
 
         filesender.ui.files.clear_crust_meter_all();
+        window.filesender.pbkdf2dialog.ensure_onPBKDF2AllEnded();
         
         var redirect_url = filesender.ui.transfer.options.redirect_url_on_complete;
         if(redirect_url) {


### PR DESCRIPTION
Close the pbkdf2 dialog before opening the success dialog.