### PR TITLE
guest expires: allow selection below the default expire

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -316,6 +316,20 @@ class Guest extends DBObject
         
         return strtotime('+'.$days.' day');
     }
+
+    /**
+     * Get min expire date. If a number of days is explicitly set then it is used
+     * otherwise we default to right now being the min value so that calling code
+     * can Utilities::clamp() using this min value without needing to check if 
+     * min_guest_days_valid is set.
+     *
+     * @return int timestamp
+     */
+    public static function getMinExpire()
+    {
+        $days = Config::get('min_guest_days_valid');
+        return strtotime('+'.$days.' day');
+    }
     
     /**
      * Get max expire date

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -251,8 +251,9 @@ class RestEndpointGuest extends RestEndpoint
         // Set expiry date
         $expires = $guest->getDefaultExpire();
         if( $data->expires ) {
-            $expires = max( $expires, $data->expires );
+            $expires = $data->expires;
         }
+        $expires = Utilities::clamp( $expires, $guest->getMinExpire(), $guest->getMaxExpire());
         $guest->expires = $expires;
 
         if($guest->does_not_expire) {

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -255,6 +255,9 @@ class Config
         if (!self::get('max_guest_days_valid')) {
             self::$parameters['max_guest_days_valid'] = self::get('max_transfer_days_valid');
         }
+        if (!self::get('min_guest_days_valid') || self::get('min_guest_days_valid') < 0) {
+            self::$parameters['min_guest_days_valid'] = 1;
+        }
         
         if (!self::get('default_guest_days_valid')) {
             self::$parameters['default_guest_days_valid'] = self::get('max_guest_days_valid');

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -715,6 +715,17 @@ class Utilities
 
 
     /**
+     * ensure $v is between the min and max values.
+     */
+    public static function clamp( $v, $minv, $maxv ) 
+    {
+        $v = max( $v, $minv );
+        $v = min( $v, $maxv );
+        return $v;
+    }
+
+
+    /**
      * Ensure that $v passes the regex from $config_key_for_regex 
      * or throw the $excep exception
      *

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1946,7 +1946,7 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __description:__ specifies the maximum expiry date for a guest invitation.  A user can not choose a larger value than this.
 * __mandatory:__ no
 * __type:__ int
-* __default:__ same as max_transfer_days_valid
+* __default:__ 20
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -187,6 +187,7 @@ A note about colours;
 * [guest_support_enabled](#guest_support_enabled)
 * [guest_options](#guest_options)
 * [default_guest_days_valid](#default_guest_days_valid)
+* [min_guest_days_valid](#min_guest_days_valid)
 * [max_guest_days_valid](#max_guest_days_valid)
 * [max_guest_recipients](#max_guest_recipients)
 * [guest_upload_page_hide_unchangable_options](#guest_upload_page_hide_unchangable_options)
@@ -1930,6 +1931,16 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __1.x name:__
 * __comment:__
 
+### min_guest_days_valid
+
+* __description:__ specifies the minimum expiry date for a guest invitation.  This is the number of days from today (0). The default of 1 will result in an effective minimum expire time of tomorrow. You might like to make this something like 5 or 7 to ensure guest vouchers are not accidentally created with very short life spans.
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 1
+* __available:__ since version 2.32
+* __1.x name:__
+* __comment:__
+
 ### max_guest_days_valid
 
 * __description:__ specifies the maximum expiry date for a guest invitation.  A user can not choose a larger value than this.
@@ -1939,6 +1950,7 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__
+
 
 ### max_guest_recipients
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -90,7 +90,10 @@ $default = array(
     'transfer_recipients_lang_selector_enabled' => false,
     'max_transfer_file_size' => 0,
     'max_transfer_encrypted_file_size' => 0,
-    
+
+    'default_guest_days_valid' => 20,
+    'min_guest_days_valid' =>  1,
+    'max_guest_days_valid' => 20,
     'max_guest_recipients' => 50,
     
     'max_legacy_file_size' => 2147483648,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -81,6 +81,7 @@ window.filesender.config = {
     
     max_transfer_days_valid: <?php echo Config::get('max_transfer_days_valid') ?>,
     default_transfer_days_valid: <?php echo Config::get('default_transfer_days_valid') ?>,
+    min_guest_days_valid: <?php echo Config::get('min_guest_days_valid') ?>,
     max_guest_days_valid: <?php echo Config::get('max_guest_days_valid') ?>,
     default_guest_days_valid: <?php echo Config::get('default_guest_days_valid') ?>,
     

--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -320,7 +320,7 @@ $(function() {
     
     // Bind picker
     filesender.ui.nodes.expires.datepicker({
-        minDate: 1,
+        minDate: filesender.config.min_guest_days_valid,
         maxDate: filesender.config.max_guest_days_valid
     });
     // set value from epoch time


### PR DESCRIPTION
This makes the range for a new guest expire time more explicit (with a clamp()). It introduces a new `min_guest_days_valid` config setting (default 1) which allows the minimum number of days a new guest invitation will be valid. It also allows for selecting dates that are less than the default expire time. 

This relates to https://github.com/filesender/filesender/issues/1193