### PR TITLE
upload page explicitly hide ui messages when generating password

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -207,19 +207,19 @@ if( $encryption_mandatory ) {
                             <label for="encryption_password" class="cursor" >{tr:file_encryption_password} : </label>
                             <input class="encryption_password" id="encryption_password" name="encryption_password" type="password" autocomplete="new-password" readonly />
                         </div>
-                        <div class="fieldcontainer" id="encryption_password_container_too_short_message">
+                        <div class="fieldcontainer passwordvalidation" id="encryption_password_container_too_short_message">
                             {tr:file_encryption_password_too_short}
                         </div>
-                        <div class="fieldcontainer" id="encryption_password_container_must_have_numbers_message">
+                        <div class="fieldcontainer passwordvalidation" id="encryption_password_container_must_have_numbers_message">
                             {tr:file_encryption_password_must_have_numbers}
                         </div>
-                        <div class="fieldcontainer" id="encryption_password_container_must_have_upper_and_lower_case_message">
+                        <div class="fieldcontainer passwordvalidation" id="encryption_password_container_must_have_upper_and_lower_case_message">
                             {tr:file_encryption_password_must_have_upper_and_lower_case}
                         </div>
-                        <div class="fieldcontainer" id="encryption_password_container_must_have_special_characters_message">
+                        <div class="fieldcontainer passwordvalidation" id="encryption_password_container_must_have_special_characters_message">
                             {tr:file_encryption_password_must_have_special_characters}
                         </div>
-                        <div class="fieldcontainer" id="encryption_password_container_can_have_text_only_min_password_length_message">
+                        <div class="fieldcontainer passwordvalidation" id="encryption_password_container_can_have_text_only_min_password_length_message">
                             {tr:encryption_password_container_can_have_text_only_min_password_length_message}
                         </div>
                         

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -532,6 +532,7 @@ filesender.ui.files = {
         var pass = input.val();
         var invalid = false;
         var msg = null;
+
         
         if( filesender.ui.transfer.encryption_password_version == 
             crypto.crypto_password_version_constants.v2018_text_password )
@@ -550,6 +551,27 @@ filesender.ui.files = {
             }
         }
 
+        var v = filesender.ui.nodes.encryption.use_generated.is(':checked');
+        if( v ) {
+            slideMessage = true;
+            filesender.ui.files.updatePasswordMustHaveMessage(
+                slideMessage, false,
+                $('#encryption_password_container_can_have_text_only_min_password_length_message'));
+            filesender.ui.files.updatePasswordMustHaveMessage(
+                slideMessage, false,
+                $('#encryption_password_container_too_short_message'));
+            filesender.ui.files.updatePasswordMustHaveMessage(
+                slideMessage, false,
+                $('#encryption_password_container_must_have_upper_and_lower_case_message'));
+            filesender.ui.files.updatePasswordMustHaveMessage(
+                slideMessage, false,
+                $('#encryption_password_container_must_have_numbers_message'));
+            filesender.ui.files.updatePasswordMustHaveMessage(
+                slideMessage, false,
+                $('#encryption_password_container_must_have_special_characters_message'));
+            return true;
+        }
+  
         //
         // Very long text passwords might be allowed by sys admin.
         //
@@ -1650,8 +1672,8 @@ $(function() {
             // so we must reset that here if the user starts modifying the password.
             filesender.ui.transfer.encryption_password_version = crypto.crypto_password_version_constants.v2018_text_password;
             filesender.ui.transfer.encryption_password_encoding = 'none';            
+            filesender.ui.files.checkEncryptionPassword(filesender.ui.nodes.encryption.password, true );
         }
-       
     });
     
     filesender.ui.nodes.encryption.generate.on('click', function() {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -554,21 +554,11 @@ filesender.ui.files = {
         var v = filesender.ui.nodes.encryption.use_generated.is(':checked');
         if( v ) {
             slideMessage = true;
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, false,
-                $('#encryption_password_container_can_have_text_only_min_password_length_message'));
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, false,
-                $('#encryption_password_container_too_short_message'));
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, false,
-                $('#encryption_password_container_must_have_upper_and_lower_case_message'));
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, false,
-                $('#encryption_password_container_must_have_numbers_message'));
-            filesender.ui.files.updatePasswordMustHaveMessage(
-                slideMessage, false,
-                $('#encryption_password_container_must_have_special_characters_message'));
+            $('.passwordvalidation').each(function( index ) {
+                filesender.ui.files.updatePasswordMustHaveMessage(
+                    slideMessage, false,
+                    $( this ));
+            });
             return true;
         }
   


### PR DESCRIPTION
When generate password is on the UI elements that relate to password validation are now explicitly hidden and are reenabled and tested when genereate is turned off.