### PR TITLE
upload page: convert blank expire time to original value

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -1195,7 +1195,7 @@ window.filesender.transfer = function() {
         if (this.size > filesender.config.max_transfer_size) {
             return errorhandler({message: 'transfer_maximum_size_exceeded', details: {size: file.size, max: filesender.config.max_transfer_size}});
         }
-         
+        
         var today = Math.floor((new Date()).getTime() / (24 * 3600 * 1000));
         var minexpires = today - 1;
         var maxexpires = today + filesender.config.max_transfer_days_valid + 1;

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -180,7 +180,7 @@ filesender.ui.elements.preventEmpty = function(el) {
     el.on( 'focus', function(e) { originalValue = e.target.value; } );
     el.on( 'blur',  function(e) {
         if( e.target.value == '' ) {
-            e.target.value = originalValue;
+            filesender.ui.setDateFromEpochData( filesender.ui.nodes.expires );
         }
     });
     return this;
@@ -1076,7 +1076,7 @@ filesender.ui.startUpload = function() {
     }
     window.filesender.pbkdf2dialog.setup(!can_use_terasender);
     window.filesender.pbkdf2dialog.reset();
-    
+
     if(!filesender.ui.nodes.required_files) {
         this.transfer.expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
         


### PR DESCRIPTION
I see the previous fix appeared to revert the value on the upload page but after the new transfer was uploaded the expire time was not set correctly. This update should fix that.

This relates to https://github.com/filesender/filesender/issues/1149