### PR TITLE
some docs for crypto_crypt_name and update to fully set crypto_crypt_name from key version

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -340,6 +340,11 @@ class Config
         self::forceLoadedToBool('guest_support_enabled');
 
         $kv = self::get('encryption_key_version_new_files');
+        // these are crypto_app.js / crypto_key_version_constants
+        //   v2019_gcm_importKey_deriveKey: 3, // AES-GCM otherwise same as v2018_importKey_deriveKey
+        //   v2019_gcm_digest_importKey:    2, // AES-GCM otherwise same as v2017_digest_importKey
+        //   v2018_importKey_deriveKey:     1, // AES-CBC
+        //   v2017_digest_importKey:        0  // AES-CBC
         if( $kv == 2 || $kv == 3 ) {
             self::$parameters['crypto_crypt_name'] = "AES-GCM";
         } else {

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -342,6 +342,8 @@ class Config
         $kv = self::get('encryption_key_version_new_files');
         if( $kv == 2 || $kv == 3 ) {
             self::$parameters['crypto_crypt_name'] = "AES-GCM";
+        } else {
+            self::$parameters['crypto_crypt_name'] = "AES-CBC";
         }
 
         

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -43,6 +43,7 @@ A note about colours;
 * [crypto_gcm_max_file_size](#crypto_gcm_max_file_size)
 * [crypto_gcm_max_chunk_size](#crypto_gcm_max_chunk_size)
 * [crypto_gcm_max_chunk_count](#crypto_gcm_max_chunk_count)
+* [crypto_crypt_name](#crypto_crypt_name)
 * [upload_crypted_chunk_padding_size](#upload_crypted_chunk_padding_size)
 * [upload_crypted_chunk_size](#upload_crypted_chunk_size)
 
@@ -566,6 +567,15 @@ $config['avprogram_list'] = array( 'always_pass',
 * __comment:__ It is recommended that you leave this setting as the default value and do not change the
      upload_chunk_size when using GCM cryptography. The default is 2^32-1.
 
+### crypto_crypt_name
+* __description:__ Internal use. The name of the cipher currently used. This is set from encryption_key_version_new_files for new transfers or the key version that was used for an existing transfer.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ calculated
+* __available:__ since before version 2.30
+* __comment:__ This is an internal setting. It will be overridden in crypto_app based on the key version to be used for a transfer. The key version in that was set in encryption_key_version_new_files
+is stored as part of the metadata for each transfer when it is created. When a transfer is to be downloaded the key version used for that transfer will be used to set the crypto_crypt_name.
+This way the encryption_key_version_new_files can be updated and existing uploads will continue to be able to be downloaded.
 
 ### upload_crypted_chunk_size
 * __description:__ Internal only setting. This is the entire size of an encrypted chunk, including any padding for per chunk IV


### PR DESCRIPTION
This adds some docs for that config setting and makes the crypto_crypt_name explicit setting cover the entire new key version range.