### PR TITLE
no merge: initial version of mediumint to int4 for mariadb

### DIFF
--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -230,7 +230,15 @@ class DatabaseMysql
                 if (!$size) {
                     $size = 'medium';
                 }
-                $typematcher = $size.'int(?:\([0-9]+\))';
+                if( $size == 'medium' ) {
+                    // 4 bytes for alignment 2022 march.
+                    $typematcher = 'int(?:\(11\))';
+                    if( $definition['type'] == 'uint' ) {
+                        $typematcher = 'int(?:\(10\))';
+                    }
+                } else {
+                    $typematcher = $size.'int(?:\([0-9]+\))';
+                }
                 if ($definition['type'] == 'uint') {
                     $typematcher .= ' unsigned';
                 }
@@ -272,6 +280,7 @@ class DatabaseMysql
         // Check type
         if (!preg_match('`'.$typematcher.'`i', $column_dfn['Type'])) {
             $logger($column.' type does not match '.$typematcher);
+            $logger("  ... found " . $column_dfn['Type']);
             $non_respected[] = 'type';
         }
         
@@ -386,7 +395,12 @@ class DatabaseMysql
                 if (!$size) {
                     $size = 'medium';
                 }
-                $mysql = strtoupper($size).'INT';
+                if( $size == 'medium' ) {
+                    // 4 bytes for alignment 2022 march.
+                    $mysql = 'INTEGER';
+                } else {
+                    $mysql = strtoupper($size).'INT';
+                }
                 if ($definition['type'] == 'uint') {
                     $mysql .= ' UNSIGNED';
                 }

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -395,6 +395,18 @@ try {
         echo 'Done removing views for table '.$table."\n";
     }
 
+
+    
+    DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_epochtype  ' );
+    DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_eventtype  ' );
+    DBI::exec( 'alter table StatLogs  drop foreign key IF EXISTS statlogs_browsertype  ' );
+    DBI::exec( 'alter table StatLogs  drop foreign key IF EXISTS statlogs_operatingsystem  ' );
+    DBI::exec( 'alter table Transfers drop foreign key IF EXISTS transfer_passwordencoding  ' );
+    DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_digestnameid' );
+    DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_fileid' );
+
+    
+
     
 
     echo "checking for major schema migrations\n";


### PR DESCRIPTION
The main failing of this is that foreign keys are dropped before the database.php changes mediumint to int4. This is a big brute force and also means that the database script really can not be run at the same time as the system is in use.

I am mainly pushing this up at this stage to make it easy to see the update.