### PR TITLE
db: make guest id a big int too

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -46,7 +46,7 @@ class Guest extends DBObject
     protected static $dataMap = array(
         'id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
             'primary' => true,
             'autoinc' => true
         ),

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -64,7 +64,7 @@ class Transfer extends DBObject
         ),
         'guest_id' => array(
             'type' => 'uint',
-            'size' => 'medium',
+            'size' => 'big',
             'null' => true
         ),
         'lang' => array(


### PR DESCRIPTION
As the user id is already a big int it makes sense that guest id should also be a big int. 