### PR TITLE
Fixed bug of python script (filesize multiple of chunk size)

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -315,7 +315,7 @@ try:
     if debug:
       print('putChunks: '+path)
     with open(path, mode='rb', buffering=0) as fin:
-      for offset in range(0,size+1,upload_chunk_size):
+      for offset in range(0,size,upload_chunk_size):
         if progress:
           print('Uploading: '+path+' '+str(offset)+'-'+str(min(offset+upload_chunk_size, size))+' '+str(round(offset/size*100))+'%')
         data = fin.read(upload_chunk_size)


### PR DESCRIPTION
Transferring files with a multiple filesize of chunksize fails with python script:

How to reproduce:
```bash

> dd if=/dev/urandom of=/tmp/dummy10 bs=1k count=5120

> python3 filesender.py -v -p -r someone@fixme-no-dest.de /tmp/dummy10
base_url          : https://apps.rrze.de/filesender/rest.php
username          : unrzl1
apikey            : NONONONO
upload_chunk_size : 5242880 bytes
recipients        : someone@fixme-no-dest.de
files             : /tmp/dummy10
insecure          : False
postTransfer
putChunks: /tmp/dummy10
Uploading: /tmp/dummy10 0-5242880 0%
Uploading: /tmp/dummy10 5242880-5242880 100%
<class 'Exception'>
('Http error 500 {"message":"auth_remote_signature_check_failed","uid":"6182c99a9b9f8","details":null}',)
Http error 500 {"message":"auth_remote_signature_check_failed","uid":"6182c99a9b9f8","details":null}
deleteTransfer

```
