### PR TITLE
guests: config option to allow a guest to extend voucher expire time

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -323,7 +323,9 @@ class RestEndpointGuest extends RestEndpoint
         // Need to extend expiry date
         if ($data->extend_expiry_date) {
             if( !Auth::isAdmin()) {
-                throw new RestAdminRequiredException();
+                if( Config::get("allow_guest_expiry_date_extension") == 0 ) {
+                    throw new RestAdminRequiredException();
+                }
             }
             $guest->extendObjectExpiryDate();
             return self::cast($guest);

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -2184,14 +2184,17 @@ This is only for old, existing transfers which have no roundtriptoken set.
 
 ### allow_guest_expiry_date_extension
 
-* __description:__ This is an untested matching config option to allow_guest_expiry_date_extension_admin. It is best to reserve this config keyword now to allow future versions to allow some users to extend their guests if desired. Extending guest expire time is only available via the admin page as at release 2.23.
-* __mandatory:__
+* __description:__ Setting this option will allow normal users to extend their guest vouchers. This can be useful for example when a user has sent a guest voucher and receives an out of office reply email. The user might like to return to the guest page and click "extend" to make the the guest voucher valid for a longer period of time to be valid after the guest has returned to the office.
+* __mandatory:__ no
 * __type:__ an array of integers containing possible extensions in days.
-* __default:__ - (= not activated)
-* __available:__ since version 2.23
+* __default:__ 0 (= not activated)
+* __available:__ since version 2.34
 * __1.x name:__
 * __comment:__
 * __Examples:__
+
+        // Allows infinite extensions, the first is by 30 days then 90 days 
+        $config['allow_guest_expiry_date_extension'] = array(30, 90, true); 
 
 
 ### allow_guest_expiry_date_extension_admin

--- a/www/js/guests_table.js
+++ b/www/js/guests_table.js
@@ -63,6 +63,21 @@ $(function() {
                 });
             });
 
+            if(table.is('[data-mode!="admin"]')) {
+                var days = $(this).closest('.objectholder').attr('data-expiry-extension');
+                if( days > 0 ) {
+                    var extend = $('<span data-action="extendguestexpires" class="extend clickable fa fa-lg fa-clock-o" />');
+                    extend.appendTo(td).attr({
+                        title: lang.tr('extend_expiry_date').r({
+                            days: $(this).closest('.objectholder').attr('data-expiry-extension')
+                        })
+                        
+                    }).on('click', function() {
+                        filesender.ui.extendExpires( extend, 'guest' );
+                    });
+                }
+            }
+            
             if(table.is('[data-mode="admin"]')) {
                 var days = $(this).closest('.objectholder').attr('data-expiry-extension');
                 if( days > 0 ) {

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -610,7 +610,7 @@ window.filesender.ui = {
         if(!id || isNaN(id)) return;
         
         var duration = parseInt(t.attr('data-expiry-extension'));
-        
+
         var extend = function(remind) {
             filesender.client.extendObject(className,id, remind, function(t) {
                 $('.objectholder[data-id="' + id + '"]').attr('data-expiry-extension', t.expiry_date_extension);


### PR DESCRIPTION
This enables the allow_guest_expiry_date_extension option to enable a regular system user to be able to extend the expire time for one of their guest vouchers. With this setting configured an expand icon appears in the actions on the guests page for a user.

This will help when a user sends a voucher to invite a guest and receives an out of office reply from the guest's email address. The user can then come back and extend the expires time for that guest voucher to allow the guest to use it when they return to the office.

For example, to allow 10 day extensions without a limit the below can be used:

```
$config['allow_guest_expiry_date_extension'] = array(10,true);
```
