### PR TITLE
fix Chunked storage free space check, while not breaking standard class

### DIFF
--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -146,6 +146,9 @@ class StorageFilesystem
         // Organize files by their storage path, get free space for each path
         foreach ($transfer->files as $file) {
             $path = static::buildPath($file);
+            if (!file_exists($path)) {
+                $path = dirname($path);
+            }
             $filesystem = self::$hashing ? self::getFilesystem($path) : 'main';
             
             if (!array_key_exists($filesystem, $filesystems)) {


### PR DESCRIPTION
fix Chunked storage free space check, while not breaking standard filesystem, as chunked uses a file as a directory that does not exist at time of check so we go one dir up