### PR TITLE
Ensure identity is a string

### DIFF
--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -315,7 +315,7 @@ class Recipient extends DBObject
         }
         
         if ($property == 'identity') {
-            return $this->email ? $this->email : Lang::tr('anonymous');
+            return $this->email ? $this->email : (string)Lang::tr('anonymous');
         }
         
         if ($property == 'name') {


### PR DESCRIPTION
Otherwise rendering of anonymous recipient in translations leads to a "1" being displayed. This is because Lang::tr returns an object, which will be converted to boolean true by the translation placeholder handler, which will be converted to "1" during later concatenation ...