### PR TITLE
s3 storage, default to filesender chunk size equals stream chunk size

### DIFF
--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -232,6 +232,7 @@ class StorageCloudS3 extends StorageFilesystem
         StorageCloudS3Stream::ensureRegistered();
         $path = "StorageCloudS3Stream://" . $file->uid;
         $fp = fopen($path, "r+");
+        stream_set_chunk_size($fp, Config::get('upload_chunk_size'));
         return $fp;
     }
 }


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/1054