### PR TITLE
download counter: count every time

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -226,6 +226,7 @@ A note about colours;
 * [exception_additional_logging_regex](#exception_additional_logging_regex)
 * [clientlogs_stashsize](#clientlogs_stashsize)
 * [clientlogs_lifetime](#clientlogs_lifetime)
+* [logs_limit_messages_from_same_ip_address](#logs_limit_messages_from_same_ip_address)
 
 
 ## Webservices API
@@ -2309,6 +2310,23 @@ $config['log_facilities'] =
 * __default:__ 10
 * __available:__ since version 2.0
 * __comment:__ Number of days after which collected client logs are automatically deleted.
+
+
+### logs_limit_messages_from_same_ip_address
+
+* __description:__ An option to limit how frequently transfers from the same IP address are logged
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.30
+* __comment:__ In version 2.30 the default action of not logging frequent items from the same IP address was turned off.
+        This option allows that throttle limit to be turned back on again if not have it causes major problems. If this
+        setting with the default of false works ok for people then the option may be removed and the default of not
+        limiting logs will be the only option. So in short, you may not ever need to know about or set this option. It
+        is here as a fallback if there are issues with it being turned off.
+
+
+
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -298,6 +298,7 @@ $default = array(
     'avprogram_list' => array(),
     'avprogram_max_size_to_scan' => 100*1024*1024,
     
+    'logs_limit_messages_from_same_ip_address' => false,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/www/download.php
+++ b/www/download.php
@@ -105,7 +105,11 @@ try {
     session_write_close();
     
     // Check if file set has already been downloaded over the last hour
-    $recently_downloaded = $recipient ? AuditLog::clientRecentlyDownloaded($recipient, $files_ids) : false;
+    if( Config::get('logs_limit_messages_from_same_ip_address')) {
+        $recently_downloaded = $recipient ? AuditLog::clientRecentlyDownloaded($recipient, $files_ids) : false;
+    } else {
+        $recently_downloaded = false;
+    }
 
     $archive_format_selected = false;
     $archive_format = "zip";


### PR DESCRIPTION
The logging of downloads is no longer subjected to a IP address filter. This will allow many downloads from the same IPv4 nat address to all be counted.

The throttling was initially introduced because of too much log activity. As such I have turned off this filtering as a configuration option (filtering off by default in 2.30). If this causes problems a single config directive will revert to previous behaviour. Setting the config option logs_limit_messages_from_same_ip_address to `true` will revert to previous behaviour of limiting the logs for given IP addresses.

My plan is to remove the logs_limit_messages_from_same_ip_address and the option to filter in a subsequent release once we know that not performing filtering is not causing a major issue.

This relates to https://github.com/filesender/filesender/issues/908.

