### PR TITLE
clouds3: option to store everything in a single bucket

### DIFF
--- a/classes/constants/TransferOptions.class.php
+++ b/classes/constants/TransferOptions.class.php
@@ -54,4 +54,8 @@ class TransferOptions extends Enum
     const ENCRYPTION                                = 'encryption';
     const COLLECTION                                = 'collection';
     const MUST_BE_LOGGED_IN_TO_DOWNLOAD             = 'must_be_logged_in_to_download';
+
+    // Optional options specific to S3 storage
+    const STORAGE_CLOUD_S3_BUCKET                   = 'storage_cloud_s3_bucket';
+    
 }

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -555,7 +555,7 @@ class Transfer extends DBObject
         $transfer->created = time();
         $transfer->status = TransferStatuses::CREATED;
         $transfer->lang = Lang::getCode();
-        
+
         return $transfer;
     }
     
@@ -972,6 +972,8 @@ class Transfer extends DBObject
                 } else {
                     $value = null;
                 }
+            } elseif ($name == TransferOptions::STORAGE_CLOUD_S3_BUCKET) {
+                // no validation as this is only set server side.
             } else {
                 $value = (bool)$value;
             }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -51,6 +51,14 @@ class RestEndpointTransfer extends RestEndpoint
      */
     public static function cast(Transfer $transfer, $files_cids = null, $creatingTransfer = false )
     {
+        $options = $transfer->options;
+
+        // The client never needs to know the bucket name used.
+        $v = Config::get('cloud_s3_bucket');
+        if( $v && $v != '' ) {
+            $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = '';
+        }
+        
         return array(
             'id' => $transfer->id,
             'userid' => $transfer->userid,
@@ -60,7 +68,7 @@ class RestEndpointTransfer extends RestEndpoint
             'created' => RestUtilities::formatDate($transfer->created),
             'expires' => RestUtilities::formatDate($transfer->expires),
             'expiry_date_extension' => $transfer->expiry_date_extension,
-            'options' => $transfer->options,
+            'options' => $options,
             'salt' => $transfer->salt,
             'roundtriptoken' => $creatingTransfer ? $transfer->roundtriptoken : '',
             
@@ -490,6 +498,12 @@ class RestEndpointTransfer extends RestEndpoint
                 }
             }
 
+            if( Config::get('storage_type') == 'CloudS3' ) {
+                $v = Config::get('cloud_s3_bucket');
+                if( $v && $v != '' ) {
+                    $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
+                }
+            }
 
             Logger::info($options);
             // Get_a_link transfers have no recipients so mail related options make no sense, remove them if set

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -170,9 +170,11 @@ class StorageCloudS3 extends StorageFilesystem
         try {
             $client = self::getClient();
 
-            $client->createBucket(array(
-                'Bucket' => $bucket_name,
-            ));
+            if( !self::usingCustomBucketName( $file )) {
+                $client->createBucket(array(
+                    'Bucket' => $bucket_name,
+                ));
+            }
 
             $result = $client->putObject(array(
                 'Bucket' => $bucket_name,

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -58,6 +58,7 @@ A note about colours;
 * [storage_filesystem_hashing](#storage_filesystem_hashing)
 * [storage_filesystem_ignore_disk_full_check](#storage_filesystem_ignore_disk_full_check)
 * [storage_filesystem_external_script](#storage_filesystem_external_script)
+* [cloud_s3_bucket](#cloud_s3_bucket)
 
 ## Shredding
 
@@ -681,6 +682,17 @@ $config['avprogram_list'] = array( 'always_pass',
 * __default:__ FILESENDER_BASE.'/scripts/StorageFilesystemExternal/external.py'
 * __available:__ since before version 2.30
 * __comment:__ The script at the given path should perform similar read/write operations as the example external.py script to maintain the storage.
+
+
+### cloud_s3_bucket
+
+* __description:__ Optional name of a single bucket to use for storing all files in on S3.
+* __mandatory:__ no.  
+* __type:__ string
+* __default:__ ''
+* __available:__ since version 2.31
+* __comment:__ If you wish to store all files in a single bucket set it's name in this configuration option.
+Ensure that the named bucket already exists if you use this setting.
 
 
 

--- a/docs/v2.0/cloud/index.md
+++ b/docs/v2.0/cloud/index.md
@@ -199,6 +199,10 @@ avoid opening the later file.
 $config['cloud_s3_endpoint'] = 'http://localhost:8000';
 $config['cloud_s3_key']      = 'accessKey1';
 $config['cloud_s3_secret']   = 'verySecretKey1';
+
+// optional, Ensure that the bucket exists if you want to use a
+// single bucket. 
+// $config['cloud_s3_bucket']   = 'filesender';
 ```
 
 ### Running a test

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -225,6 +225,7 @@ $default = array(
     'cloud_s3_use_path_style_endpoint' => true,
     'cloud_s3_key'    => 'accessKey1',
     'cloud_s3_secret' => 'verySecretKey1',
+    'cloud_s3_bucket' => '',
 
     'disable_directory_upload' => true,
     'directory_upload_button_enabled' => true,

--- a/scripts/cloud/s3/test-s3-simple.php
+++ b/scripts/cloud/s3/test-s3-simple.php
@@ -37,7 +37,15 @@ require_once dirname(__FILE__).'/../../../optional-dependencies/s3/vendor/autolo
 use Aws\S3\S3Client;
 
 $bucket_name = '5b264219-57e2-447d-c9c6-0a8d602f1ba5';
+$folder_name = '';
 $object_name = '000000000000000000';
+
+$v = Config::get('cloud_s3_bucket');
+if( $v && $v != '' ) {
+    // include the slash here so it works if set or not set in the below code.
+    $folder_name = $bucket_name . '/';
+    $bucket_name = $v;
+}
 
 $client = S3Client::factory([
     'region'   => Config::get('cloud_s3_region'),
@@ -56,7 +64,7 @@ $client->createBucket(array(
 
 $result = $client->putObject(array(
     'Bucket' => $bucket_name,
-    'Key'    => $object_name,
+    'Key'    => $folder_name . $object_name,
     'Body'   => 'Hello, world!'     
 ));
      
@@ -64,7 +72,7 @@ echo 'uploaded url is at ' . $result['ObjectURL'] . "\n";
 
 $result = $client->getObject(array(
     'Bucket' => $bucket_name,
-    'Key'    => $object_name,
+    'Key'    => $folder_name . $object_name,
 ));
 
 echo 'downloaded result: ' . $result['Body'];


### PR DESCRIPTION
This provides the option that was suggested in https://github.com/filesender/filesender/pull/1114 to allow all files to be stored in a single bucket. The code is updated to store the current setting for each Transfer as it is created. This way the setting in the config.php can change and existing files can still be downloaded. This allows migration to using buckets or changing the bucket name while the existing files remain available. Conversely you can remove the bucket name and revert to the original style while existing files remain available.

The option is stored in the Rest Transfer class during creation of the Transfer. The option is sought in the Storage class if it is set for the Transfer and used if found. The Rest Transfer class does not return the bucket name in the `cast()` as it is not useful to the client so they should not be able to see it.
