### PR TITLE
A new option to only allow downloads from authenticated users.

### DIFF
--- a/classes/constants/TransferOptions.class.php
+++ b/classes/constants/TransferOptions.class.php
@@ -53,4 +53,5 @@ class TransferOptions extends Enum
 
     const ENCRYPTION                                = 'encryption';
     const COLLECTION                                = 'collection';
+    const MUST_BE_LOGGED_IN_TO_DOWNLOAD             = 'must_be_logged_in_to_download';
 }

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1030,6 +1030,9 @@ class Transfer extends DBObject
         if ($property == "get_a_link") {
             return $this->getOption(TransferOptions::GET_A_LINK);
         }
+        if ($property == "must_be_logged_in_to_download") {
+            return $this->getOption(TransferOptions::MUST_BE_LOGGED_IN_TO_DOWNLOAD);
+        }
         
         if ($property == 'size') {
             return array_sum(array_map(function ($file) {

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -426,4 +426,25 @@ class GUI
         
         return in_array($page, self::allowedPages());
     }
+
+    /**
+     * Make a login button with css class $addedClass. If present, the $target
+     * should be the result of a call to Utilities::http_build_query()
+     * which may wish to use the 's' parameter to set the page to use after login
+     * as well as any other state that page might want.
+     */
+    public static function getLoginButton($target = null,$addedClass=null)
+    {
+        if(!$addedClass) {
+            $addedClass = '';
+        }
+        
+        $embed = Config::get('auth_sp_embed');
+        
+        if(!$embed) {
+            $embed = '<a class="'.$addedClass.'" id="btn_logon" href="'.AuthSP::logonURL($target).'">'.Lang::tr('logon').'</a>';
+        }
+        
+        return $embed;
+    }
 }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1162,7 +1162,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __default:__
 * __available:__ since version 2.0
 * __1.x name:__
-* __comment:__
+* __comment:__ For current defaults see https://github.com/filesender/filesender/search?q=transfer_options+in%3Afile+path%3Aincludes
 * __*Standard parameters for all options:*__
 	* __available__(boolean): if set to true then this option shown in the upload form
 	* __advanced__ (boolean): if set to true the option is hidden under an "Advanced options" click-out.  The user must click "Advanced" to make the option visible.
@@ -1179,6 +1179,7 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 	* __add\_me\_to\_recipients:__ include the sender as one of the recipients.
 	* __get\_a\_link:__ if checked it will not send any emails, only present the uploader with a download link once the upload is complete.  This is useful when sending files to mailinglists, newsletters etc.  When ticked the message subject and message text box disappear from the UI.  Under the hood it creates an anonymous recipient with a token for download.  You can se the download count, but not who downloaded it (obviously, as there are no recipients defined).
 	* __redirect_url_on_complete:__ When the transfer upload completes, instead of showing a success message, redirect the user to a URL. This interferes with __get\_a\_link__ in that the uploader will not see the link after the upload completes. Additionally, if the uploader is a guest, there is no way straightforward way for the uploader to learn the download link, although this must not be used as a security feature.
+        * __must_be_logged_in_to_download__ (boolean): To download the files the user must log in to the FileSender server. This allows people to send files to other people they know also use the same FileSender server.
 
 * __*Configuration example:*__
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -355,6 +355,11 @@ $default = array(
             'advanced' => true,
             'default' => ''
         ),
+        'must_be_logged_in_to_download' => array(
+            'available' => true,
+            'advanced' => false,
+            'default' => false
+        ),
     ),
 
     'guest_upload_page_hide_unchangable_options' => false,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -670,3 +670,5 @@ $lang['you_can_report_exception_by_email'] = 'You can report this error by email
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
 $lang['guest_create_attempted_while_system_disabled'] = 'Guest system is disabled, you should not have been offered the choice to make a guest';
+$lang['must_be_logged_in_to_download'] = 'User must login to FileSender to download file(s)';
+$lang['must_be_logged_in_to_download_first_person'] = 'The person who uploaded this file requires that you must be logged in to FileSender in order to download files from this transfer.';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -1,5 +1,7 @@
 <?php
 
+$canDownload = true;
+
 if (!function_exists('str_starts_with')) {
     function str_starts_with($haystack, $needle) {
         return (string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
@@ -37,6 +39,7 @@ function presentAVName( $v )
     <h1>{tr:download_page}</h1>
     
     <?php
+
     
     if(!array_key_exists('token', $_REQUEST))
         throw new TokenIsMissingException();
@@ -86,6 +89,28 @@ function presentAVName( $v )
             $canDownloadArchive = true;
         }
     }
+
+
+    
+    if( $transfer->must_be_logged_in_to_download ) {
+        $user = Auth::user();
+        if( !$user ) {
+
+            $loginToDownload = GUI::getLoginButton(Utilities::http_build_query(array('token' => $token, 's' => 'download')));
+            echo '<div class="must_login_message">';
+            echo Lang::tr('must_be_logged_in_to_download_first_person');
+            echo '<br/>' . $loginToDownload;
+            echo '</div>';
+            
+            $canDownload = false;
+            $canDownloadAsTar = false;
+            $canDownloadAsZip = false;
+            // close page
+            echo "</div>";
+            return;
+        }
+    } 
+    
     ?>
     
     <div class="disclamer">

--- a/templates/logon_page.php
+++ b/templates/logon_page.php
@@ -3,13 +3,7 @@
     
     <div class="logon">
         <?php
-        
-        $embed = Config::get('auth_sp_embed');
-        
-        if(!$embed) $embed = '<a id="btn_logon" href="'.AuthSP::logonURL().'">'.Lang::tr('logon').'</a>';
-        
-        echo $embed;
-        
+        echo GUI::getLoginButton();
         ?>
     </div>
 </div>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -184,6 +184,14 @@ abbr {
     background-color: rgb(151,51,51);
 }
 
+.must_login_message {
+    background-color: rgb(251,201,201);
+    border: 1px solid;
+    border-radius: 0.5em;
+    -moz-border-radius: 0.5em;
+    padding: 0.4em 0.4em 0.4em 32px;
+    margin: 2em 5em;
+}
 
 #menu ul li select {
     display: block;
@@ -1278,6 +1286,7 @@ table.guests .guest .to .errors .details {
     float: right;
     margin-top: -0.5em;
 }
+
 
 .download_page .archive {
     margin-top: 1em;

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -229,11 +229,10 @@ $(function() {
 
         filesender.client.getTransferOption(transferid, 'enable_recipient_email_download_complete', token, function(dl_complete_enabled){
             dl(id, dl_complete_enabled, encrypted, progress );
-        });
-        
+        });        
         return false;
     });
-
+    
     var dlArchive = function( archive_format ) {
         var ids = [];
         page.find('.file[data-selected="1"]').each(function() {


### PR DESCRIPTION
A new transfer option (false by default) to allow a user to force the downloading user to authenticate with the FileSender server in order to download files. This might be handy when a user knows that the recipients are all users of the same system for example, they are at the same university or organization.

This relates to https://github.com/filesender/filesender/issues/1066.
