### PR TITLE
allow zip stream size and filesender chunk size to match

### DIFF
--- a/classes/utils/Archiver.class.php
+++ b/classes/utils/Archiver.class.php
@@ -221,6 +221,8 @@ class Archiver
             header("Content-Length: $contentLength");
             
             $zip = new ZipStreamer\ZipStreamer();
+            // make chunk sizes match for network IO efficiency.
+            $zip->STREAM_CHUNK_SIZE = Config::get('upload_chunk_size');
             $filename .= '.zip';
             
             $zip->sendHeaders($filename, "application/octet-stream");

--- a/lib/PHPZipStreamer/src/ZipStreamer.php
+++ b/lib/PHPZipStreamer/src/ZipStreamer.php
@@ -56,7 +56,7 @@ class ZipStreamer {
 
   const ATTR_MADE_BY_VERSION = 0x032d; // made by version  (upper byte: UNIX, lower byte v4.5)
 
-  const STREAM_CHUNK_SIZE = 1048560; // 16 * 65535 = almost 1mb chunks, for best deflate performance
+  public $STREAM_CHUNK_SIZE = 1048560; // 16 * 65535 = almost 1mb chunks, for best deflate performance
 
   private $extFileAttrFile;
   private $extFileAttrDir;
@@ -400,7 +400,7 @@ class ZipStreamer {
       $compStream = DeflateStream::create($level);
     }
 
-    while (!feof($stream) && $data = fread($stream, self::STREAM_CHUNK_SIZE)) {
+    while (!feof($stream) && $data = fread($stream, $this->STREAM_CHUNK_SIZE)) {
       $dataLength->add(strlen($data));
       hash_update($hashCtx, $data);
       if (COMPR::DEFLATE === $compress) {

--- a/lib/run-this-after-composer-to-update-files.sh
+++ b/lib/run-this-after-composer-to-update-files.sh
@@ -2,3 +2,7 @@
 
 
 cp -f vendor/owasp/csrf-protector-php/js/csrfprotector.js ../www/js/
+
+sed -i -e 's/self::STREAM_CHUNK_SIZE/$this->STREAM_CHUNK_SIZE/g' PHPZipStreamer/src/ZipStreamer.php
+sed -i -e 's/const STREAM_CHUNK_SIZE = 1048560/public $STREAM_CHUNK_SIZE = 1048560/g' PHPZipStreamer/src/ZipStreamer.php
+


### PR DESCRIPTION
If this proves to improve performance then I'll have to look at pushing the update upstream to allow STREAM_CHUNK_SIZE to be modified without changing the source file.