### PR TITLE
added encryption symbol (key) to transfers table

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -209,6 +209,9 @@ if (!function_exists('clickableHeader')) {
             
             <td class="transfer_id">
                 <?php echo $transfer->id ?>
+                <?php if($transfer->getOption(TransferOptions::ENCRYPTION)) { ?>
+                        <span class='right'> &#128273;</span>
+                <?php } ?>
             </td>
             
             <?php if($show_guest) { ?>
@@ -316,7 +319,11 @@ if (!function_exists('clickableHeader')) {
                     <tbody>
                         <tr>
                             <td class="desc">{tr:transfer_id}</td>
-                            <td><?php echo $transfer->id ?></td>
+                            <td><?php echo $transfer->id ?>
+                            <?php if($transfer->getOption(TransferOptions::ENCRYPTION)) { ?>
+                                <span class='right'> &#128273;</span>
+                            <?php } ?>
+                            </td>
                         </tr>
                         <tr>
                             <td class="desc">{tr:created}</td>


### PR DESCRIPTION
We use this to show encrypted transfers beside the transferid in the transfers table. Maybe it finds the way to the origin filesender.
![image](https://user-images.githubusercontent.com/7682804/124143132-27531e00-da8b-11eb-8aa5-385ee93f0f1a.png)
