### PR TITLE
Add a service wide AUP with basic versioning

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -277,6 +277,22 @@ class Auth
     }
 
     /**
+     * Return current user or guest if it exists.
+     */
+    public static function getPrincipal()
+    {
+        $principal = null;
+        
+        if (Auth::isGuest()) {
+            $principal = AuthGuest::getGuest();
+        }
+        if( !$principal ) {
+            $principal = Auth::user();
+        }
+        return $principal;
+    }
+
+    /**
      * Reset the current user to the given data, creating database records if needed.
      * This function should only be called from testing code that is executed locally.
      *

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -184,7 +184,7 @@ class Guest extends DBObject
     protected $reminder_count = 0;
     protected $last_reminder = 0;
     protected $expiry_extensions = 0;
-    protected $service_aup_accepted_version = null;
+    protected $service_aup_accepted_version = 0;
     protected $service_aup_accepted_time = null;
 
     /**

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -116,6 +116,18 @@ class Guest extends DBObject
             'size' => 'small',
             'default' => 0
         ),
+
+        // Shared guest/user Principal options
+        'service_aup_accepted_version' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'null' => false,
+            'default' => 0
+        ),
+        'service_aup_accepted_time' => array(
+            'type' => 'datetime',
+            'null' => true
+        ),
     );
 
     public static function getViewMap()
@@ -127,6 +139,7 @@ class Guest extends DBObject
                         . DBView::columnDefinition_age($dbtype, 'expires')
                         . DBView::columnDefinition_age($dbtype, 'last_activity', 'last_activity_days_ago')
                         . DBView::columnDefinition_age($dbtype, 'last_reminder', 'last_reminder_days_ago')
+                        . DBView::columnDefinition_age($dbtype, 'service_aup_accepted_time', 'service_aup_accepted_time_days_ago')
                         . ' , expires < now() as expired '
                         . " , status = 'available' as is_available "
                         . '  from ' . self::getDBTable();
@@ -171,6 +184,8 @@ class Guest extends DBObject
     protected $reminder_count = 0;
     protected $last_reminder = 0;
     protected $expiry_extensions = 0;
+    protected $service_aup_accepted_version = null;
+    protected $service_aup_accepted_time = null;
 
     /**
      * Cache
@@ -676,7 +691,7 @@ class Guest extends DBObject
         if (in_array($property, array(
             'id', 'user_email', 'token', 'email', 'transfer_count',
             'subject', 'message', 'options', 'transfer_options', 'status', 'created', 'expires', 'last_activity', 'userid'
-            , 'expiry_extensions'
+            , 'expiry_extensions', 'service_aup_accepted_version', 'service_aup_accepted_time'
         ))) {
             return $this->$property;
         }
@@ -833,6 +848,10 @@ class Guest extends DBObject
                 }
                 $this->$property = (string)$value;
             }
+        } elseif ($property == 'service_aup_accepted_version') {
+            $this->service_aup_accepted_version = $value;
+        } elseif ($property == 'service_aup_accepted_time') {
+            $this->service_aup_accepted_time = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -173,7 +173,7 @@ class User extends DBObject
     protected $auth_secret_created = null;
     protected $quota = 0;
     protected $guest_expiry_default_days = null;
-    protected $service_aup_accepted_version = null;
+    protected $service_aup_accepted_version = 0;
     protected $service_aup_accepted_time = null;
 
     

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -116,6 +116,18 @@ class User extends DBObject
             'null' => true,
             'default' => null
         ),
+
+        // Shared guest/user Principal options
+        'service_aup_accepted_version' => array(
+            'type' => 'uint',
+            'size' => 'medium',
+            'null' => false,
+            'default' => 0
+        ),
+        'service_aup_accepted_time' => array(
+            'type' => 'datetime',
+            'null' => true
+        ),
     );
 
 
@@ -129,6 +141,7 @@ class User extends DBObject
                         . DBView::columnDefinition_is_encrypted('transfer_preferences', 'prefers_enceyption')
                         . DBView::columnDefinition_age($dbtype, 'last_activity', 'last_activity_days_ago')
                         . DBView::columnDefinition_age($dbtype, 'aup_last_ticked_date', 'aup_last_ticked_days_ago')
+                        . DBView::columnDefinition_age($dbtype, 'service_aup_accepted_time', 'service_aup_accepted_time_days_ago')
                         . ' , id as email_address '
                         . ' , id is not null as is_active '
                                 . '  from ' . self::getDBTable();
@@ -160,7 +173,10 @@ class User extends DBObject
     protected $auth_secret_created = null;
     protected $quota = 0;
     protected $guest_expiry_default_days = null;
+    protected $service_aup_accepted_version = null;
+    protected $service_aup_accepted_time = null;
 
+    
     /** 
      * These are not real properties and are used by queries in the
      * system to return additional data about a user from the query.
@@ -639,7 +655,7 @@ class User extends DBObject
             'auth_secret_created',
             'transfer_preferences', 'guest_preferences', 'frequent_recipients', 'created', 'last_activity',
             'email_addresses', 'name', 'quota', 'authid'
-          , 'guest_expiry_default_days'
+          , 'guest_expiry_default_days', 'service_aup_accepted_version', 'service_aup_accepted_time'
         ))) {
             return $this->$property;
         }
@@ -731,6 +747,10 @@ class User extends DBObject
             if( $this->guest_expiry_default_days == 0 ) {
                 $this->guest_expiry_default_days = null;
             }
+        } elseif ($property == 'service_aup_accepted_version') {
+            $this->service_aup_accepted_version = $value;
+        } elseif ($property == 'service_aup_accepted_time') {
+            $this->service_aup_accepted_time = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/exceptions/RestExceptions.class.php
+++ b/classes/exceptions/RestExceptions.class.php
@@ -262,3 +262,19 @@ class RestCannotAddDataToCompleteTransferException extends RestException
         parent::__construct('cannot_add_data_to_complete_transfer', 400, array('target_type' => $target_type, 'target_id' => $target_id));
     }
 }
+
+/**
+ * REST error if the user or guest can not be found.
+ */
+class RestUnknownPrincipalException extends RestException
+{
+    /**
+     * Constructor
+     *
+     * @param string $name name of the missing parameter
+     */
+    public function __construct()
+    {
+        parent::__construct('rest_unknown_principal', 404, array());
+    }
+}

--- a/classes/rest/endpoints/RestEndpointPrincipal.class.php
+++ b/classes/rest/endpoints/RestEndpointPrincipal.class.php
@@ -81,6 +81,9 @@ class RestEndpointPrincipal extends RestEndpoint
         
         if( $data->service_aup_version ) {
 
+            if( $data->service_aup_version != Config::get('service_aup_min_required_version')) {
+                throw new RestBadParameterException('service_aup_version');
+            }
             $principal->service_aup_accepted_version = $data->service_aup_version;
             $principal->service_aup_accepted_time = time();
             $principal->save();

--- a/classes/rest/endpoints/RestEndpointPrincipal.class.php
+++ b/classes/rest/endpoints/RestEndpointPrincipal.class.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ * REST principal endpoint
+ */
+class RestEndpointPrincipal extends RestEndpoint
+{
+    
+    
+    
+    /**
+     * Get info about a principal
+     *
+     * This is not possible yet.
+     *
+     * @throws RestAuthenticationRequiredException
+     * @throws RestBadParameterException
+     * @throws RestMissingParameterException
+     * @throws RestOwnershipRequiredException
+     * @throws AuthRemoteUserRejectedException
+     */
+    public function get($id = null, $property = null)
+    {
+        throw new RestBadParameterException('bad_attempt');
+    }
+    
+    /**
+     * Set user preference
+     *
+     * Call examples :
+     *  /principal/ : set preferences of principal
+     *
+     * @return mixed
+     *
+     * @throws RestAuthenticationRequiredException
+     * @throws RestOwnershipRequiredException
+     */
+    public function put($id = null)
+    {
+        $principal = Auth::getPrincipal();
+        if( !$principal ) {
+            throw new RestUnknownPrincipalException();
+        }
+        
+        $data = $this->request->input;
+        
+        if( $data->service_aup_version ) {
+
+            $principal->service_aup_accepted_version = $data->service_aup_version;
+            $principal->service_aup_accepted_time = time();
+            $principal->save();
+        }
+        return true;
+    }
+
+
+    /**
+     * Create new principal
+     *
+     * This is not possible.
+     *
+     * @throws RestAuthenticationRequiredException
+     * @throws RestOwnershipRequiredException
+     */
+    public function post($id = null, $add = null)
+    {
+        throw new RestBadParameterException('bad_attempt');
+    }
+}

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -292,7 +292,7 @@ class RestEndpointUser extends RestEndpoint
             if (!Auth::user()->is($user) && !Auth::isAdmin()) {
                 throw new RestOwnershipRequiredException(Auth::user()->id, 'user = '.$user->id);
             }
-        } else {
+        } else {        
             $user = Auth::user();
         }
         

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -29,7 +29,7 @@ A note about colours;
 * [admin_can_view_user_transfers_page](#admin_can_view_user_transfers_page)
 * [mime_type_regex](#mime_type_regex)
 * [mime_type_default](#mime_type_default)
-
+* [service_aup_min_required_version](#service_aup_min_required_version)
 
 ## Security settings
 * [use_strict_csp](#use_strict_csp)
@@ -397,6 +397,17 @@ A note about colours;
 * __default:__ application/octet-stream
 * __available:__ since version 2.29
 * __comment:__ Some failures are worse than others. This is the default mimetype to use if a client presents an invalid value.
+
+
+### service_aup_min_required_version
+
+* __description:__ If the site uses a service level AUP this is the current minimum version a user must have accepted to continue to upload files.
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 0
+* __available:__ since version 2.30
+* __comment:__ A setting of 0 disables the site wide AUP. Setting to 1 will enable AUP and force the user to accept the text from the language translation service_aup_text_version_1. If you were on level 1 and change service_aup_min_required_version=2 anyone who has not accepted or has only accepted service_aup_text_version_1 will be prompted to accept service_aup_text_version_2 after loading the next page. This continues onward allowing new AUP text and terms to be introduced and explicitly seeking user acceptance before they can continue to upload to the service.
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -299,6 +299,9 @@ $default = array(
     'avprogram_max_size_to_scan' => 100*1024*1024,
     
     'logs_limit_messages_from_same_ip_address' => false,
+
+
+    'service_aup_min_required_version' => 0,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -672,3 +672,10 @@ $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at:
 $lang['guest_create_attempted_while_system_disabled'] = 'Guest system is disabled, you should not have been offered the choice to make a guest';
 $lang['must_be_logged_in_to_download'] = 'User must login to FileSender to download file(s)';
 $lang['must_be_logged_in_to_download_first_person'] = 'The person who uploaded this file requires that you must be logged in to FileSender in order to download files from this transfer.';
+$lang['service_aup_text_version_1'] = 'Do not try to hack the site. Do not upload stuff that you know is not correct to do';
+$lang['service_aup_header'] = 'FileSender service Acceptable User Terms';
+$lang['service_aup_body_version_1'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v1 <p>';
+$lang['service_aup_body_version_2'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v2 <p>';
+$lang['service_aup_body_version_3'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v3 <p>';
+
+

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -672,10 +672,9 @@ $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at:
 $lang['guest_create_attempted_while_system_disabled'] = 'Guest system is disabled, you should not have been offered the choice to make a guest';
 $lang['must_be_logged_in_to_download'] = 'User must login to FileSender to download file(s)';
 $lang['must_be_logged_in_to_download_first_person'] = 'The person who uploaded this file requires that you must be logged in to FileSender in order to download files from this transfer.';
-$lang['service_aup_text_version_1'] = 'Do not try to hack the site. Do not upload stuff that you know is not correct to do';
 $lang['service_aup_header'] = 'FileSender service Acceptable User Terms';
-$lang['service_aup_body_version_1'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v1 <p>';
-$lang['service_aup_body_version_2'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v2 <p>';
-$lang['service_aup_body_version_3'] = 'To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v3 <p>';
+$lang['service_aup_body_version_1'] = '<p>To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v1 </p>';
+$lang['service_aup_body_version_2'] = '<p>To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v2 </p>';
+$lang['service_aup_body_version_3'] = '<p>To keep everybody happy the use of this FileSender service has some terms which you must accept.</p><p>These terms include:</p><ul><li>Do not try to hack into the site</li><li>Do not upload content which would violate copyright</li></ul> v3 </p>';
 
 

--- a/templates/service_aup_page.php
+++ b/templates/service_aup_page.php
@@ -6,7 +6,7 @@ $ver = Config::get('service_aup_min_required_version');
 
     <h1>{tr:service_aup_header}</h1>
 
-    <p><?php echo Lang::tr('service_aup_body_version_' . $ver ) ?></p>
+    <?php echo Lang::tr('service_aup_body_version_' . $ver ) ?>
     
     <div class="service_aup_accept">
         <a href="#">

--- a/templates/service_aup_page.php
+++ b/templates/service_aup_page.php
@@ -1,0 +1,22 @@
+<?php
+include_once "pagemenuitem.php";
+$ver = Config::get('service_aup_min_required_version');
+?>
+<div class="box serviceaup" data-service-aup-version="<?php echo $ver ?>">
+
+    <h1>{tr:service_aup_header}</h1>
+
+    <p><?php echo Lang::tr('service_aup_body_version_' . $ver ) ?></p>
+    
+    <div class="service_aup_accept">
+        <a href="#">
+            <span class="fa fa-lg fa-check"></span>
+            {tr:ui2_accept_aup_1}
+        </a>
+    </div>
+
+    
+    
+</div>
+
+<script type="text/javascript" src="{path:js/service_aup_page.js}"></script>

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1736,3 +1736,12 @@ div.not_displayed {
 .avheader0 {
     color: #AA0000;
 }
+
+.serviceaup ul {
+    margin-bottom: 2em;
+}
+
+.serviceaup ul li {
+    margin-bottom: 0.3em;
+    line-height: 1.1em;
+}

--- a/www/index.php
+++ b/www/index.php
@@ -69,6 +69,23 @@ try {
             if(Config::get('auth_sp_autotrigger')) AuthSP::trigger();
         }
 
+        // Service level AUP
+        if( Config::get('service_aup_min_required_version') > 0 ) {
+
+            $principal = Auth::getPrincipal();
+
+            // If the user just "got a link" they are neither a guest
+            // or a user of the system so we can't really ask them to
+            // accept a service wide AUP because they have no account
+            // to record that information into.
+            if( $principal &&
+                $principal->service_aup_accepted_version < Config::get('service_aup_min_required_version'))
+            {
+                // new service wide AUP to accept for this user/guest
+                GUI::currentPage('service_aup');
+            }
+        }
+        
         if(!in_array($page, array('download', 'maintenance')))
             Template::display('menu');
 

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -754,6 +754,17 @@ window.filesender.client = {
     updateUserIDPreferences: function(id, preferences, callback) {
         return this.put('/user/' + id + '/', preferences, callback);
     },
+    serviceAUPAccept: function(version, callback) {
+        var p = {};
+        p['service_aup_version'] = version;
+        
+        var url = new URL(location);
+        var tailer = '';
+        if( url.searchParams.get("vid")) {
+            tailer = '?vid=' + url.searchParams.get("vid");
+        }
+        return this.put('/principal'+tailer, p, callback );
+    },
     
     getUserQuota: function(callback, onerror) {
         this.get('/user/@me/quota', callback, {ignore_authentication_required: true});

--- a/www/js/service_aup_page.js
+++ b/www/js/service_aup_page.js
@@ -1,0 +1,71 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+$(function() {
+    var page = $('.service_aup_page');
+    if(!page.length) return;
+
+    $('.service_aup_accept a').button().on('click', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+
+        var aup_version = page.find(".serviceaup").attr('data-service-aup-version');
+        window.filesender.log("Principal has accepted service AUP version " + aup_version );
+
+        filesender.client.serviceAUPAccept(aup_version, function() {
+            filesender.ui.notify('success', lang.tr('terms_accepted'));
+
+            var url = new URL(location);
+            var page = url.searchParams.get("s");
+            if( !page ) {
+                page = 'upload';
+            }
+            var args = {};
+            if( url.searchParams.get("vid") ) {
+                args = {
+                    vid: url.searchParams.get("vid")
+                };
+            }
+            if( url.searchParams.get("token") ) {
+                args = {
+                    token: url.searchParams.get("token")
+                };
+            }
+            filesender.ui.goToPage( page, args, null );
+        });
+        
+        return false;
+    });
+
+    window.filesender.log("window.filesender.log() from service aup page ");    
+});


### PR DESCRIPTION
The default setting `(service_aup_min_required_version = 0)` for this will have no change relative to previous versions. If you want to use it you need to enable it.

If you set in your config.php
```
$config['service_aup_min_required_version'] = 0;
```
Then users and guests will be asked to accept a service wide AUP the next time they load a page. Once they accept version 1 then they will not be asked again to accept the service wide AUP while min_required_version remains at 1.

If you then update `$config['service_aup_min_required_version'] = 2;` then any user or guest who has either not accepted the service AUP or only accepted version 1 will, on the next page load, be shown the service AUP for v2 and asked to accept it. This goes on allowing alterations of service AUP as desired (v3, v4... et al).

The text on the service AUP page is taken from the language translation for service_aup_body_version_1, service_aup_body_version_2, and so on so the terms can be updated in the translation file and included for many human languages. 

The is related to the issue https://github.com/filesender/filesender/issues/927.

