### PR TITLE
mysql/mariadb backed filesender

### DIFF
--- a/classes/utils/DatabaseMysql.class.php
+++ b/classes/utils/DatabaseMysql.class.php
@@ -230,7 +230,15 @@ class DatabaseMysql
                 if (!$size) {
                     $size = 'medium';
                 }
-                $typematcher = $size.'int(?:\([0-9]+\))';
+                if( $size == 'medium' ) {
+                    // 4 bytes for alignment 2022 march.
+                    $typematcher = 'int(?:\(11\))';
+                    if( $definition['type'] == 'uint' ) {
+                        $typematcher = 'int(?:\(10\))';
+                    }
+                } else {
+                    $typematcher = $size.'int(?:\([0-9]+\))';
+                }
                 if ($definition['type'] == 'uint') {
                     $typematcher .= ' unsigned';
                 }
@@ -272,6 +280,7 @@ class DatabaseMysql
         // Check type
         if (!preg_match('`'.$typematcher.'`i', $column_dfn['Type'])) {
             $logger($column.' type does not match '.$typematcher);
+            $logger("  ... found " . $column_dfn['Type']);
             $non_respected[] = 'type';
         }
         
@@ -386,7 +395,12 @@ class DatabaseMysql
                 if (!$size) {
                     $size = 'medium';
                 }
-                $mysql = strtoupper($size).'INT';
+                if( $size == 'medium' ) {
+                    // 4 bytes for alignment 2022 march.
+                    $mysql = 'INTEGER';
+                } else {
+                    $mysql = strtoupper($size).'INT';
+                }
                 if ($definition['type'] == 'uint') {
                     $mysql .= ' UNSIGNED';
                 }

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -496,6 +496,9 @@ try {
         echo 'Done removing views for table '.$table."\n";
     }
 
+
+    
+
     
 
     echo "checking for major schema migrations\n";

--- a/scripts/upgrade/migration-drop-foreign-keys.php
+++ b/scripts/upgrade/migration-drop-foreign-keys.php
@@ -34,6 +34,7 @@ require_once dirname(__FILE__).'/../../includes/init.php';
 
 Logger::setProcess(ProcessTypes::UPGRADE);
 
+DBI::beginTransaction();
 
 DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_epochtype  ' );
 DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_eventtype  ' );
@@ -42,5 +43,6 @@ DBI::exec( 'alter table StatLogs  drop foreign key IF EXISTS statlogs_operatings
 DBI::exec( 'alter table Transfers drop foreign key IF EXISTS transfer_passwordencoding  ' );
 DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_digestnameid' );
 DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_fileid' );
+
 
     

--- a/scripts/upgrade/migration-drop-foreign-keys.php
+++ b/scripts/upgrade/migration-drop-foreign-keys.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../includes/init.php';
+
+Logger::setProcess(ProcessTypes::UPGRADE);
+
+
+DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_epochtype  ' );
+DBI::exec( 'alter table AggregateStatistics  drop foreign key IF EXISTS AggregateStatistic_eventtype  ' );
+DBI::exec( 'alter table StatLogs  drop foreign key IF EXISTS statlogs_browsertype  ' );
+DBI::exec( 'alter table StatLogs  drop foreign key IF EXISTS statlogs_operatingsystem  ' );
+DBI::exec( 'alter table Transfers drop foreign key IF EXISTS transfer_passwordencoding  ' );
+DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_digestnameid' );
+DBI::exec( 'alter table FileChunkDigests drop foreign key IF EXISTS FileChunkDigest_fileid' );
+
+    


### PR DESCRIPTION
This moves meduimint from 24 to 32 bit.

This requires foreign keys to be removed temporarily. Note that database.php should recreate them at the end of it's execution. This should be a safe update though it may take some time to migrate many int fields to 32 bit so one should expect delays when updating this time.

```
php migration-drop-foreign-keys.php 
php database.php
```

This only effects mysql/mariadb so postgresql users do *not* need to perform the `php migration-drop-foreign-keys.php ` step.

This relates to https://github.com/filesender/filesender/issues/174 and will close it.
