### PR TITLE
upload: show a very basic ETA

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -682,4 +682,5 @@ $lang['epoch_minutes'] = 'Minutes';
 $lang['epoch_seconds'] = 'Seconds';
 $lang['no_estimate'] = 'No estimate';
 $lang['soon'] = 'Soon';
+$lang['initializing'] = 'Initializing';
 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -676,3 +676,10 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['estimated_completion'] = 'Estimated completion';
+$lang['epoch_hours'] = 'Hours';
+$lang['epoch_minutes'] = 'Minutes';
+$lang['epoch_seconds'] = 'Seconds';
+$lang['no_estimate'] = 'No estimate';
+$lang['soon'] = 'Soon';
+

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -144,6 +144,7 @@ if( $encryption_mandatory ) {
                 <div class="stats">
                     <div class="uploaded">{tr:uploaded} : <span class="value"></span></div>
                     <div class="average_speed">{tr:average_speed} : <span class="value"></span></div>
+                    <div class="estimated_completion">{tr:estimated_completion} : <span class="value"></span></div>
                 </div>
             </div>
             

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -838,7 +838,8 @@ table.list .date {
 
 #upload_form .uploading_actions .msg,
 #upload_form .uploading_actions .stats .uploaded,
-#upload_form .uploading_actions .stats .average_speed
+#upload_form .uploading_actions .stats .average_speed,
+#upload_form .uploading_actions .stats .estimated_completion
 {
     display: none;
 }

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -434,6 +434,35 @@ window.filesender.ui = {
         
         return bytes.toFixed(precision).replace(/\.0+$/g, '') + ' ' + multipliers[pow];
     },
+
+
+    /**
+     * Format a number of seconds in the future to a readable string
+     * 
+     * @param int v
+     * 
+     * @return string
+     */
+    formatETA : function (v) {
+        if( v==-1 ) {
+            return lang.tr('no_estimate');
+        }
+        if( !v ) {
+            return lang.tr('soon');
+        }
+        if( v > 3600 ) {
+            v = v / 3600; // epoch_hours
+            return (v).toFixed(1) + ' ' + lang.tr('epoch_hours');
+        }
+        if( v > 5*60 ) {
+            v = v / 60;
+            return (v).toFixed(0) + ' ' + lang.tr('epoch_minutes');
+        }
+        if( v < 5 ) {
+            return lang.tr('soon');
+        }
+        return ''+ (v).toFixed(0) + ' ' + lang.tr('epoch_seconds');
+    },
     
     /**
      * Pending transfer check

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -100,7 +100,7 @@ function pause( changeTextElements )
     if( changeTextElements ) {
         filesender.ui.nodes.seconds_since_data_sent_info.text('');
         filesender.ui.nodes.stats.average_speed.find('.value').text(lang.tr('paused'));
-        filesender.ui.nodes.stats.estimated_completion.find('.value').text(lang.tr(''));
+        filesender.ui.nodes.stats.estimated_completion.find('.value').text('');
         filesender.ui.setTimeSinceDataWasLastSentMessage(lang.tr('paused'));
     }
 }
@@ -138,6 +138,36 @@ function resume( force, resetResumeCount )
  */
 var checkEncryptionPassword_slideToggleDelay = 200;
 var checkEncryptionPassword_delay = 300;
+
+if(!('filesender' in window)) window.filesender = {};
+if(!('ui'         in window.filesender)) window.filesender.ui = {};
+if(!('elements'   in window.filesender.ui)) window.filesender.ui.elements = {};
+
+/**
+ * Update the UI element at uielement only once every delayMS time interval.
+ * While the first delayMS interval is passing show the string initString.
+ */
+filesender.ui.elements.nonBusyUpdater = function( uielement, delayMS, initString ) {
+    return {
+        e: uielement,
+        lastUpdate: null,
+        update: function( v ) {
+            var $this = this;
+            t = (new Date()).getTime();
+            if( $this.lastUpdate && ($this.lastUpdate + delayMS < t )) {
+                $this.e.text( v );
+            }
+            if( !$this.lastUpdate ) {
+                $this.e.text( initString );
+            }
+            if( !$this.lastUpdate || ($this.lastUpdate + delayMS < t )) {
+                $this.lastUpdate = t;
+            }
+        }
+    }
+};
+
+
 
 // Manage files
 filesender.ui.files = {
@@ -478,7 +508,7 @@ filesender.ui.files = {
         if( remaining && speed ) {
             eta = remaining / speed;
         }
-        filesender.ui.nodes.stats.estimated_completion.find('.value').text(filesender.ui.formatETA(eta));
+        filesender.ui.nodes.stats.estimated_completion_updater.update( filesender.ui.formatETA(eta));
 
         
         if (filesender.config.upload_display_bits_per_sec)
@@ -1402,6 +1432,11 @@ $(function() {
         var i = $(this);
         filesender.ui.nodes.options[i.attr('name')] = i;
     });
+    
+    filesender.ui.nodes.stats.estimated_completion_updater = filesender.ui.elements.nonBusyUpdater(
+        filesender.ui.nodes.stats.estimated_completion.find('.value'),
+        2000,
+        lang.tr('initializing'));
 
     
     // Bind file list clear button
@@ -1728,7 +1763,7 @@ $(function() {
 
             pause( true );
             filesender.ui.nodes.stats.average_speed.find('.value').text(lang.tr('paused'));
-            filesender.ui.nodes.stats.estimated_completion.find('.value').text(lang.tr(''));
+            filesender.ui.nodes.stats.estimated_completion.find('.value').text('');
             filesender.ui.setTimeSinceDataWasLastSentMessage(lang.tr('paused'));
             return false;
         }).button();

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -100,6 +100,7 @@ function pause( changeTextElements )
     if( changeTextElements ) {
         filesender.ui.nodes.seconds_since_data_sent_info.text('');
         filesender.ui.nodes.stats.average_speed.find('.value').text(lang.tr('paused'));
+        filesender.ui.nodes.stats.estimated_completion.find('.value').text(lang.tr(''));
         filesender.ui.setTimeSinceDataWasLastSentMessage(lang.tr('paused'));
     }
 }
@@ -471,6 +472,14 @@ filesender.ui.files = {
         }
         
         var speed = uploaded / (time / 1000);
+
+        var remaining = size - uploaded;
+        var eta = 0;
+        if( remaining && speed ) {
+            eta = remaining / speed;
+        }
+        filesender.ui.nodes.stats.estimated_completion.find('.value').text(filesender.ui.formatETA(eta));
+
         
         if (filesender.config.upload_display_bits_per_sec)
             speed *= 8;
@@ -1212,7 +1221,8 @@ filesender.ui.startUpload = function() {
     filesender.ui.nodes.stats.size.hide();
     filesender.ui.nodes.stats.uploaded.show();
     filesender.ui.nodes.stats.average_speed.show();
-    
+    filesender.ui.nodes.stats.estimated_completion.show();
+
     filesender.ui.nodes.form.find(':input:not(.file input[type="file"])').prop('disabled', true);
 
     // Report and possibly resume the upload
@@ -1379,7 +1389,8 @@ $(function() {
             number_of_files: form.find('.files_actions .stats .number_of_files'),
             size: form.find('.files_actions .stats .size'),
             uploaded: form.find('.uploading_actions .stats .uploaded'),
-            average_speed: form.find('.uploading_actions .stats .average_speed')
+            average_speed: form.find('.uploading_actions .stats .average_speed'),
+            estimated_completion: form.find('.uploading_actions .stats .estimated_completion')
         },
         need_recipients: form.attr('data-need-recipients') == '1'
     };
@@ -1717,6 +1728,7 @@ $(function() {
 
             pause( true );
             filesender.ui.nodes.stats.average_speed.find('.value').text(lang.tr('paused'));
+            filesender.ui.nodes.stats.estimated_completion.find('.value').text(lang.tr(''));
             filesender.ui.setTimeSinceDataWasLastSentMessage(lang.tr('paused'));
             return false;
         }).button();


### PR DESCRIPTION
This is based on the current upload speed and amount of data that remains to upload. If the upload speed is stable then the estimate should be _reasonable_. The display of an ETA has a built in 2 second delay to allow some time for the speed to work itself out. The ETA display will also only refresh every 2 seconds to avoid it flickering around too much while the user is trying to read it.

The updating is handled in a new class `nonBusyUpdater` which can be used elsewhere when a once per X milliseconds only update is desired.

This could be expanded to retain a fixed size set of ETA values and perhaps show the variance to the user in a simple way like green, orange, or red if the estimate is varying widely.