### PR TITLE
avprograms: record a passing result by the encrypted tester

### DIFF
--- a/classes/avprograms/AVProgram.class.php
+++ b/classes/avprograms/AVProgram.class.php
@@ -63,6 +63,7 @@ abstract class AVProgram
                 DBConstantAVProgram::URL          => new AVProgramURL(),
                 DBConstantAVProgram::TOOBIG       => new AVProgramTooBig(),
                 DBConstantAVProgram::MIME         => new AVProgramMIME(),
+                DBConstantAVProgram::ENCRYPTED    => new AVProgramEncrypted(),
             );
         }
         if( !self::$programList ) {

--- a/classes/avprograms/AVProgramEncrypted.class.php
+++ b/classes/avprograms/AVProgramEncrypted.class.php
@@ -37,15 +37,14 @@ if (!defined('FILESENDER_BASE')) {
 
 /**
  */
-class AVProgramTooBig extends AVProgram
+class AVProgramEncrypted extends AVProgram
 {
-    
     public function inspect( $file )
     {
-        $appid = DBConstantAVProgram::lookup( DBConstantAVProgram::TOOBIG );
-        echo "AVProgramTooBig on file " . $file->id . "\n";
-        $passes = false;
-        $result = AVResult::create( $file, $appid, $this->name, $passes, false, $internaldesc = 'file is too large.' );
+        $appid = DBConstantAVProgram::lookup( DBConstantAVProgram::ENCRYPTED );
+        echo "AVProgramEncrypted on file " . $file->id . "\n";
+        $passes = true;
+        $result = AVResult::create( $file, $appid, $this->name, $passes, false, $internaldesc = 'file is encrypted.' );
     }
     
 };

--- a/classes/data/constants/DBConstantAVProgram.class.php
+++ b/classes/data/constants/DBConstantAVProgram.class.php
@@ -50,6 +50,7 @@ class DBConstantAVProgram extends DBConstant
     const URL            = 'url';
     const TOOBIG         = 'toobig';
     const MIME           = 'mime';
+    const ENCRYPTED      = 'encrypted';
     
     protected function getEnum()
     {
@@ -61,6 +62,7 @@ class DBConstantAVProgram extends DBConstant
             self::URL           => 5,
             self::TOOBIG        => 6,
             self::MIME          => 7,
+            self::ENCRYPTED     => 8,
         );
     }
 

--- a/scripts/task/execute-av-program-on-files.php
+++ b/scripts/task/execute-av-program-on-files.php
@@ -45,6 +45,7 @@ foreach(array_slice($argv, 1) as $arg) {
 $maxsizetoscan = Config::get("avprogram_max_size_to_scan");
 $avprograms = AVProgram::getActiveProgramList();
 $toobig = new AVProgramTooBig();
+$encr = new AVProgramEncrypted();
 
 if( !count($avprograms)) {
     $emsg = "No AV programs are defined\n"
@@ -68,9 +69,15 @@ while( true ) {
     
     foreach( $fileList as $file ) {
         echo "Looking at file " . $file->id . "\n";
-        if( !$file->is_encrypted ) {
+        
+        if( $file->is_encrypted )
+        {
+            $encr->inspect( $file );
+        }
+        else
+        {
             if( $file->size > $maxsizetoscan ) {
-                $toobig->insepect( $file );
+                $toobig->inspect( $file );
             } else {
                 foreach( $avprograms as $prg ) {
                     $prg->inspect( $file );


### PR DESCRIPTION
For encrypted content to avoid it being returned by File::findFilesWithoutAVResults().

This will avoid encrypted files being returned more than once for inspection.
