### PR TITLE
Rate Limits: new hard and soft rate limits for some actions

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -83,6 +83,7 @@ class Autoloader
         'AggregateStatistic' => 'data/',
         'AggregateStatisticMetadata' => 'data/',
         'AVResult' => 'data/',
+        'RateLimitHistory' => 'data/',
         
         'AVProgram*' => 'avprograms/',
         

--- a/classes/data/RateLimitHistory.class.php
+++ b/classes/data/RateLimitHistory.class.php
@@ -1,0 +1,304 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+
+if(!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool {
+        return \strncmp($haystack, $needle, \strlen($needle)) === 0;
+    }
+}
+    
+/**
+ * Represents an user in database
+ */
+class RateLimitHistory extends DBObject
+{
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        'id' => array(
+            'type' => 'uint',
+            'size' => 'big',
+            'primary' => true,
+            'autoinc' => true
+        ),
+        'created' => array(
+            'type' => 'datetime'
+        ),
+        'author_context_type' => array(
+            'type' => 'string',
+            'size' => 255
+        ),
+        'author_context_id' => array(
+            'type' => 'string',
+            'size' => 255
+        ),
+        'action' => array(
+            'type' => 'string',
+            'size' => 40
+        ),
+        'event' => array(
+            'type' => 'string',
+            'size' => 255
+        ),
+        'target_context_type' => array(
+            'type' => 'string',
+            'size' => 255
+        ),
+        'target_context_id' => array(
+            'type' => 'string',
+            'size' => 255,
+            'null' => true
+        ),
+    );
+
+    
+    public static function getViewMap()
+    {
+        $a = array();
+        foreach (array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype, 'created')
+                        . '  from ' . self::getDBTable();
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a );
+    }
+
+    protected static $secondaryIndexMap = array(
+        'action_event_created' => array(
+            'action' => array(),
+            'event' => array(),
+            'created' => array()
+        )
+    );
+    
+    
+    /**
+     * Properties
+     */
+    protected $id                  = null;
+    protected $created             = null;
+    protected $author_context_type = null;
+    protected $author_context_id   = null;
+    protected $action              = null;
+    protected $event               = null;
+    protected $target_context_type = null;
+    protected $target_context_id   = null;
+
+    /**
+     * Constructor
+     *
+     * @param integer $id identifier of object to load from database (null if loading not wanted)
+     * @param array $data data to create the object from (if already fetched from database)
+     *
+     * @throws UserNotFoundException
+     */
+    protected function __construct($id = null, $data = null)
+    {
+        if (!is_null($id)) {
+            // Load from database if id given
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+            $this->id = $id;
+        }
+        
+        if ($data) {
+            // Fill properties from provided data
+            $this->fillFromDBData($data);
+        } else {
+            // New user, set base data
+            $this->id = $id;
+            $this->created = time();
+        }
+    }
+
+    /**
+     * Create a new RateLimitHistory record
+     *
+     * @return RateLimitHistory
+     */
+    public static function create( $author_context_type, $author_context_id
+                                 , $action, $event
+                                 , $target_context_type, $target_context_id )
+    {
+        $r = new self();
+        $r->created = time();
+        $r->author_context_type = $author_context_type;
+        $r->author_context_id   = $author_context_id;
+        $r->action              = $action;
+        $r->event               = $event;
+        $r->target_context_type = $target_context_type;
+        $r->target_context_id   = $target_context_id;
+        return $r;
+    }
+
+    /**
+     * Check if this action/event is over the rate limit or not.
+     * 
+     * Throw an exception if the limit has been reached.
+     *
+     * If $updateDatabase is set then the action is recorded in the database
+     * if you are performing a check before performing an action then 
+     * set $updateDatabase=false
+     * 
+     */   
+    public static function rateLimit( $updateDatabase
+                                    , $author_context_type, $author_context_id
+                                    , $action, $event
+                                    , $target_context_type, $target_context_id )
+    {        
+        $count = self::countEntries( $author_context_type, $author_context_id
+                                   , $action, $event
+                                   , $target_context_type, $target_context_id );
+
+        $r = -1;
+
+        $rates = Config::get('rate_limits');
+        
+        if( array_key_exists( $action, $rates )) {
+            $cfg = $rates[$action];
+            if( array_key_exists( $event, $cfg )) {
+                $cfg = $cfg[$event];
+                if( array_key_exists( 'day', $cfg )) {
+                    $r = $cfg['day'];
+                }
+            }
+        }
+
+        
+        if( $r != -1 && $count >= $r ) {
+            throw new RateLimitException( $author_context_type, $author_context_id
+                                        , $action, $event );
+        }
+        
+        //
+        // If we get here then the action is likely to have been performed already
+        // for example, creating a guest
+        // so we should update the counter *after* checking that we are not already
+        // over the limit.
+        //
+        if( $updateDatabase ) {
+            $ratehistory = self::create( $author_context_type, $author_context_id
+                                       , $action, $event
+                                       , $target_context_type, $target_context_id );
+            $ratehistory->save();
+        }
+    }
+    
+    public static function countEntries( $author_context_type, $author_context_id
+                                       , $action, $event
+                                       , $target_context_type, $target_context_id )
+    {
+        $ret = 0;
+
+        $secondsAgo = 24*3600;
+        $created = time() - $secondsAgo;
+        $includeTargetID = false;
+        
+        if( $target_context_type == 'Transfer' ) {
+            if( $action == 'email' && $event == 'transfer_available' ) {
+                // only count stats for transfer_available using the author context.
+                // when creating objects we shouldn't include their new id in the
+                // test or we will not have any limit action
+            } else {
+                $includeTargetID = true;
+            }
+        }
+        if( $target_context_type == 'User' ) {
+            $includeTargetID = true;
+        }
+        if( $target_context_type == 'Guest' ) {
+            if( $action == 'email' && str_starts_with( $event, 'guest_created' )) {
+                // do not count the ID of the new guest or the system will never rate limit
+                // create operations
+            } else {
+                $includeTargetID = true;
+            }
+        }
+
+        $sql = 'SELECT count(*) as count, 1 as one '
+             . ' FROM ' . self::getDBTable()
+                              . ' WHERE author_context_type = :author_context_type '
+                              . ' AND   author_context_id   = :author_context_id '
+                              . ' AND   action              = :action '
+                              . ' AND   event               = :event '
+                              . ' AND   target_context_type = :target_context_type '
+                              . ' AND   created >= :created ';
+        $params = array(
+            ':author_context_type'   => $author_context_type
+          , ':author_context_id'   => $author_context_id
+          , ':action'              => $action
+          , ':event'               => $event
+          , ':target_context_type' => $target_context_type
+          , ':created' => date('Y-m-d H:0:0', $created)
+        );
+
+        $vvvv = date('Y-m-d H:0:0', $created);
+        if( $includeTargetID ) {
+            $sql .= ' AND   target_context_id   = :target_context_id ';
+            $params[':target_context_id'] = $target_context_id;
+        }
+        $statement = DBI::prepare( $sql );
+        $statement->execute( $params );
+        $data = $statement->fetch();
+        if( $data ) {
+            $ret = $data['count'];
+        }
+        
+        return $ret;
+    }
+    
+    public function __get($property)
+    {
+        if (in_array($property, array(
+            'id', 'created'
+            , 'author_context_type', 'author_context_id'
+            , 'action',              'event'
+            , 'target_context_type', 'target_context_id'
+        ))) {
+            return $this->$property;
+        }
+        
+        throw new PropertyAccessException($this, $property);
+    }
+    
+  
+}
+
+    

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -220,6 +220,53 @@ class TranslatableEmail extends DBObject
         
         return $email;
     }
+
+    public static function getContext($translation_id, DBObject $to, $vars )
+    {
+        // Extract context info from arguments
+        $context = null;
+        switch (get_class($to)) {
+            case 'Recipient': // Recipient context is it's transfer
+                $context = $to->transfer;
+                break;
+                
+            case 'Guest': // Guest is a context by itself
+                $context = $to;
+                break;
+
+            case 'Transfer': // Transfer
+                $context = $to;
+                break;
+                
+            case 'User': // If recipient is user try to find Transfer, File or Guest in variables
+                foreach ($vars as $v) {
+                    if (!is_object($v)) {
+                        continue;
+                    }
+                    
+                    if (in_array(get_class($v), array('Transfer', 'Guest'))) {
+                        $context = $v;
+                    }
+                    
+                    if ('File' == get_class($v)) {
+                        $context = $v->transfer;
+                    }
+                }
+                if ($context) {
+                    break;
+                }
+                if( $translation_id == 'local_authdb_password_reminder' ) {
+                    $context = $to;
+                    break;
+                } 
+                
+                // no break
+            default:
+                Logger::debug("getContext bad to ", $to );
+                throw new TranslatableEmailUnknownContextException(get_class($to));
+        }
+        return $context;
+    }
     
     /**
      * Prepare mail to be sent to recipient (be it Guest, Recipient ...)
@@ -232,6 +279,7 @@ class TranslatableEmail extends DBObject
      */
     public static function prepare($translation_id, DBObject $to)
     {
+        $original_to = $to;
         $vars = array_slice(func_get_args(), 2);
         array_unshift($vars, $to);
         
@@ -301,17 +349,69 @@ class TranslatableEmail extends DBObject
             $plain .= "\n\n".$footer_translation->plain->out();
             $html .= "\n\n".$footer_translation->html->out();
         }
+
         
         $mail = new ApplicationMail(new Translation(array(
             'subject' => $email_translation->subject->out(),
             'plain' => $plain,
             'html' => $html,
         )));
+
+        try {
+            self::rateLimit( true, $translation_id, $context, ...$vars );
+        }
+        catch ( RateLimitException $e ) {
+            Logger::info("rate limiting action $action");
+            $mail->setReallySend( false );
+        }
         
         // Add recipient
         $mail->to($to);
         
         return $mail;
+    }
+
+    /**
+     * There are two cases for a rateLimit():
+     * A) Calling early before an action is performed to see if the limit is reached and
+     *    if so then throwing an error rather than doing anything
+     * B) Calling once an action has been performed and a resulting email is about to be sent.
+     *    In this case we may wish to limit email creation but can not stop the action as it has already been performed.
+     *
+     * For case (B) you should catch RateLimitException and avoid sending the email.
+     * It is useful for the exception to be thrown from this method so that the exception
+     * can access all the state that would have been used for the ratelimit record. For example,
+     * event type, sender class and id etc.
+     *
+     */
+    public static function rateLimit( $updateDatabase, $translation_id, DBObject $to )
+    {
+        $vars = array_slice(func_get_args(), 2);
+        array_unshift($vars, $to);
+
+        $action = 'email';
+        $event  = $translation_id;
+        $author = null;
+        if( Auth::isGuest() ) {
+            $author = AuthGuest::getGuest();
+        }
+        if( Auth::isAuthenticated()) {
+            $author = Auth::user();
+        }
+        $author_context_type = 'unknown';
+        $author_context_id   = 'unknown';
+        if( $author ) {
+            $author_context_type = get_class($author);
+            $author_context_id   = $author->id;
+        }
+        $target = self::getContext($translation_id, $to, $vars );
+        $target_context_type = get_class($target);
+        $target_context_id   = $target->id;
+
+        RateLimitHistory::rateLimit( $updateDatabase
+                                   , $author_context_type, $author_context_id
+                                   , $action, $event
+                                   , $target_context_type, $target_context_id );
     }
     
     /**
@@ -326,7 +426,7 @@ class TranslatableEmail extends DBObject
         $mail = call_user_func_array(get_called_class().'::prepare', func_get_args());
         
         $mail->setDebugTemplate($translation_id);
-
+      
         $mail->send();
     }
     

--- a/classes/exceptions/RateLimitExceptions.class.php
+++ b/classes/exceptions/RateLimitExceptions.class.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2022, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copynright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+if (!defined('FILESENDER_BASE')) {        // Require environment (fatal)
+    die('Missing environment');
+}
+
+/**
+ * Rate Limit violation
+ */
+class RateLimitException extends DetailedException
+{
+    /**
+     * Constructor
+     *
+     * @param string $selector column used to select guest
+     */
+    public function __construct($author_context_type, $author_context_id
+                              , $action, $event )
+    {
+        parent::__construct(
+            'rate_limit_exceeded',   // Message to give to the user
+            array('event' => $event) // Real message to log
+        );
+    }
+}
+

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -185,9 +185,12 @@ class RestEndpointGuest extends RestEndpoint
                                         'guest_create_limit_per_day',
                                         LogEventTypes::GUEST_CREATED_RATE, $user );
 
+        
         // Create new guest object
         $guest = Guest::create($data->recipient, $data->from);
 
+        // Check rate limit
+        TranslatableEmail::rateLimit( false, 'guest_created', $guest );
         
         // Set provided metadata
         if ($data->subject) {
@@ -367,7 +370,7 @@ class RestEndpointGuest extends RestEndpoint
         if (!$guest->isOwner($user) && !Auth::isAdmin()) {
             throw new RestOwnershipRequiredException($user->id, 'guest = '.$guest->id);
         }
-        
+
         // Remove guest access rights
         $guest->close();
     }

--- a/classes/rest/endpoints/RestEndpointRecipient.class.php
+++ b/classes/rest/endpoints/RestEndpointRecipient.class.php
@@ -145,6 +145,7 @@ class RestEndpointRecipient extends RestEndpoint
         
         // Need to remind the transfer's availability to its recipients ?
         if ($data->remind) {
+            TranslatableEmail::rateLimit( false, 'transfer_reminder', $recipient->transfer );
             $recipient->remind();
         }
 

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -223,8 +223,18 @@ class RestEndpointTransfer extends RestEndpoint
 
             // Want auditlog data ...
             if ($property == 'auditlog') {
+
+                // ... to be sent by email
                 if ($property_id == 'mail') {
-                    // ... to be sent by email
+                    // Check rate limit
+                    $format = Config::get('report_format');
+                    if (!$format) {
+                        $format = ReportFormats::INLINE;
+                    }
+                    $lid = ($format == ReportFormats::INLINE) ? 'inline' : 'attached';
+                    TranslatableEmail::rateLimit( false, 'report_'.$lid, $transfer );
+
+                    
                     $report = new Report($transfer);
                     if( $filtertype && $filterid ) {
                         $files = $transfer->files;

--- a/classes/utils/ApplicationMail.class.php
+++ b/classes/utils/ApplicationMail.class.php
@@ -38,6 +38,7 @@ if (!defined('FILESENDER_BASE')) {
 class ApplicationMail extends Mail
 {
     private $to = array('email' => null, 'name' => null, 'object' => null);
+    private $reallySend = true;
     
     /**
      * Constructor
@@ -86,6 +87,10 @@ class ApplicationMail extends Mail
                 $this->writeHTML($content->html);
             }
         }
+    }
+
+    public function setReallySend( $v ) {
+        $this->reallySend = $v;
     }
     
     /**
@@ -322,7 +327,11 @@ class ApplicationMail extends Mail
                 }
             }
         }
-        
+
+        if( !$this->reallySend ) {
+            Logger::info("ApplicationMail mail is rejected due to over threshold. From: $from");
+            return;
+        }
         // Send email
         return parent::send();
     }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -47,6 +47,7 @@ A note about colours;
 * [upload_crypted_chunk_padding_size](#upload_crypted_chunk_padding_size)
 * [upload_crypted_chunk_size](#upload_crypted_chunk_size)
 * [cookie_domain](#cookie_domain)
+* [rate_limits](#rate_limits) (rate limits for some actions)
 
 
 ## Backend storage
@@ -605,6 +606,41 @@ This way the encryption_key_version_new_files can be updated and existing upload
 * __default:__ ''
 * __available:__ since version 2.33
 * __comment:__ It is highly recommended that you leave this setting as the default value which will be unset. The default will mean "If omitted, this attribute defaults to the host of the current document URL, not including subdomains.". This setting is here to allow a deployment to set a value like filesender.example.com to allow all subdomains from that domain to also see the cookie if desired.   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value
+
+
+### rate_limits
+* __description:__ Some actions have hard or soft limits that can be applied. For example, actions that result in sending an email may have a soft limit that will perform the action but not send an email after the nominated number of actions is performed per time period. This allows for the system to prevent a nefarious guest from sending too many emails. The database table ratelimithistorys is used to track the information needed for this option. The time period for actions performed used for the initial implementation is 24 hours. For example, with the right setting you can not create more than 200 guests in a 24 hour block of time. There are two types of limits, hard and soft. A hard limit will be checked before performing an action and if the limit is already reached the action will not be performed. For example, creating a guest or sending a transfer_reminder is a hard limit. This is because creating a guest may require sending an email to be performed so it is not useful to try to perform the action if the rate limit is already reached. Some actions are soft limits such as guest_upload_start and will only effect the sending of an email. For the guest_upload_start example, if the limit is 30 per day then a guest may start an upload 1000 times and you will only receive emails for the first 30 attempts. This way the system remains functional but does not try to produce excessive emails while it is performing that function. In general a soft limit is to protect against excessive email but not to limit the use of the system itself.
+* __mandatory:__ no
+* __type:__ array
+* __default:__
+* __available:__ since version 2.33
+* __1.x name:__
+* __comment:__ For current defaults see https://github.com/filesender/filesender/search?q=rate_limits+in%3Afile+path%3Aincludes
+* __*Standard parameters for all options:*__
+	* __day__(integer): The number of times this action can be performed per day.
+ed off by the user.
+* __*Available options:*__
+	* __guest\_created:__ hard limit
+	* __report\_inline:__ hard limit
+	* __transfer\_reminder:__ hard limit
+	* __download\_complete:__ soft limit
+	* __files\_downloaded:__ soft limit
+	* __guest\_upload\_start:__ soft limit
+	* __transfer\_available:__ soft limit
+
+* __*Configuration example:*__
+
+$config['rate_limits'] = array(
+        'email' => array(
+            'guest_created'      => array( 'day' => 30 ),
+            'report_inline'      => array( 'day' => 20 ),
+            'transfer_reminder'  => array( 'day' => 15 ),
+            'download_complete'  => array( 'day' => 300 ),
+            'files_downloaded'   => array( 'day' => 100 ),
+            'guest_upload_start' => array( 'day' => 50 ),
+            'transfer_available' => array( 'day' => 200 ),
+        ),
+);
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -417,4 +417,18 @@ $default = array(
             'default' => true
         ),
     ),
+
+
+    'rate_limits' => array(
+        'email' => array(
+            'guest_created'      => array( 'day' => 100 ),
+            'report_inline'      => array( 'day' => 100 ),
+            'transfer_reminder'  => array( 'day' => 100 ),
+            'download_complete'  => array( 'day' => 500 ),
+            'files_downloaded'   => array( 'day' => 500 ),
+            'guest_upload_start' => array( 'day' => 100 ),
+            'transfer_available' => array( 'day' => 500 ),
+        ),
+    ),
+
 );

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -687,3 +687,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['rate_limit_exceeded'] = 'You have attempted to perform this operation more frequently than is allowed in a 24 hour period.';


### PR DESCRIPTION
Some actions have hard or soft limits that can be applied. For example, actions that result in sending an email may have a soft limit that will perform the action but not send an email after the nominated number of actions is performed per time period. This allows for the system to prevent a nefarious guest from sending too many emails. The database table ratelimithistorys is used to track the information needed for this option. The time period for actions performed used for the initial implementation is 24 hours.

For example, with the right setting you can not create more than 200 guests in a 24 hour block of time. There are two types of limits, hard and soft. A hard limit will be checked before performing an action and if the limit is already reached the action will not be performed. For example, creating a guest or sending a transfer_reminder is a hard limit. This is because creating a guest may require sending an email to be performed so it is not useful to try to perform the action if the rate limit is already reached. 

Some actions are soft limits such as guest_upload_start and will only effect the sending of an email. For the guest_upload_start example, if the limit is 30 per day then a guest may start an upload 1000 times and you will only receive emails for the first 30 attempts. This way the system remains functional but does not try to produce excessive emails while it is performing that function. In general a soft limit is to protect against excessive email but not to limit the use of the system itself.

See the rate_limits config option for details on how to change the new defaults.

Audit report 5.1.2.