### PR TITLE
allow select directory button to store paths too

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -114,7 +114,7 @@ if( $encryption_mandatory ) {
                 <?php if ($upload_directory_button_enabled) { ?>
                 <div class="<?php echo $files_actions_div_extra_class ?>">
                     <input type="file" name="selectdir" id="selectdir" class="selectdir_hidden_input_element" webkitdirectory directory multiple mozdirectory />
-                    <label for="selectdir" class="select_directory  ">{tr:select_directory}</label>                    
+                    <label for="selectdir" class="select_directory  ">{tr:select_directory}</label>
                 </div>
                 <?php } ?>
                 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -217,7 +217,9 @@ filesender.ui.files = {
         var node = null;
         for(var i=0; i<files.length; i++) {
             var file_name = files[i].name;
-            if(typeof files[i].webkitRelativePath === "string") {
+            if(typeof files[i].webkitRelativePath === "string"
+               && files[i].webkitRelativePath != "" )
+            {
                 file_name = files[i].webkitRelativePath;
             }
             

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -216,7 +216,12 @@ filesender.ui.files = {
     addList: function(files, source_node) {
         var node = null;
         for(var i=0; i<files.length; i++) {
-            var latest_node = filesender.ui.files.addFile(files[i].name, files[i], source_node);
+            var file_name = files[i].name;
+            if(typeof files[i].webkitRelativePath === "string") {
+                file_name = files[i].webkitRelativePath;
+            }
+            
+            var latest_node = filesender.ui.files.addFile(file_name, files[i], source_node);
             if (latest_node) {
                 node = latest_node;
             }


### PR DESCRIPTION
As reported in https://github.com/filesender/filesender/issues/1223 the functionality is different between adding a directory by drag and drop and adding by "select a directory". Specifically the drag and drop would retain the relative paths of the files in the directories added and the "select a directory" would only store the file names.

This patch allows the relative paths to be stored where the browser supports it for "select a directory" mode. This will also allow the files to be downloaded in a zip containing the paths.
