### PR TITLE
Fixes to allow running under PHP8

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -87,8 +87,8 @@ class Utilities
         // Generate 16 bytes of random data (128 bits)
         $bytes = random_bytes(16);
         // Set bits required for a valid UUIDv4
-        $bytes{8} = chr((ord($bytes{8}) & 0x3F) | 0x80); // Eat 2 bits of entropy
-        $bytes{6} = chr((ord($bytes{6}) & 0x4F) | 0x40); // Eat 4 bits of entropy
+        $bytes[8] = chr((ord($bytes[8]) & 0x3F) | 0x80); // Eat 2 bits of entropy
+        $bytes[6] = chr((ord($bytes[6]) & 0x4F) | 0x40); // Eat 4 bits of entropy
         // $bytes has now 122 bits of entropy
 
         // Convert bytes to hex and split in 4-char strings (hex, so 2 bytes per string)

--- a/includes/init/init_web.php
+++ b/includes/init/init_web.php
@@ -60,12 +60,6 @@ if(!session_id()) {
 // Ensure HTTPS if needed
 GUI::forceHTTPS();
 
-// Handle magic quoting (TODO maybe deprecated now ?)
-if(get_magic_quotes_gpc()) {
-    $_POST = array_map('stripslashes', $_POST);
-    $_GET = array_map('stripslashes', $_GET);
-};
-
 // Sanitize all input variables
 $_GET = Utilities::sanitizeInput($_GET);
 $_POST = Utilities::sanitizeInput($_POST);


### PR DESCRIPTION
This isn't comprehensive by any means, but to get FileSender to run under PHP8 we needed to make these changes.

No behaviour should be changed, as it's just a formatting change, and dead code removal.