### PR TITLE
Remove domain flag from cookie

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -284,7 +284,7 @@ class GUI
                         '',
                         time() - 42000,
                         $params['path'],
-                        Config::get('cookie_domain'),
+                        '',
                         $params['secure'],
                         $params['httponly']
                     );


### PR DESCRIPTION
This removes the domain flag from the cookie to be compatible with [draft-west-cookie-prefixes](https://datatracker.ietf.org/doc/html/draft-west-cookie-prefixes)

As further explained in #1276, compatibility with this draft, which is implemented by major browsers, should improve protection of the session cookie we use