### PR TITLE
GUI allowed pages update to move these settings to the config

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -357,44 +357,46 @@ class GUI
     {
         // Already cached ?
         if (is_null(self::$allowed_pages)) {
-            self::$allowed_pages = array();
+
+            self::$allowed_pages = Config::get('allow_pages_core');
             
             // Authenticated users have access to lots ...
             if (Auth::isAuthenticated(false)) {
                 if (Auth::isGuest()) {
-                    self::$allowed_pages = array('home', 'upload',
-                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY, GUIPages::APISECRETAUP );
+                    self::$allowed_pages = array_merge( self::$allowed_pages,
+                                                        Config::get('allow_pages_add_for_guest'));
                 } else {
-                    self::$allowed_pages = array('home', 'upload', 'transfers', 'guests', 'download',
-                                                 GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY, GUIPages::APISECRETAUP );
+                    self::$allowed_pages = array_merge( self::$allowed_pages,
+                                                        Config::get('allow_pages_add_for_user'));
                     
                     // ... and admin to even more !
                     if (Auth::isAdmin()) {
-                        self::$allowed_pages[] = 'admin';
+                        self::$allowed_pages = array_merge( self::$allowed_pages,
+                                                            Config::get('allow_pages_add_for_admin'));
                     }
 
                     if (Auth::canViewAggregateStatistics()) {
-                        self::$allowed_pages[] = 'aggregate_statistics';
+                        self::$allowed_pages[] = GUIPages::AGGREGATE_STATISTICS;
                     }
 
                     if (Auth::canViewStatistics()) {
-                        self::$allowed_pages[] = 'statistics';
+                        self::$allowed_pages[] = GUIPages::STATISTICS;
                     }
                     
-                    // Is user page enabled ?
-                    if (Config::get('user_page')) {
-                        self::$allowed_pages[] = 'user';
+                    // Is user page disabled?
+                    if (!Config::get('user_page')) {
+                        self::$allowed_pages = array_diff( self::$allowed_pages,
+                                                           array(GUIPages::USER));
                     }
                 }
             }
             
-            // Always accessible pages
-            foreach (array('download', 'translate_email', 'logout', 'exception', GUIPages::HELP, GUIPages::ABOUT) as $p) {
-                self::$allowed_pages[] = $p;
-            }
-            
+
+            //
+            // the above doesn't matter if we are not allowing use right now.
+            //
             if (Config::get('maintenance')) {
-                self::$allowed_pages = array('maintenance');
+                self::$allowed_pages = array(GUIPages::MAINTENANCE);
             }
         }
         

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -123,6 +123,11 @@ A note about colours;
 * [crypto_pbkdf2_dialog_custom_webasm_delay](#crypto_pbkdf2_dialog_custom_webasm_delay)
 * [upload_page_password_can_not_be_part_of_message_handling](#upload_page_password_can_not_be_part_of_message_handling)
 * [user_page](#user_page)
+* [allow_pages_core](#allow_pages_core)
+* [allow_pages_add_for_guest](#allow_pages_add_for_guest)
+* [allow_pages_add_for_user](#allow_pages_add_for_user)
+* [allow_pages_add_for_admin](#allow_pages_add_for_admin)
+
 
 ## Transfers
 
@@ -1254,6 +1259,43 @@ User language detection is done in the following order:
 * __comment:__ To show an item set the value for the name of the item to true.
      For more possible values to include in the array see the second level keys in $infos on the templates/user_page.php file.
 
+
+### allow_pages_core
+* __description:__ The pages that should be available to all visitors before logging in. Note that if you include some pages such as transfers
+                   and the system requires the user to be logged in to view the page they will be redirected to login to view the page. The default
+                   value should be acceptable to most sites.
+* __mandatory:__ no
+* __type:__ array of values from GUIPages constants
+* __default:__ array( GUIPages::DOWNLOAD, GUIPages::TRANSLATE_EMAIL, GUIPages::LOGOUT, GUIPages::EXCEPTION, GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY )
+* __available:__ since version 2.33
+* __comment:__ See also allow_pages_add_for_guest and allow_pages_add_for_user
+
+
+### allow_pages_add_for_guest
+* __description:__ These values will be added to the allow_pages_core pages if the principal is a guest
+* __mandatory:__ no
+* __type:__ array of values from GUIPages constants
+* __default:__ array( GUIPages::HOME, GUIPages::UPLOAD, GUIPages::APISECRETAUP )
+* __available:__ since version 2.33
+* __comment:__ See also allow_pages_core
+
+### allow_pages_add_for_user
+* __description:__ These values will be added to the allow_pages_core pages if the principal is an authenticated user (normal or admin). Note that GUIPages::USER will be removed if
+                you have set $config['user_page'] = null.
+* __mandatory:__ no
+* __type:__ array of values from GUIPages constants
+* __default:__ array( GUIPages::HOME, GUIPages::USER, GUIPages::UPLOAD, GUIPages::TRANSFERS, GUIPages::GUESTS, GUIPages::DOWNLOAD, GUIPages::APISECRETAUP )
+* __available:__ since version 2.33
+* __comment:__ See also allow_pages_core
+
+
+### allow_pages_add_for_admin
+* __description:__ These values will be added to the allow_pages_core pages if the principal is an authenticated admin. This will be in addition to the values from allow_pages_add_for_user.
+* __mandatory:__ no
+* __type:__ array of values from GUIPages constants
+* __default:__ array( GUIPages::ADMIN )
+* __available:__ since version 2.33
+* __comment:__ See also allow_pages_core
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -309,6 +309,24 @@ $default = array(
     'service_aup_min_required_version' => 0,
 
     'cookie_domain' => '',
+
+    'allow_pages_core' => array(
+        GUIPages::DOWNLOAD, GUIPages::TRANSLATE_EMAIL,
+        GUIPages::LOGOUT, GUIPages::EXCEPTION,
+        GUIPages::HELP, GUIPages::ABOUT, GUIPages::PRIVACY ),
+
+    'allow_pages_add_for_guest' => array( GUIPages::HOME,
+                                          GUIPages::UPLOAD,
+                                          GUIPages::APISECRETAUP ),
+    'allow_pages_add_for_user' => array( GUIPages::HOME,
+                                         GUIPages::USER,
+                                         GUIPages::UPLOAD,
+                                         GUIPages::TRANSFERS,
+                                         GUIPages::GUESTS,
+                                         GUIPages::DOWNLOAD,
+                                         GUIPages::APISECRETAUP ),
+    'allow_pages_add_for_admin' => array( GUIPages::ADMIN ),
+    
     
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
This PR moves the fixed page lists that are allowed for unlogged in, guest, user, and admin to configuration settings with defaults provided. Note that the user_page is now handled by removing the user page if there are no configured settings for that page.

The allowed pages builds from allow_pages_core adding guest and user pages if the principal meets those requirements.

The new default is to allow unauthenticated users to view the privacy page so they can see information from there without needing to log in to the system.

This relates to https://github.com/filesender/filesender/issues/1261.