### PR TITLE
ability to disable guest system

### DIFF
--- a/classes/exceptions/GuestExceptions.class.php
+++ b/classes/exceptions/GuestExceptions.class.php
@@ -189,3 +189,20 @@ class GuestExpiryExtensionCountExceededException extends GuestException
         parent::__construct($transfer, 'expiry_extension_count_exceeded');
     }
 }
+
+
+/**
+ * Guest system disabled and creation attempt made
+ */
+class GuestSystemDisabledException extends GuestException
+{
+    /**
+     * Constructor
+     *
+     * @param Transfer $transfer
+     */
+    public function __construct($user)
+    {
+        parent::__construct($user,'guest_create_attempted_while_system_disabled');
+    }
+}

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -166,7 +166,7 @@ class RestEndpointGuest extends RestEndpoint
         // User who is creating the new guest
         $user = Auth::user();
 
-        if(Utilities::isFalse(Config::get('guest_support_enabled'))) {
+        if(!Config::get('guest_support_enabled')) {
             throw new GuestSystemDisabledException($user);
         }
 

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -166,6 +166,10 @@ class RestEndpointGuest extends RestEndpoint
         // User who is creating the new guest
         $user = Auth::user();
 
+        if(Utilities::isFalse(Config::get('guest_support_enabled'))) {
+            throw new GuestSystemDisabledException($user);
+        }
+
         // Raw guest data
         $data = $this->request->input;
 

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -345,10 +345,17 @@ class Config
         ClientLog::validateConfig();
     }
 
+   /**
+    * This makes sure the value for $k is a boolean using isTrue() to coerce.
+    *
+    * @return the updated value for Config::get($k) which is also assigned internally.
+    */
     private static function forceLoadedToBool($k)
     {
         $v = Config::get($k);
-        self::$parameters[$k] = Utilities::isTrue($v);
+        $v = Utilities::isTrue($v);
+        self::$parameters[$k] = $v;
+        return $v;
     }
     
     public static function performLongerValidation()

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -336,7 +336,8 @@ class Config
         // force to bool
         $v = Utilities::isTrue(self::get('data_protection_user_frequent_email_address_disabled'));
         self::$parameters['data_protection_user_frequent_email_address_disabled'] = $v;
-        
+
+        self::forceLoadedToBool('guest_support_enabled');
 
         
         // verify classes are happy
@@ -344,6 +345,11 @@ class Config
         ClientLog::validateConfig();
     }
 
+    private static function forceLoadedToBool($k)
+    {
+        $v = Config::get($k);
+        self::$parameters[$k] = Utilities::isTrue($v);
+    }
     
     public static function performLongerValidation()
     {

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -417,6 +417,12 @@ class GUI
         if (!GUIPages::isValidValue($page)) {
             throw new GUIUnknownPageException($page);
         }
+
+        // no guests page if disabled
+        if(!Config::get('guest_support_enabled') && $page == 'guests') {
+            throw new GUIUnknownPageException($page);
+        }
+        
         
         return in_array($page, self::allowedPages());
     }

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -437,6 +437,10 @@ class Utilities
     {
         return $v == '1' || $v == 'true';
     }
+    public static function isFalse($v)
+    {
+        return !self::isTrue($v);
+    }
     public static function boolToString($v)
     {
         if( $v == '1' || $v == 'true' ) {

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -173,6 +173,7 @@ A note about colours;
 
 ## Guest use
 
+* [guest_support_enabled](#guest_support_enabled)
 * [guest_options](#guest_options)
 * [default_guest_days_valid](#default_guest_days_valid)
 * [max_guest_days_valid](#max_guest_days_valid)
@@ -1663,6 +1664,19 @@ This is only for old, existing transfers which have no roundtriptoken set.
 ## Guest use
 
 ---
+
+
+### guest_support_enabled
+
+* __description:__ Allow users to create guests.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ true
+* __available:__ since version 2.30
+* __1.x name:__
+* __comment:__ Setting this to false will disable the guest system and fail on attempts to create a guest if they are directly attempted.
+
+
 
 ### guest_options
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -184,6 +184,7 @@ $default = array(
     'message_can_not_contain_urls_regex' => '',
 //    'message_can_not_contain_urls_regex' => '(ftp:|http[s]*:|[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})',
 
+    'guest_support_enabled' => true,
     'guest_limit_per_user' => 50,
     'guest_create_limit_per_day' => 0,
     'guest_reminder_limit' => 50,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -669,3 +669,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['guest_create_attempted_while_system_disabled'] = 'Guest system is disabled, you should not have been offered the choice to make a guest';

--- a/templates/admin_page.php
+++ b/templates/admin_page.php
@@ -2,6 +2,10 @@
     <?php
     
     $sections = array('transfers', 'guests', 'users', 'testing' );
+
+    if(Utilities::isFalse(Config::get('guest_support_enabled'))) {
+        $sections = array_diff($sections,['guests']);
+    }
     
     if(Config::get('config_overrides'))
         $sections[] = 'config';

--- a/templates/admin_page.php
+++ b/templates/admin_page.php
@@ -3,7 +3,7 @@
     
     $sections = array('transfers', 'guests', 'users', 'testing' );
 
-    if(Utilities::isFalse(Config::get('guest_support_enabled'))) {
+    if(!Config::get('guest_support_enabled')) {
         $sections = array_diff($sections,['guests']);
     }
     

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -16,8 +16,10 @@ $maybe_display_aggregate_statistics_menu = false;
             
             if(!Auth::isGuest()) {
                 pagemenuitem('upload');
-                
-                pagemenuitem('guests');
+
+                if(Utilities::isTrue(Config::get('guest_support_enabled'))) {
+                    pagemenuitem('guests');
+                }
                 
                 pagemenuitem('transfers');
                 

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -17,7 +17,7 @@ $maybe_display_aggregate_statistics_menu = false;
             if(!Auth::isGuest()) {
                 pagemenuitem('upload');
 
-                if(Utilities::isTrue(Config::get('guest_support_enabled'))) {
+                if(Config::get('guest_support_enabled')) {
                     pagemenuitem('guests');
                 }
                 


### PR DESCRIPTION
This does not delete existing guests. The default for the new option is to allow guests. Existing systems need not do anything.

A admin may elect to not allow guests by setting in config.php
```
$config['guest_support_enabled'] = false;
```

With this setting in place FileSender will 
* remove the menu item to access the guests page
* fail to load the guests page if explicitly attempted
* fail to create a new guest if explicitly attempted via the REST api.

This relates to https://github.com/filesender/filesender/issues/1123
