### PR TITLE
allow no max_transfer_files if admin desires it

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -83,7 +83,7 @@ $default = array(
     
     'max_transfer_size' => 107374182400,
     'max_transfer_recipients' => 50,
-    'max_transfer_files' => 30,
+    'max_transfer_files' => 5,
     'max_transfer_days_valid' => 20,
     'default_transfer_days_valid' => 10,
     'failed_transfer_cleanup_days' => 7,

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -367,7 +367,8 @@ window.filesender.transfer = function() {
             }
         }
         
-        if (this.files.length >= filesender.config.max_transfer_files) {
+        if (filesender.config.max_transfer_files > 0 &&
+            this.files.length >= filesender.config.max_transfer_files) {
             errorhandler({message: 'transfer_too_many_files', details: {max: filesender.config.max_transfer_files}});
             return false;
         }
@@ -1152,7 +1153,8 @@ window.filesender.transfer = function() {
         }
         
         // Redo sanity checks
-        if (this.files.length > filesender.config.max_transfer_files) {
+        if (filesender.config.max_transfer_files > 0 &&
+            this.files.length > filesender.config.max_transfer_files) {
             return errorhandler({message: 'transfer_too_many_files', details: {max: filesender.config.max_transfer_files}});
         }
         for (var i = 0; i < this.files.length; i++) {


### PR DESCRIPTION
If max_transfer_files=0 then do not enforce any maximum amount of files for a transfer. It turns out the server side already supported this if max_transfer_files=0 was in the config so it is client side only.
This addresses https://github.com/filesender/filesender/issues/359.
