### PR TITLE
https://bugs.php.net/bug.php?id=77782 workaround

### DIFF
--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -85,7 +85,7 @@ class AuthSPShibboleth
             
             self::load();
             
-            $attributes = array('idp' => getenv('Shib-Identity-Provider'));
+            $attributes = array('idp' => getenv()['Shib-Identity-Provider']);
             
             // Wanted attributes
             foreach (array('uid', 'name', 'email') as $attr) {
@@ -97,7 +97,7 @@ class AuthSPShibboleth
                 
                 $values = array();
                 foreach ($keys as $key) { // For all possible keys for attribute
-                    $value = explode(';', getenv($key));
+                    $value = explode(';', getenv()[$key]);
                     foreach ($value as $v) {
                         $values[] = $v;
                     } // Gather values of all successive possible keys as array


### PR DESCRIPTION
In some circumstances when using an SAPI that does not run 
in-process with the http server (e.g. fcgid, fpm) PHP fails to 
return some environment variables when they are queried as
getenv($foo) - however they can be seen with getenv().

According to the bug, the root cause is that different code
paths are taken when calling getenv() vs getenv($foo):

"... it looks like calling `getenv` without a param eventually
calls fcgi_loadenv with cgi_php_load_env_var, but if you pass 
varname to getenv it only calls fcgi_getenv."

This results in FileSender being unable to load attributes set
by Shibboleth, despite them being present in memory.

Querying the whole array, and then slicing out the entry needed
should be a drop in replacement with equivalent functionality
for all SAPI's.