### PR TITLE
security: allow remote user and app to not have to perform CSRF

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -111,7 +111,15 @@ class Auth
             session_start($opts);
         }
     }
+
     
+    /**
+     * Are remote users or applications an enabled feature for this server
+     */
+    public static function isRemoteFeatureEnabled()
+    {
+        return Config::get('auth_remote_application_enabled') || Config::get('auth_remote_user_enabled');
+    }
     
     /**
      * Return current user if it exists.
@@ -138,7 +146,7 @@ class Auth
                 } elseif (AuthLocal::isAuthenticated()) { // Local (script)
                     self::$attributes = AuthLocal::attributes();
                     self::$type = 'local';
-                } elseif ((Config::get('auth_remote_application_enabled') || Config::get('auth_remote_user_enabled')) && AuthRemote::isAuthenticated()) { // Remote application/user
+                } elseif (self::isRemoteFeatureEnabled() && AuthRemote::isAuthenticated()) { // Remote application/user
                     if (
                         (AuthRemote::application() && Config::get('auth_remote_application_enabled')) ||
                         (!AuthRemote::application() && Config::get('auth_remote_user_enabled'))

--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -89,15 +89,9 @@ class RestServer
             if (array_key_exists('PATH_INFO', $_SERVER)) {
                 $path = array_filter(explode('/', $_SERVER['PATH_INFO']));
             }
-            
+
             // Get method from possible headers
-            $method = null;
-            foreach (array('X_HTTP_METHOD_OVERRIDE', 'REQUEST_METHOD') as $k) {
-                if (!array_key_exists($k, $_SERVER)) {
-                    continue;
-                }
-                $method = strtolower($_SERVER[$k]);
-            }
+            $method = Utilities::getHTTPMethod();
 
             // Record called method (for log), fail if unknown
             RestException::setContext('method', $method);

--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -97,6 +97,16 @@ class Security
     public static function validateAgainstCSRF( $canReturnJSON = false )
     {
         $checkToken = Utilities::isTrue(Config::get('owasp_csrf_protector_enabled'));
+        $method = Utilities::getHTTPMethod();
+
+        //
+        // Remote API users and applications do not need to do CSRF
+        //
+        if( Auth::isRemoteFeatureEnabled()) {
+            if( Auth::isRemote() && AuthRemote::isAuthenticated()) {
+                return;
+            }
+        }
 
         if (Auth::isGuest()) {
             $checkToken = true;

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -584,6 +584,22 @@ class Utilities
         return $token_to_check === self::$security_token['old']['value'];
     }
 
+    /**
+     * Get the URL method
+     */
+    public static function getHTTPMethod()
+    {
+        // Get method from possible headers
+        $method = null;
+        foreach (array('X_HTTP_METHOD_OVERRIDE', 'REQUEST_METHOD') as $k) {
+            if (!array_key_exists($k, $_SERVER)) {
+                continue;
+            }
+            $method = strtolower($_SERVER[$k]);
+        }
+        return $method;
+    }
+    
 
     /**
      * Read the config $configkey and if it is set then regex


### PR DESCRIPTION
This is the CSRF part of https://github.com/filesender/filesender/pull/1233 with the logic moved into the always made `validateAgainstCSRF()` call.