### PR TITLE
docs: add contributing info

### DIFF
--- a/docs/_includes/menu.html
+++ b/docs/_includes/menu.html
@@ -19,6 +19,7 @@
 			<li><a href="{{site.baseurl}}/v2.0/admin/reference/">Reference guide</a>
 			<li><a href="{{site.baseurl}}/v2.0/admin/maintenance/">Maintenance</a>
 		</ul>
+		<li><a href="{{site.baseurl}}/v2.0/dev/contributing//">Contributing code changes</a>
 		<li><a href="{{site.baseurl}}/v2.0/dev/testing/">Running the test suite</a>
 		<li><a href="{{site.baseurl}}/v2.0/dev/formatting/">Reformatting the code</a>
 		<li><a href="{{site.baseurl}}/v2.0/release/">Making a release</a>

--- a/docs/v2.0/dev/contributing/index.md
+++ b/docs/v2.0/dev/contributing/index.md
@@ -1,0 +1,30 @@
+---
+title: Contributing to FileSender
+---
+
+# Branches
+
+Filesender hosts its code on github. For each major release there is a
+development branch which takes all new code via pull requests. When a
+release is made the changes on that development branch are considered
+locally to make a single patch which is then fed into the master
+branch just prior to the release.
+
+This arrangement of development and master branches was desired by the
+Filesender board.
+
+For the 2.x series changes should be made on a branch of development and a pull
+request made for the development branch on the Filesender github project.
+
+For the 3.x bootstrap releases the development branch is called
+development3. The respective master branch is called master3.
+
+This naming convention will allow future major releases to be made and
+avoid confusion about which git branch will match which major release.
+
+As of the end of 2021 the 3.x series is still in prerelease so changes
+should be made on the 2.x series where possible and will be ported to
+the 3.x series. The obvious case where this does not apply is where
+the Bootstrap UI is to be updated where the PR should be made against
+development3.
+


### PR DESCRIPTION
This should help new contributors navigate the development/master split.
