### PR TITLE
Only send a single email with all downloaded files listed after encrypted download to zip

### DIFF
--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -278,6 +278,11 @@ class Logger
         self::log(LogLevels::WARN, $message);
     }
 
+    public static function nefarious($message)
+    {
+        self::log(LogLevels::WARN, "nefarious activity suspected: " . $message);
+    }
+    
     /**
      * Log info
      *

--- a/www/download.php
+++ b/www/download.php
@@ -406,7 +406,7 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
 
 function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false) {
 
-    if( $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_DOWNLOAD'] ) {
+    if( $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_DOWNLOAD'] && $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_DOWNLOAD'] == 'true' ) {
     
         $archiveList = $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_CONTENTS'];
         if( $transfer && 
@@ -442,13 +442,13 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
             return;
         }
     }
-    
+
     if ($transfer->getOption(TransferOptions::ENABLE_RECIPIENT_EMAIL_DOWNLOAD_COMPLETE)) {
         if (array_key_exists('notify_upon_completion', $_REQUEST) && (bool) $_REQUEST['notify_upon_completion']) {
 
             try {
                 // do not email too often
-                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
+//                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
 
                 // Notify file download
                 ApplicationMail::quickSend('download_complete', $recipient, $ret);
@@ -465,7 +465,7 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
     if ($transfer->getOption(TransferOptions::EMAIL_DOWNLOAD_COMPLETE) && !$recently_downloaded) {
         try {
             // do not email too often
-            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
+//            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
             ApplicationMail::quickSend('files_downloaded', $transfer->owner, $ret, array('recipient' => $recipient));
         }
         catch ( RateLimitException $e ) {

--- a/www/download.php
+++ b/www/download.php
@@ -430,6 +430,8 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
                 }
                 
                 $ret['files'] = $files;
+            } else {
+                Logger::nefarious("badly formed header HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_CONTENTS");
             }
         }
         else
@@ -448,7 +450,7 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
 
             try {
                 // do not email too often
-//                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
+                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
 
                 // Notify file download
                 ApplicationMail::quickSend('download_complete', $recipient, $ret);
@@ -465,7 +467,7 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
     if ($transfer->getOption(TransferOptions::EMAIL_DOWNLOAD_COMPLETE) && !$recently_downloaded) {
         try {
             // do not email too often
-//            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
+            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
             ApplicationMail::quickSend('files_downloaded', $transfer->owner, $ret, array('recipient' => $recipient));
         }
         catch ( RateLimitException $e ) {

--- a/www/download.php
+++ b/www/download.php
@@ -405,12 +405,49 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
 
 
 function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false) {
+
+    if( $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_DOWNLOAD'] ) {
+    
+        $archiveList = $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_CONTENTS'];
+        Logger::error("AAA archiveList1 $archiveList ");
+        if( $transfer && 
+            $transfer->is_encrypted &&
+            strlen($archiveList))
+        {
+            // user data MUST be list of numbers only
+            if (preg_match("/^[0-9,]+$/", $archiveList)) {        
+                Logger::error("AAA archiveList2 $archiveList ");
+
+                $files = array();
+                $files_ids = array_filter(array_map('trim', explode(',', $_SERVER['HTTP_X_FILESENDER_ENCRYPTED_ARCHIVE_CONTENTS'])));
+                
+                foreach ($files_ids as $fileId) {
+                    $file = File::fromId($fileId);
+                    // no trying to sneak in files that are not in this transfer.
+                    if( $file->transfer_id != $transfer->id ) {
+                        Logger::nefarious("a fileid was supplied for a encrypted archive download that did not belong to the transfer");
+                        return;
+                    }
+                    $files[] = $file;
+                }
+                
+                $ret['files'] = $files;
+            }
+        }
+        else
+        {
+            Logger::error("AAA not first file...");
+            return;
+        }
+    }
+    Logger::error("AAA ret " . json_encode( $ret ));
+    
     if ($transfer->getOption(TransferOptions::ENABLE_RECIPIENT_EMAIL_DOWNLOAD_COMPLETE)) {
         if (array_key_exists('notify_upon_completion', $_REQUEST) && (bool) $_REQUEST['notify_upon_completion']) {
 
             try {
                 // do not email too often
-                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
+//                TranslatableEmail::rateLimit( true, 'download_complete', $recipient, $transfer );
 
                 // Notify file download
                 ApplicationMail::quickSend('download_complete', $recipient, $ret);
@@ -427,7 +464,7 @@ function manageOptions($ret, $transfer, $recipient, $recently_downloaded = false
     if ($transfer->getOption(TransferOptions::EMAIL_DOWNLOAD_COMPLETE) && !$recently_downloaded) {
         try {
             // do not email too often
-            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
+//            TranslatableEmail::rateLimit( true, 'files_downloaded', $transfer->owner, $transfer);
             ApplicationMail::quickSend('files_downloaded', $transfer->owner, $ret, array('recipient' => $recipient));
         }
         catch ( RateLimitException $e ) {

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -776,8 +776,6 @@ window.filesender.crypto_app = function () {
             oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', '1' );
             console.log("AAA downloadAndDecryptChunk fileidlist " + window.filesender.crypto_encrypted_archive_download_fileidlist );
 
-            oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Contents', window.filesender.crypto_encrypted_archive_download_fileidlist );
-            window.filesender.crypto_encrypted_archive_download_fileidlist = '';
             
             //
             // There are some extra things to do for streaming legacy type files
@@ -831,6 +829,10 @@ window.filesender.crypto_app = function () {
                 window.filesender.log("downloadAndDecryptChunk(adjustments done) "
                                       + " eoffset " + endoffset
                                       + " padding " + padding );
+
+                oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Contents', window.filesender.crypto_encrypted_archive_download_fileidlist );
+                window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+                
             }
             
             var brange = 'bytes=' + startoffset + '-' + endoffset;
@@ -1328,6 +1330,16 @@ window.filesender.crypto_app = function () {
                 + "." + archiveFormat;
             return archiveName;
         },
+        setDownloadFileidlist: function( selectedFiles ) {
+            var fileidlist = '';
+            for(var i=0; i<selectedFiles.length; i++) {
+                var f = selectedFiles[i];
+                fileidlist += f.fileid;
+                fileidlist += ',';
+            }
+            window.filesender.crypto_encrypted_archive_download_fileidlist = fileidlist;
+            console.log("AAA setDownloadFileidlist fileidlist " + fileidlist );
+        },
         decryptDownloadToZip: function(link,transferid,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
 
             var $this = this;
@@ -1341,14 +1353,7 @@ window.filesender.crypto_app = function () {
                 }
             };
 
-            var fileidlist = '';
-            for(var i=0; i<selectedFiles.length; i++) {
-                var f = selectedFiles[i];
-                fileidlist += f.fileid;
-                fileidlist += ',';
-            }
-            window.filesender.crypto_encrypted_archive_download_fileidlist = fileidlist;
-            console.log("AAA decryptDownloadToZip fileidlist " + fileidlist );
+//            $this.setDownloadFileidlist(selectedFiles);
             
             var prompt = window.filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -40,6 +40,11 @@ if (!('onPBKDF2AllEnded' in window.filesender)) {
 
 window.filesender.crypto_app_downloading = false;
 
+// list of fileid for this encrypted download
+window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+
+
+
 /*
  * Main entry points
  *   decryptDownload()
@@ -768,7 +773,12 @@ window.filesender.crypto_app = function () {
             var startoffset = 1 * (chunkid * chunksz);
             var endoffset   = 1 * (chunkid * chunksz + (1*$this.upload_crypted_chunk_size)-1);
             var legacyChunkPadding = 0;
+            oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', '1' );
+            console.log("AAA downloadAndDecryptChunk fileidlist " + window.filesender.crypto_encrypted_archive_download_fileidlist );
 
+            oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Contents', window.filesender.crypto_encrypted_archive_download_fileidlist );
+            window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+            
             //
             // There are some extra things to do for streaming legacy type files
             //
@@ -1330,6 +1340,15 @@ window.filesender.crypto_app = function () {
                     progress.html(window.filesender.config.language.file_encryption_wrong_password);
                 }
             };
+
+            var fileidlist = '';
+            for(var i=0; i<selectedFiles.length; i++) {
+                var f = selectedFiles[i];
+                fileidlist += f.fileid;
+                fileidlist += ',';
+            }
+            window.filesender.crypto_encrypted_archive_download_fileidlist = fileidlist;
+            console.log("AAA decryptDownloadToZip fileidlist " + fileidlist );
             
             var prompt = window.filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -774,7 +774,6 @@ window.filesender.crypto_app = function () {
             var endoffset   = 1 * (chunkid * chunksz + (1*$this.upload_crypted_chunk_size)-1);
             var legacyChunkPadding = 0;
             oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', '1' );
-            console.log("AAA downloadAndDecryptChunk fileidlist " + window.filesender.crypto_encrypted_archive_download_fileidlist );
 
             
             //
@@ -1338,7 +1337,6 @@ window.filesender.crypto_app = function () {
                 fileidlist += ',';
             }
             window.filesender.crypto_encrypted_archive_download_fileidlist = fileidlist;
-            console.log("AAA setDownloadFileidlist fileidlist " + fileidlist );
         },
         decryptDownloadToZip: function(link,transferid,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
 
@@ -1353,8 +1351,6 @@ window.filesender.crypto_app = function () {
                 }
             };
 
-//            $this.setDownloadFileidlist(selectedFiles);
-            
             var prompt = window.filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();
 

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -773,7 +773,7 @@ window.filesender.crypto_app = function () {
             var startoffset = 1 * (chunkid * chunksz);
             var endoffset   = 1 * (chunkid * chunksz + (1*$this.upload_crypted_chunk_size)-1);
             var legacyChunkPadding = 0;
-            oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', '1' );
+            oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', filesender.terasender.crypto_encrypted_archive_download );
 
             
             //
@@ -1350,6 +1350,7 @@ window.filesender.crypto_app = function () {
                     progress.html(window.filesender.config.language.file_encryption_wrong_password);
                 }
             };
+            filesender.terasender.crypto_encrypted_archive_download = true;
 
             var prompt = window.filesender.ui.prompt(window.filesender.config.language.file_encryption_enter_password, function (password) {
                 var pass = $(this).find('input').val();

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -1216,6 +1216,8 @@ window.filesender.crypto_app = function () {
         {
             var $this = this;
 
+            filesender.terasender.crypto_encrypted_archive_download = false;
+            
             callbackError = function (error) {
                 window.filesender.log(error);
                 window.filesender.crypto_app_downloading = false;

--- a/www/js/crypter/streamsaver_sink.js
+++ b/www/js/crypter/streamsaver_sink.js
@@ -152,7 +152,7 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
 
         downloadNext: function() {
             var $this = this;
-
+            
             if( $this.selectedFiles.length == 0 ) {
                 window.filesender.log("blobSinkStreamedzip64 no more files to add to archive... done");
                 $this.complete = true;
@@ -167,8 +167,20 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
                 $this.openFile(f.filename,f.fileid);
 
                 // last file in selection, tell server we are almost done.
-                if( $this.selectedFiles.length == 1 ) {
+                if( $this.selectedFiles.length == 0 ) {
+                    window.filesender.log("aaa blobSinkStreamedzip64 downloadNext(sel==1?) selfiles.len " + $this.selectedFiles.length );
                     window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
+
+                    var transfer = new filesender.transfer();
+                    if (transfer.canUseTeraReceiver()) {
+                        window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+                        if( window.filesender.terasender  ) {
+                            window.filesender.terasender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
+                        }
+                        
+                    }
+
+                    
                 }
                 
                 $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,

--- a/www/js/crypter/streamsaver_sink.js
+++ b/www/js/crypter/streamsaver_sink.js
@@ -99,6 +99,7 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
         activeFileID: null,
         progress: null,
         archiveName: archiveName,
+        crypto_encrypted_archive_download_fileidlist: '',
         onOpen:  function( blobSink, fileid ) { },
         onClose: function( blobSink, fileid ) { },
         onComplete: function( blobSink ) {},
@@ -114,7 +115,16 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
                 $this.zip.init($this.archiveName);
 
                 $this.totalFilesToDownload = selectedFiles.length;
+
+                $this.cryptoapp.setDownloadFileidlist( $this.selectedFiles );
+                $this.crypto_encrypted_archive_download_fileidlist = window.filesender.crypto_encrypted_archive_download_fileidlist;
+                window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+                
+                window.filesender.log("blobSinkStreamedzip64 init AAA fileidlist " + $this.crypto_encrypted_archive_download_fileidlist );
+                
             }
+
+            
         },
         error: function(error) {
             var $this = this;
@@ -158,6 +168,13 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
                 var f = $this.selectedFiles.shift();
                 window.filesender.log("blobSinkStreamedzip64 adding next file with name " + f.filename );
                 $this.openFile(f.filename,f.fileid);
+
+                window.filesender.log("blobSinkStreamedzip64 AAA selfiles length " + $this.selectedFiles.length );
+                if( $this.selectedFiles.length == 1 ) {
+                    window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
+                    window.filesender.log("blobSinkStreamedzip64 AAA fileidlist " + $this.crypto_encrypted_archive_download_fileidlist );
+                }
+                
                 $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,
                                                            $this.link+f.fileid,
                                                            f.mime, f.filename, f.filesize, f.encrypted_filesize,

--- a/www/js/crypter/streamsaver_sink.js
+++ b/www/js/crypter/streamsaver_sink.js
@@ -119,9 +119,6 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
                 $this.cryptoapp.setDownloadFileidlist( $this.selectedFiles );
                 $this.crypto_encrypted_archive_download_fileidlist = window.filesender.crypto_encrypted_archive_download_fileidlist;
                 window.filesender.crypto_encrypted_archive_download_fileidlist = '';
-                
-                window.filesender.log("blobSinkStreamedzip64 init AAA fileidlist " + $this.crypto_encrypted_archive_download_fileidlist );
-                
             }
 
             
@@ -169,10 +166,9 @@ window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferi
                 window.filesender.log("blobSinkStreamedzip64 adding next file with name " + f.filename );
                 $this.openFile(f.filename,f.fileid);
 
-                window.filesender.log("blobSinkStreamedzip64 AAA selfiles length " + $this.selectedFiles.length );
+                // last file in selection, tell server we are almost done.
                 if( $this.selectedFiles.length == 1 ) {
                     window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
-                    window.filesender.log("blobSinkStreamedzip64 AAA fileidlist " + $this.crypto_encrypted_archive_download_fileidlist );
                 }
                 
                 $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -196,7 +196,8 @@ $(function() {
                     if( fileaead.length ) {
                         fileaead = atob(fileaead);
                     }
-                    
+
+                    filesender.terasender.crypto_encrypted_archive_download = false;
                     crypto_app.decryptDownload( filesender.config.base_path
                                                 + 'download.php?token=' + token
                                                 + '&files_ids=' + ids.join(','),

--- a/www/js/terasender/terasender.js
+++ b/www/js/terasender/terasender.js
@@ -83,6 +83,12 @@ window.filesender.terasender = {
     crypto_app: null,
 
     /**
+     * To stop the server sending emails for each file in the encrypted download.
+     */
+    crypto_encrypted_archive_download_fileidlist: '',
+    crypto_encrypted_archive_download: false,
+    
+    /**
      * Send command to worker
      * 
      * @param worker workerinterface
@@ -134,7 +140,9 @@ window.filesender.terasender = {
                 roundtriptoken:     this.transfer.roundtriptoken,
                 link:               this.receiver.link,
                 security_token:     this.security_token,
-                csrfptoken:         filesender.client.getCSRFToken()
+                csrfptoken:         filesender.client.getCSRFToken(),
+                crypto_encrypted_archive_download: this.crypto_encrypted_archive_download,
+                crypto_encrypted_archive_download_fileidlist: this.crypto_encrypted_archive_download_fileidlist
             };
 
             this.log('allocateJob(recv) chunk:' + chunkid + ' giving job to worker');
@@ -259,7 +267,6 @@ window.filesender.terasender = {
         
         if(job) {
             this.log('Found job file:' + (job.file ? job.file.id : worker.file_id) + '[' + job.chunk.start + '...' + job.chunk.end + ']');
-            
             workerinterface.status = 'uploading';
             this.sendCommand(workerinterface, 'executeJob', job);
         }else{

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -133,7 +133,8 @@ var terasender_worker = {
                 var startoffset = 1 * (chunkid * chunksz);
                 var endoffset   = 1 * (chunkid * chunksz + (1*this.crypto_app.upload_crypted_chunk_size)-1);
                 var legacyChunkPadding = 0;
-
+                oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', job.crypto_encrypted_archive_download );
+                
                 //
                 // There are some extra things to do for streaming legacy type files
                 //
@@ -186,6 +187,11 @@ var terasender_worker = {
                     this.log("ts.worker executeJob(adjustments done) "
                              + " eoffset " + endoffset
                              + " padding " + padding );
+
+                    if( job.crypto_encrypted_archive_download_fileidlist ) {
+                        oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Contents', job.crypto_encrypted_archive_download_fileidlist );
+                        job.crypto_encrypted_archive_download_fileidlist = '';
+                    }
                 }
                 
                 var brange = 'bytes=' + startoffset + '-' + endoffset;


### PR DESCRIPTION
When multiple files are selected this PR will delay "file downloaded" to the end and send a single email will the names of all the files that were downloaded by a user.

This should fix https://github.com/filesender/filesender/issues/1220.