### PR TITLE
relates to issue 1332 with guest after upload message

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1162,11 +1162,12 @@ filesender.ui.startUpload = function() {
         
         var close = function() {
             window.filesender.notification.clear();
-            filesender.ui.goToPage(
-                filesender.ui.transfer.guest_token ? 'home' : 'transfers',
-                reditectargs,
-                filesender.ui.transfer.guest_token ? null : 'transfer_' + filesender.ui.transfer.id
-            );
+            if( filesender.ui.transfer.guest_token ) {
+                filesender.ui.goToPage( 'home', null, null );
+            } else {
+                filesender.ui.goToPage( 'transfers', reditectargs,
+                                        'transfer_' + filesender.ui.transfer.id );
+            }
         };
 
         var p = filesender.ui.alert('success', lang.tr('done_uploading'), close);


### PR DESCRIPTION
This relates to issue https://github.com/filesender/filesender/issues/1332 and is a slight update to the solution provided by @liedekef inline on that issue. I think it is simpler to have two different function calls rather than each of the 3 args being conditional on the guest condition. Granted that two inline conditionals were already there but the functions read a little easier this way so it's a little clean up at the same time.

Thanks @liedekef :)