### PR TITLE
Stronger checks on guest vid, round trip token checks are forced on for guest uploads

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -787,6 +787,8 @@ class Transfer extends DBObject
     /**
      * Check that the user has read/write permission 
      * for this transfer.
+     *
+     * If the user is a guest then a valid 'vid' must be provided.
      * 
      * @return true if they are allowed or false if access should be forbidden
      */
@@ -800,6 +802,7 @@ class Transfer extends DBObject
         }
         
         if (Auth::isGuest()) {
+            // this will throw if there is no vid
             $guest = AuthGuest::getGuest();
             if( !$guest ) {
                 return FALSE;

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -361,7 +361,7 @@ class TranslatableEmail extends DBObject
             self::rateLimit( true, $translation_id, $context, ...$vars );
         }
         catch ( RateLimitException $e ) {
-            Logger::info("rate limiting action $action");
+            Logger::info("rate limiting action");
             $mail->setReallySend( false );
         }
         

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -150,17 +150,42 @@ class RestEndpointFile extends RestEndpoint
      */
     private function testRoundTripToken( $file, $userrtt )
     {
-        if( Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'))) {
+        // should we check the RTT by default
+        $checkRTT = Utilities::isTrue(Config::get('chunk_upload_roundtriptoken_check_enabled'));
 
-            // To allow old transfers to complete we allow this test to pass
-            // with a warning if there is no roundtriptoken in the database
-            // and the transfer was already 'created' before the server was upgraded
+        // Always check the RTT if we are dealing with a guest
+        if (Auth::isGuest()) {
+            $checkRTT = true;
+            // make sure there is a guest for the supplied vid
+            AuthGuest::getGuest();
+            
+            //
+            // We might as well just fail right here for a guest upload
+            // if the stored roundtriptoken is not valid. We assume that
+            // guests are not continuing an upload over a FileSender version upgrade.
+            //
             if( strlen($file->transfer->roundtriptoken) < 5 ) {
-                $accept_before = Config::get('chunk_upload_roundtriptoken_accept_empty_before');
-                if( $accept_before > 0 ) {
-                    if( $file->transfer->created < $accept_before ) {
-                        Logger::warn('Allowing a transfer roundtriptoken_check to pass because the transfer is older than accept_empty_before.');
-                        return;
+                throw new RestRoundTripTokensInvalidException();
+            }
+        }
+        
+        if( $checkRTT ) {
+
+            //
+            // Do not allow old transfer grace perioud for guests
+            //
+            if (!Auth::isGuest()) {
+            
+                // To allow old transfers to complete we allow this test to pass
+                // with a warning if there is no roundtriptoken in the database
+                // and the transfer was already 'created' before the server was upgraded
+                if( strlen($file->transfer->roundtriptoken) < 5 ) {
+                    $accept_before = Config::get('chunk_upload_roundtriptoken_accept_empty_before');
+                    if( $accept_before > 0 ) {
+                        if( $file->transfer->created < $accept_before ) {
+                            Logger::warn('Allowing a transfer roundtriptoken_check to pass because the transfer is older than accept_empty_before.');
+                            return;
+                        }
                     }
                 }
             }
@@ -341,6 +366,7 @@ class RestEndpointFile extends RestEndpoint
         // Evaluate security type depending on config and auth
         $security = Config::get('chunk_upload_security');
         if (Auth::isAuthenticated()) {
+            // We will get here for guests as well as authenticated users.
             $security = 'auth';
         }
         if (($security == 'auth') && !Auth::isAuthenticated()) {

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -387,6 +387,20 @@ class RestEndpointFile extends RestEndpoint
             }
         }
 
+        //
+        // If the transfer was created by a guest then check that the uploading
+        // principal is in fact that guest
+        // Note that getGuest() forces a guest lookup from vid
+        //
+        if( $file->transfer->guest_id > 0 ) {
+            $g = AuthGuest::getGuest();
+            if( !$g ) {
+                throw new RestUnknownPrincipalException();
+            }
+            if( $g->id != $file->transfer->guest_id ) {
+                throw new RestUnknownPrincipalException();
+            }
+        }
         self::testRoundTripToken( $file, Utilities::getGETparam('roundtriptoken'));
         
 

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -362,7 +362,7 @@ class GUI
             // Authenticated users have access to lots ...
             if (Auth::isAuthenticated(false)) {
                 if (Auth::isGuest()) {
-                    self::$allowed_pages = array('upload',
+                    self::$allowed_pages = array('home', 'upload',
                                                  GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY, GUIPages::APISECRETAUP );
                 } else {
                     self::$allowed_pages = array('home', 'upload', 'transfers', 'guests', 'download',

--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -96,7 +96,13 @@ class Security
      */
     public static function validateAgainstCSRF( $canReturnJSON = false )
     {
-        if( Config::get('owasp_csrf_protector_enabled') ) {
+        $checkToken = Utilities::isTrue(Config::get('owasp_csrf_protector_enabled'));
+
+        if (Auth::isGuest()) {
+            $checkToken = true;
+        }
+        
+        if( $checkToken ) {
             include_once('../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
             if( !self::$filesender_csrf_protector_logger ) {
                 self::$filesender_csrf_protector_logger = new FileSendercsrfProtectorLogger();

--- a/templates/header.php
+++ b/templates/header.php
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <?php
-    $headerclass = "header";
+include_once "vidattr.php";
+
+$headerclass = "header";
 
     try {
         if (Auth::isAuthenticated()) {
@@ -19,6 +21,9 @@
         // nothing to do on failure
     }
 
+
+
+
 ?>
 
 <html xmlns="http://www.w3.org/1999/xhtml" lang="<?php echo Lang::getCode() ?>" xml:lang="<?php echo Lang::getCode() ?>">
@@ -35,7 +40,7 @@
         
         <script type="text/javascript" src="{path:filesender-config.js.php}"></script>
         
-        <script type="text/javascript" src="{path:rest.php/lang?callback=lang.setTranslations}"></script>
+        <script type="text/javascript" src="{path:rest.php/lang?callback=lang.setTranslations<?php echo $vidattr ?>}"></script>
         
         <meta name="robots" content="noindex, nofollow" />
         

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -1,6 +1,7 @@
 <?php
 
 include_once "pagemenuitem.php";
+include_once "vidattr.php";
 
 $maybe_display_aggregate_statistics_menu = false;
 
@@ -22,7 +23,7 @@ $maybe_display_aggregate_statistics_menu = false;
                 }
                 
                 pagemenuitem('transfers');
-                
+               
                 if(Config::get('user_page'))
                     pagemenuitem('user');
                 

--- a/templates/pagemenuitem.php
+++ b/templates/pagemenuitem.php
@@ -1,5 +1,6 @@
 <?php
 
+include_once "vidattr.php";
 
 function pagelink($page) {
     if(!GUI::isUserAllowedToAccessPage($page)) return;
@@ -9,6 +10,8 @@ function pagelink($page) {
 }
 
 function pagemenuitem($page) {
+    global $vidattr;
+    
     if(!GUI::isUserAllowedToAccessPage($page)) return;
     $class = ($page == GUI::currentPage()) ? 'current' : '';
 
@@ -24,6 +27,6 @@ function pagemenuitem($page) {
             }
         }
     }
-    echo '<li><a class="'.$class.'" id="topmenu_'.$page.'" href="?s='.$page.'">'.$label.'</a></li>';
+    echo '<li><a class="'.$class.'" id="topmenu_'.$page.'" href="?s='.$page.$vidattr.'">'.$label.'</a></li>';
 }
 

--- a/templates/vidattr.php
+++ b/templates/vidattr.php
@@ -1,0 +1,13 @@
+<?php
+
+global $vidattr;
+
+$vidattr = "";
+
+if (array_key_exists('vid', $_REQUEST)) {
+    $vid = $_REQUEST['vid'];
+    if( Utilities::isValidUID($vid) ) {
+        $vidattr = "&vid=" . $vid;
+    }
+}
+

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -317,8 +317,21 @@ window.filesender.ui = {
      * Redirect user to url
      * 
      * @param string url
+     * @param object args optional cgi key=value settings to send as args to the server
      */
-    redirect: function(url) {
+    redirect: function(url,args) {
+        if(args) {
+            var current_args = {};
+            for(var k in args) {
+                current_args[k] = args[k];
+            }
+            args = [];
+            for(var k in current_args) {
+                args.push(k + '=' + current_args[k]);
+            }
+            url = url + '&' + args.join('&');
+        }
+        
         window.location.href = url;
     },
     

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1141,13 +1141,19 @@ filesender.ui.startUpload = function() {
 
         filesender.ui.files.clear_crust_meter_all();
         window.filesender.pbkdf2dialog.ensure_onPBKDF2AllEnded();
-        
+
+        var usp = new URLSearchParams(window.location.search);
+        var reditectargs = [];
+        if( usp.has('vid')) {
+            reditectargs['vid'] = usp.get('vid');
+        }
         var redirect_url = filesender.ui.transfer.options.redirect_url_on_complete;
+        
         if(redirect_url) {
-            filesender.ui.redirect(redirect_url);
+            filesender.ui.redirect(redirect_url,reditectargs);
             
             window.setTimeout(function(f) {
-                filesender.ui.redirect(redirect_url);
+                filesender.ui.redirect(redirect_url,reditectargs);
                 filesender.ui.alert('success', lang.tr('done_uploading_redirect').replace({url: redirect_url}));
             }, 5000);
                     
@@ -1158,7 +1164,7 @@ filesender.ui.startUpload = function() {
             window.filesender.notification.clear();
             filesender.ui.goToPage(
                 filesender.ui.transfer.guest_token ? 'home' : 'transfers',
-                null,
+                reditectargs,
                 filesender.ui.transfer.guest_token ? null : 'transfer_' + filesender.ui.transfer.id
             );
         };


### PR DESCRIPTION
If a transfer was created by a guest then make sure the 'vid' is sent and that it matches the guest who created the transfer.

And `testRoundTripToken()` will also be forced on to make sure that the roundtriptoken set in the web session is sent in the chunk upload RestEndpointFile/PUT and matches the expected value.