### PR TITLE
core: new terareceiver mode for encrypted downloads

### DIFF
--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -297,9 +297,9 @@ class RestEndpointFile extends RestEndpoint
     {
         if (Utilities::isTrue(Config::get('testsuite_run_locally'))) {
             include_once(FILESENDER_BASE . "/vendor/autoload.php");
-            include_once(FILESENDER_BASE . "/unittests/selenium_tests/SeleniumTest.php");
-            include_once(FILESENDER_BASE . "/unittests/selenium_tests/tests/UploadAutoResumeTest.php");
-            eval(Config::get("PUT_PERFORM_TESTSUITE"));
+            include_once(FILESENDER_BASE . "/unittests/selenium/SeleniumTest.php");
+            include_once(FILESENDER_BASE . "/unittests/selenium/tests/UploadAutoResumeTest.php");
+            TestSuiteSupport::evalOverride("PUT_PERFORM_TESTSUITE");
         }
     }
 

--- a/classes/utils/TestSuiteSupport.class.php
+++ b/classes/utils/TestSuiteSupport.class.php
@@ -133,4 +133,12 @@ class TestSuiteSupport
             rmdir($dir);
         }
     }
+
+    public static function evalOverride($key)
+    {
+        $v = Config::get($key);
+        if( strlen($v) ) {
+            eval($v);
+        }
+    }
 }

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -123,6 +123,7 @@ $default = array(
     'crypto_gcm_max_chunk_count' => 4294967295,                   // 2^32-1
 
     'terasender_enabled' => true,
+    'terareceiver_enabled' => false,
     'terasender_advanced' => false,
     'terasender_disableable' => true,
     'terasender_start_mode' => 'multiple',

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -107,6 +107,7 @@ window.filesender.config = {
     crypto_use_custom_password_code: '<?php echo GUI::use_webasm_pbkdf2_implementation() ?>',
 
     terasender_enabled: <?php  echo value_to_TF(Config::get('terasender_enabled')) ?>,
+    terareceiver_enabled: <?php  echo value_to_TF(Config::get('terareceiver_enabled')) ?>,
     terasender_advanced: <?php echo value_to_TF(Config::get('terasender_advanced')) ?>,
     terasender_worker_count: <?php echo Config::get('terasender_worker_count') ?>,
     terasender_start_mode: '<?php echo Config::get('terasender_start_mode') ?>',
@@ -166,6 +167,7 @@ window.filesender.config = {
                 , user_hit_guest_rate_limit : "<?php echo Lang::tr('user_hit_guest_rate_limit')->out(); ?>"
                 , download_complete:       "<?php echo Lang::tr('download_complete')->out(); ?>"
 /**/            , download_chunk_progress: "<?php echo Lang::tr('download_chunk_progress')->out(); ?>"
+                , file_not_found:          "<?php echo Lang::tr('file_not_found')->out(); ?>"
 	},
     
     clientlogs: {

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -678,16 +678,12 @@ window.filesender.crypto_app = function () {
             var key_version = encryption_details.key_version;
             var blobArray = [];
 	    var wrongPassword = false;
-            var nonStreamedTeraRecv = false;
+            var nonStreamed = false;
 
-            var transfer = new filesender.transfer();
-            if (transfer.canUseTeraReceiver()) {
-                window.filesender.log("decryptBlob() can use TR");
-                if( chunkid==0 ) {
-                    if( !window.filesender.config.use_streamsaver ) {
-                        window.filesender.log("decryptBlob() first chunk of non streamed download");
-                        nonStreamedTeraRecv = true;
-                    }
+            if( chunkid==0 ) {
+                if( !window.filesender.config.use_streamsaver ) {
+                    window.filesender.log("decryptBlob() first chunk of non streamed download");
+                    nonStreamed = true;
                 }
             }
             
@@ -704,7 +700,7 @@ window.filesender.crypto_app = function () {
                                                             decryptParams,
                                                             callbackError );
 
-                window.filesender.log("decryptBlob() about to really decrypt() nonStreamedTeraRecv " + nonStreamedTeraRecv );
+                window.filesender.log("decryptBlob() about to really decrypt() nonStreamed " + nonStreamed );
                 
                 crypto.subtle.decrypt(decryptParams, key, value.data).then(
                     function (result) {
@@ -725,14 +721,14 @@ window.filesender.crypto_app = function () {
                         }
                     },
                     function (e) {
-                        window.filesender.log("decrypt(e) nonStreamedTeraRecv " + nonStreamedTeraRecv );
+                        window.filesender.log("decrypt(e) nonStreamed " + nonStreamed );
                         window.filesender.log(e);
-                        if(nonStreamedTeraRecv) {
+                        if(nonStreamed) {
                             e = new Error();
                         }
                         if (!wrongPassword) {
                             wrongPassword=true;
-                            window.filesender.log("decrypt(e5) nonStreamedTeraRecv " + nonStreamedTeraRecv );
+                            window.filesender.log("decrypt(e5) nonStreamed " + nonStreamed );
                             window.filesender.log("decrypt(e5) msg " + e.message );
                             filesender.client.decryptionFailedForTransfer( encryption_details.transferid );
                             callbackError(e);

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -894,6 +894,15 @@ window.filesender.crypto_app = function () {
             // start downloading this chunk
             oReq.send();
         },
+
+        /**
+         * Some functions like handleXHRError() want to call alert()
+         * but that can not happen from a web worker. By making this
+         * alert() a callback function it allows such an alert() call
+         * to be sent back to the main thread by an error() type message
+         * channel. The callback must match the alert() function signature.
+         */
+        alertcb: window.alert,
         
         /**
          * Display an error message to the user in has the XHR error
@@ -903,11 +912,13 @@ window.filesender.crypto_app = function () {
          */
         handleXHRError: function( xhr, link, defaultMsg )
         {
+            $this = this;
+            
             if(xhr.responseURL && xhr.responseURL.includes("/?s=exception&"))
             {
-                window.filesender.log("handleXHRError() XHR ERROR DETECTED");
-                window.filesender.log("link " + link );
-                window.filesender.log("got  " + xhr.responseURL );
+                window.filesender.log("handleXHRError(XHR ERROR DETECTED)");
+                window.filesender.log("handleXHRError link " + link );
+                window.filesender.log("handleXHRError got  " + xhr.responseURL );
 
                 var message = defaultMsg;
                 var url = new URL(xhr.responseURL);
@@ -915,6 +926,8 @@ window.filesender.crypto_app = function () {
                 if( c ) {
                     try {
                         var jc = JSON.parse(atob(c));
+                        window.filesender.log("handleXHRError jc " + jc );
+                        
                         if( jc ) {
                             message = jc.message;
                             window.filesender.log("have untranslated message: " + message );
@@ -923,11 +936,11 @@ window.filesender.crypto_app = function () {
                         // use default message if base64 decode failed.
                     }
                 }
-                
+
                 if( window.filesender.config.language[message] ) {
-                    alert( window.filesender.config.language[message] );
+                    $this.alertcb.call( window, window.filesender.config.language[message] );
                 } else {
-                    alert( window.filesender.config.language[defaultMsg] );
+                    $this.alertcb.call( window, window.filesender.config.language[defaultMsg] );
                 }                            
                 return true;
             }
@@ -1066,15 +1079,34 @@ window.filesender.crypto_app = function () {
             // to assumed password failures.
             //
             callbackError = function (error) {
+                window.filesender.log("decryptDownloadToBlobSink() explicit error " + error);
                 window.filesender.log(error);
                 window.filesender.crypto_app_downloading = false;
-                alert( window.filesender.config.language.file_encryption_wrong_password );
+                var msg = window.filesender.config.language.file_encryption_wrong_password;
+                
+                if( error && error.message && error.message != "" ) {
+                    msg = error.message;
+                } 
+                alert( msg );
                 if (progress){
-                    progress.html(window.filesender.config.language.file_encryption_wrong_password);
+                    progress.html( msg );
+                }
+                if( msg == window.filesender.config.language.file_encryption_wrong_password ) {
+                    filesender.terasender.stop();
                 }
                 blobSink.error( error );
             };
 
+            onProgressCallback = function( ts, chunkid, totalrecv, percentComplete, percentOfFileComplete ) {
+
+                var msg = lang.tr('download_chunk_progress').r({chunkid: chunkid,
+                                                                chunkcount: encryption_details.chunkcount,
+                                                                percentofchunkcomplete: percentComplete.toFixed(2),
+                                                                percentOffilecomplete:  percentOfFileComplete.toFixed(2)
+                                                               }).out();
+                progress.html(msg);
+            }
+            
                 encryption_details.password = pass;
 
                 $this.obtainKey(
@@ -1102,11 +1134,48 @@ window.filesender.crypto_app = function () {
                             }
                         };
 
-                        window.filesender.crypto_app_downloading = true;                        
-                        $this.downloadAndDecryptChunk( chunkid, link, progress,
-                                                       encryption_details, key,
-                                                       blobSink,
-                                                       callbackDone, callbackProgress, callbackError );
+                        window.filesender.crypto_app_downloading = true;
+
+                        var transfer = new filesender.transfer();
+                        if (transfer.canUseTeraReceiver()) {
+
+                            transfer.id = transferid;
+                            transfer.encryption = 1;
+
+                            var decryptCallback = function( job ) {
+                                $this.decryptBlob(
+                                    job.chunkid,
+                                    job.encryptedChunk,
+                                    job.encryption_details,
+                                    key,
+                                    filesender.terasender.receiver.blobSink,
+                                    function() {
+                                        // callbackNext()
+                                    },
+                                    callbackDone, callbackError );
+                            };
+
+                            filesender.terasender.crypto_app = this;
+                            filesender.terasender.receiver = {
+                                chunkid: chunkid,
+                                link: link,
+                                progress: progress,
+                                encryption_details: encryption_details,
+                                key: key,
+                                blobSink: blobSink,
+                                onChunkSuccess: decryptCallback,
+                                onProgress: onProgressCallback,
+                                onError: callbackError
+                            };
+
+                            filesender.terasender.startReceiver( transfer );
+                            
+                        } else {
+                            $this.downloadAndDecryptChunk( chunkid, link, progress,
+                                                           encryption_details, key,
+                                                           blobSink,
+                                                           callbackDone, callbackProgress, callbackError );
+                        }
                     },
                     function (e) {
                         // error occured during obtainkey

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -678,7 +678,19 @@ window.filesender.crypto_app = function () {
             var key_version = encryption_details.key_version;
             var blobArray = [];
 	    var wrongPassword = false;
+            var nonStreamedTeraRecv = false;
 
+            var transfer = new filesender.transfer();
+            if (transfer.canUseTeraReceiver()) {
+                window.filesender.log("decryptBlob() can use TR");
+                if( chunkid==0 ) {
+                    if( !window.filesender.config.use_streamsaver ) {
+                        window.filesender.log("decryptBlob() first chunk of non streamed download");
+                        nonStreamedTeraRecv = true;
+                    }
+                }
+            }
+            
             try {
                     
                 var value = encryptedChunk;
@@ -692,7 +704,7 @@ window.filesender.crypto_app = function () {
                                                             decryptParams,
                                                             callbackError );
 
-                window.filesender.log("decryptBlob()" );
+                window.filesender.log("decryptBlob() about to really decrypt() nonStreamedTeraRecv " + nonStreamedTeraRecv );
                 
                 crypto.subtle.decrypt(decryptParams, key, value.data).then(
                     function (result) {
@@ -713,10 +725,15 @@ window.filesender.crypto_app = function () {
                         }
                     },
                     function (e) {
-                        window.filesender.log("decrypt(e)");
+                        window.filesender.log("decrypt(e) nonStreamedTeraRecv " + nonStreamedTeraRecv );
                         window.filesender.log(e);
+                        if(nonStreamedTeraRecv) {
+                            e = new Error();
+                        }
                         if (!wrongPassword) {
                             wrongPassword=true;
+                            window.filesender.log("decrypt(e5) nonStreamedTeraRecv " + nonStreamedTeraRecv );
+                            window.filesender.log("decrypt(e5) msg " + e.message );
                             filesender.client.decryptionFailedForTransfer( encryption_details.transferid );
                             callbackError(e);
                         }

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -229,6 +229,12 @@ window.filesender.transfer = function() {
         enable &= !this.disable_terasender;
         return enable;
     };
+    this.canUseTeraReceiver = function() {
+        var enable = filesender.config.terareceiver_enabled && filesender.supports.workers;
+        enable &= !this.encryption || filesender.supports.workerCrypto;
+        enable &= !this.disable_terasender;
+        return enable;
+    }
 
     this.getExtention = function(file) {
         var fileSplit = file.name.split('.');

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -339,8 +339,13 @@ window.filesender.ui = {
      */
     error: function(error,callback) {
         this.log('[error] ' + error.message);
-        
-        var d = this.alert('error', lang.tr(error.message),callback);
+        this.log(error);
+
+        var msg = lang.tr(error.message);
+        if( error.messageTranslated ) {
+            msg = error.messageTranslated;
+        }
+        var d = this.alert('error', msg, callback);
         
         if(error.details) {
             var i = $('<div class="details" />').appendTo(d);


### PR DESCRIPTION
The start of a new TeraReceiver mode. Note the limitations of this initial version below. Work will continue on TeraReceiver to allow multiple workers and move encryption to the workers. TeraReceiver is disabled by default at the moment It can be enabled using 
```
$config['terareceiver_enabled'] = true;
```

The current implementation is limited to one web worker being active, so only one chunk downloaded at a time. Traditionally encrypted downloads have been performed using nested callbacks in crypto_app.js. The code path is retained and a new TeraReceiver mode added which uses the same TeraSender manager/worker code updated to allow chunk downloads. 

The main differences begin around the code that calls filesender.terasender.startReceiver() which passes control of the download over to TeraSender/TeraReceiver instead of calling back into other cryptp_app callbacks such as downloadAndDecryptChunk().

The requires code such as handleXHRError to allow alerts() to be optionally sent over web worker channels. This is handled by using the optional alertcb member variable.