### PR TITLE
New Env class to allow getenv() to do more in some cases

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -96,7 +96,7 @@ class AuthSPSaml
             $raw_attributes = self::loadSimpleSAML()->getAttributes();
             
             $attributes = array();
-            
+
             // Wanted attributes
             foreach (array('uid', 'name', 'email') as $attr) {
                 // Keys in raw_attributes (can be array of key)

--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -85,7 +85,7 @@ class AuthSPShibboleth
             
             self::load();
             
-            $attributes = array('idp' => getenv('Shib-Identity-Provider'));
+            $attributes = array('idp' => Env::getenv('Shib-Identity-Provider'));
             
             // Wanted attributes
             foreach (array('uid', 'name', 'email') as $attr) {
@@ -97,7 +97,7 @@ class AuthSPShibboleth
                 
                 $values = array();
                 foreach ($keys as $key) { // For all possible keys for attribute
-                    $value = explode(';', getenv($key));
+                    $value = explode(';', Env::getenv($key));
                     foreach ($value as $v) {
                         $values[] = $v;
                     } // Gather values of all successive possible keys as array

--- a/classes/utils/Env.class.php
+++ b/classes/utils/Env.class.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2022, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ * Env access and update
+ */
+class Env
+{
+    /**
+     * This largely works like php getenv($k) but:
+     * - Can work around some cases where getenv() must be called to unpack values
+     *   https://bugs.php.net/bug.php?id=77782
+     * - Allows for dumping calls to getenv() in the log for debugging
+     *
+     * @param $k and $local_only as per php getenv()
+     */
+    public static function getenv( $k, $local_only = false ) 
+    {
+        $v = @getenv( $k, $local_only );
+        if( !$v ) {
+            // workaround for
+            // https://bugs.php.net/bug.php?id=77782
+            $v = @getenv()[$k];
+        }
+        return $v;
+    }
+}


### PR DESCRIPTION
This is a slight update to https://github.com/filesender/filesender/pull/1208 which creates a new Env class which offers it's own `getenv` method. By abstracting things into a class we can document why `Env::getenv()` exists in the code. 

This should also lead new readers of the code to the method to see why it is there rather than potential updates from `getenv()['key']` to `getenv('key')` in the future in places where it will make the code fail for some users.