### PR TITLE
Make files, filecollections, and transfer ids bigints.

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -47,13 +47,13 @@ class File extends DBObject
         //file id, as in the database
         'id' => array(
             'type' => 'uint',   //data type of 'id'
-            'size' => 'medium', //size of the integer stored in 'id' (in bytes, or otherwise)
+            'size' => 'big',    //size of the integer stored in 'id' (in bytes, or otherwise)
             'primary' => true,  //indicates that 'id' is the primary key in the DB
             'autoinc' => true,   //indicates that 'id' is auto-incremented
         ),
         'transfer_id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
         ),
         'uid' => array(
             'type' => 'string',

--- a/classes/data/FileCollection.class.php
+++ b/classes/data/FileCollection.class.php
@@ -46,13 +46,13 @@ class FileCollection extends DBObject
         //primary key pair <collection_id,file_id>
         'collection_id' => array(
             'type' => 'uint',   //data type of 'id'
-            'size' => 'medium',
+            'size' => 'big',
             'primary' => true,
         ),
         'file_id' => array(
             'type' => 'uint',   //data type of 'id'
-            'size' => 'medium',
-                        'primary' => true,
+            'size' => 'big',
+            'primary' => true,
         ),
     );
 

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -50,7 +50,7 @@ class Transfer extends DBObject
     protected static $dataMap = array(
         'id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
             'primary' => true,
             'autoinc' => true
         ),


### PR DESCRIPTION
The File.id was a medium which was implemented as a 24 bit number by the mariadb translation layer. This can overflow after 8 million files so this PR updates that and some other identifiers to explicitly be "big" integers which should be 64 bit and not cause any issues for "a while".

I have used the database.php migration script on both mariadb and postgresql though installations will want to test the update to their satisfaction.

This relates to https://github.com/filesender/filesender/issues/1293.