### PR TITLE
db: mariadb test the TEXT CHARACTER SET for utf8mb4 value

### DIFF
--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -256,6 +256,12 @@ function verifyTableCharacterSetForTable( $class )
             if( $d['db_charset'] != 'utf8mb4' ) {
                 echo "WARNING The database table $table has a string/text column with an incorrect character set!\n";
                 echo "WARNING   please update column $column to use utf8mb4 \n";
+
+                $coldef = Database::columnDefinition($d);
+                $query = 'ALTER TABLE '.$table.' MODIFY '.$column.' '.$coldef. ' COLLATE utf8mb4 ';
+                echo "SQL : " . $query . "\n";
+                //DBI::exec($query);
+                
             }
         }
     }


### PR DESCRIPTION
Because the text character set is taken from containing objects I have put a warning here if the value is not the expected one. This allows an admin to know that they might like to change the utf8 to utf8mb4 at the correct level (table or database).

There is also an option which is shown in the error message itself to allow the script to be run ignoring this issue. This allows an admin to continue to update FileSender as they may have done before and schedule a character set change at their leisure rather than right now in order to update.

This is related to https://github.com/filesender/filesender/issues/1285.
