### PR TITLE
dev3: run tests from both m2a and m2b

### DIFF
--- a/unittests/config_tests_filesender.xml
+++ b/unittests/config_tests_filesender.xml
@@ -55,13 +55,12 @@
         </testsuite>
 
         <testsuite name="selenium">
-<!--
+
           <file>./selenium/tests/UploadAutoResumeTest.php</file>
           <file>./selenium/tests/EncryptionTest.php</file>
           <file>./selenium/tests/ConfigurationOptionsTest.php</file>
           <file>./selenium/tests/TransferExpiredTest.php</file>
 
--->
           <file>./selenium/tests/InvalidExtensionsTest.php</file>
           <file>./selenium/tests/MaxFilesTest.php</file>
           <file>./selenium/tests/MaxUploadSizeTest.php</file>


### PR DESCRIPTION
While testing m2b tests I disabled the existing m2a for a shorter run of the cloud selenium tests. This enables both m2a and m2b during a CI execution.
