### PR TITLE
url-encode email address in admin_transfers

### DIFF
--- a/www/js/admin_transfers.js
+++ b/www/js/admin_transfers.js
@@ -80,7 +80,7 @@ $(function() {
         
         filesender.ui.redirect( filesender.config.base_path
                                 + '?s=admin&as=transfers'
-                                + '&senderemail=' + senderemail.val()
+                                + '&senderemail=' + encodeURIComponent(senderemail.val())
                                 + '&senderemail_full_match=' + full_match
                               );
     }


### PR DESCRIPTION
It couldn't search email addresses including the '+' sign in admin_transfers.

I fix it using encodeURIComponent().