### PR TITLE
Cookies: override the cookie_domain with settings from config.php

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -106,7 +106,9 @@ class Auth
     private static function ensure_php_session()
     {
         if ( self::isSessionStarted() === false ) {
-            session_start();
+            $opts = array();
+            $opts['cookie_domain'] = Config::get('cookie_domain');
+            session_start($opts);
         }
     }
     

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -284,7 +284,7 @@ class GUI
                         '',
                         time() - 42000,
                         $params['path'],
-                        $params['domain'],
+                        Config::get('cookie_domain'),
                         $params['secure'],
                         $params['httponly']
                     );

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -46,6 +46,7 @@ A note about colours;
 * [crypto_crypt_name](#crypto_crypt_name)
 * [upload_crypted_chunk_padding_size](#upload_crypted_chunk_padding_size)
 * [upload_crypted_chunk_size](#upload_crypted_chunk_size)
+* [cookie_domain](#cookie_domain)
 
 
 ## Backend storage
@@ -597,6 +598,13 @@ This way the encryption_key_version_new_files can be updated and existing upload
            needed for an encrypted chunk that is uploaded (not the encrypted content itself).
 
 
+### cookie_domain
+* __description:__ Optionally allow the cookie_domain to be set for new cookies.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ ''
+* __available:__ since version 2.33
+* __comment:__ It is highly recommended that you leave this setting as the default value which will be unset. The default will mean "If omitted, this attribute defaults to the host of the current document URL, not including subdomains.". This setting is here to allow a deployment to set a value like filesender.example.com to allow all subdomains from that domain to also see the cookie if desired.   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -307,6 +307,8 @@ $default = array(
 
 
     'service_aup_min_required_version' => 0,
+
+    'cookie_domain' => '',
     
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
Setting the cookie domain to '' (the new default) will force the browser to use the most restrictive cookie domain where the cookie was served from. This is an improvement over just using filesender.example.com becuase that explicit domain would allow hacker.filesender.example.com and other subdomains to also get access to the cookie.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value

This has become an option in config.php to allow sites to use filesender.example.com if they explicitly want to allow some subdomains.

This is 5.1.9 of the may2022 report.