### PR TITLE
update metadata that is shared in filesender-config.js.php

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -339,6 +339,11 @@ class Config
 
         self::forceLoadedToBool('guest_support_enabled');
 
+        $kv = self::get('encryption_key_version_new_files');
+        if( $kv == 2 || $kv == 3 ) {
+            self::$parameters['crypto_crypt_name'] = "AES-GCM";
+        }
+
         
         // verify classes are happy
         Guest::validateConfig();


### PR DESCRIPTION
The crypto_crypt_name is overridden in the `setCipherAlgorithm` function based on the value of the key version (0,1,2,3) being used. For new uploads the key version is taken from the encryption_key_version_new_files configuration setting. You will likely want 3.

When crypto is performed in the browser the `setCipherAlgorithm` is called to set the crypto_crypt_name correctly. 
https://github.com/filesender/filesender/blob/25fb8150fd29d2a93bad6b05695d2553022931b4/www/js/crypter/crypto_app.js#L447

However the filesender-config.js.php was showing the value from config.php for crypto_crypt_name instead of the overridden value. This should not have effected things as the crypto is initialized using the key version instead of using the crypto_crypt_name directly.
