### PR TITLE
mariadb: do not try transactions on DDL heavy script

### DIFF
--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -75,6 +75,7 @@ if( $db_database ) {
 echo "current db_database is " . Config::get('db_database') . "\n";
 
 $currentSchemaVersion = Metadata::getLatestUsedSchemaVersion();
+$dbtype = Config::get('db_type');
 if( $dbtype != 'mysql' ) {
     DBI::beginTransaction();
 }
@@ -744,6 +745,7 @@ try {
 
 echo "\n\n";
 echo "All core code worked (leaving foreign keys), commit to database starting...\n";
+$dbtype = Config::get('db_type');
 if( $dbtype != 'mysql' ) {
     DBI::commit();
 }

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -75,7 +75,9 @@ if( $db_database ) {
 echo "current db_database is " . Config::get('db_database') . "\n";
 
 $currentSchemaVersion = Metadata::getLatestUsedSchemaVersion();
-DBI::beginTransaction();
+if( $dbtype != 'mysql' ) {
+    DBI::beginTransaction();
+}
 
 
 // Get data classes
@@ -724,16 +726,17 @@ try {
         echo '    " MariaDB (...) supports rollback of SQL-data change statements, but not of SQL-Schema statements."  ' . "\n";
         echo "    --  https://mariadb.com/kb/en/rollback/ \n";
         echo "\n";
+        echo "as this script performs mostly DDL statements transactions are not used for mariadb\n";
         echo "you should either get a full run of this script or compare the output to a backup\n";
     } else {
         echo " This should leave the database state as it was before you started the script\n";
+        DBI::rollBack();
     }
     if( $majorMigrationPerformed ) {
         echo "\n";
         echo "NOTE: As this was a major database schema update you might like to compare with a backup\n";
         echo "\n";
     }        
-    DBI::rollBack();
     $uid = ($e instanceof LoggingException) ? $e->getUid() : 'no available uid';
     echo 'Encountered exception : ' . $e->getMessage() . ', see logs for details (uid: '.$uid.') ...\n';
     exit(1);
@@ -741,7 +744,9 @@ try {
 
 echo "\n\n";
 echo "All core code worked (leaving foreign keys), commit to database starting...\n";
-DBI::commit();
+if( $dbtype != 'mysql' ) {
+    DBI::commit();
+}
 echo "Commit went well, those changes are now permanent\n";
 
 


### PR DESCRIPTION
As mariadb does not allow rollback for transactions over ddl statements and database.php is mostly going to do ddl maybe do not try to wrap it in a transaction for mariadb.

This relates to https://github.com/filesender/filesender/issues/1309