### PR TITLE
dev3: update bootstrap and bootbox metadata

### DIFF
--- a/scripts/dev/www-lib-update/package.json
+++ b/scripts/dev/www-lib-update/package.json
@@ -10,8 +10,8 @@
   "license": "ISC",
   "dependencies": {
     "@popperjs/core": "^2.11.5",
-    "bootbox": "^5.5.2",
-    "bootstrap": "^5.0.2",
+    "bootbox": "^5.5.3",
+    "bootstrap": "^5.1.3",
     "chart.js": "^3.7.1",
     "flag-icon-css": "^3.5.0",
     "font-awesome": "^4.7.0",

--- a/scripts/dev/www-lib-update/show-existing-versions.php
+++ b/scripts/dev/www-lib-update/show-existing-versions.php
@@ -15,6 +15,14 @@ echo "\n";
 // out the version into the first () match.
 //
 $packages = array(
+   'bootstrap' => array(
+        'path' => 'bootstrap/dist/css/bootstrap.min.css',
+        'pattern' => '/Bootstrap v([0-9.]+).*/m',
+    ),
+    'bootbox' => array(
+        'path' => 'bootbox/dist/bootbox.all.min.js',
+        'pattern' => '/bootbox.js ([0-9.]+).*/m',
+    ),    
     'chart.js' => array(
         'path' => 'chart.js/chart.min.js',
         'pattern' => '/Chart.js v([0-9.]+).*/m',


### PR DESCRIPTION
This updates the bootstrap metadata to 5.1.3 and bumps bootbox version a minor release too. The www/lib files are already updated during https://github.com/filesender/filesender/pull/1252

This relates to https://github.com/filesender/filesender/pull/1229