### PR TITLE
New Option: log downloads from authenticated users as recipients

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -450,6 +450,14 @@ class Auth
         return self::$isAdmin && !self::isGuest();
     }
 
+    /**
+     * Current user is not an admin, not remote, not guest.
+     */
+    public static function isRegularUser()
+    {
+        return !self::isAdmin() && !self::isRemote() && !self::isGuest();
+    }
+
     public static function canViewAggregateStatistics()
     {
         if (is_null(self::$canViewAggregateStats)) {

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -161,6 +161,7 @@ class Recipient extends DBObject
         
         return $recipient;
     }
+
     
     /**
      * Create a new recipient bound to a transfer

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -176,6 +176,7 @@ A note about colours;
 * [streamsaver_on_edge](#streamsaver_edge)
 * [streamsaver_on_safari](#streamsaver_safari)
 * [recipient_reminder_limit](#recipient_reminder_limit)
+* [log_user_download_by_ensure_user_as_recipient](#log_user_download_by_ensure_user_as_recipient)
 
 ## Graphs
 
@@ -1886,6 +1887,31 @@ This is only for old, existing transfers which have no roundtriptoken set.
     defaulted to 50 so the default configuration will effectively
     remain the same as before 2.30 but now these settings can be
     changed independently.
+
+
+### log_user_download_by_ensure_user_as_recipient
+
+* __description:__ Log the saml Identifiant for downloads performed by authenticated users
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since before version 2.39
+* __comment:__ This option allows a user to see which authenticated users have
+     downloaded their transfers. This is mainly useful when the
+     transfer is created with "get a link" and that link is shared by
+     the user with other users outside of the system. If another user
+     logs into the FileSender server and downloads a file from a
+     transfer then the authenticated downloader is logged against each
+     file that they download.
+     This logging is not done when the user has admin privlidges.
+     
+     This option will ensure that there is an entry in the recipients
+     table for the transfer for the saml Identifiant (normally email
+     address) of an authenticated user who is downloading a file. This
+     has privacy implications as the person who created a transfer may
+     be able to see the email address of each authenticated user who
+     has downloaded each file.
+
 
 
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1897,20 +1897,31 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __default:__ false
 * __available:__ since before version 2.39
 * __comment:__ This option allows a user to see which authenticated users have
-     downloaded their transfers. This is mainly useful when the
-     transfer is created with "get a link" and that link is shared by
-     the user with other users outside of the system. If another user
-     logs into the FileSender server and downloads a file from a
-     transfer then the authenticated downloader is logged against each
-     file that they download.
-     This logging is not done when the user has admin privlidges.
+     downloaded their transfers. This option is most effective when
+     "User must login to FileSender to download file" is enabled for a transfer.
+
+     This is mainly useful when the transfer is created with "get a
+     link" and that link is shared by the user with other users
+     outside of the system. If another user logs into the FileSender
+     server and downloads a file from a transfer then the
+     authenticated downloader is logged against each file that they
+     download. This logging is not done when the user has admin
+     privileges.
      
      This option will ensure that there is an entry in the recipients
      table for the transfer for the saml Identifiant (normally email
      address) of an authenticated user who is downloading a file. This
      has privacy implications as the person who created a transfer may
      be able to see the email address of each authenticated user who
-     has downloaded each file.
+     has downloaded each file. One should be aware of and accept this
+     arrangement before enabling this feature for a FileSender
+     installation.
+
+     Note that if a regular user visits a download link and they are
+     allowed to download because "User must login to FileSender to
+     download file" is not selected then the user can download without
+     log in and thus the exact user is not known for the download log.
+     
 
 
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -176,7 +176,7 @@ A note about colours;
 * [streamsaver_on_edge](#streamsaver_edge)
 * [streamsaver_on_safari](#streamsaver_safari)
 * [recipient_reminder_limit](#recipient_reminder_limit)
-* [log_user_download_by_ensure_user_as_recipient](#log_user_download_by_ensure_user_as_recipient)
+* [log_authenticated_user_download_by_ensure_user_as_recipient](#log_authenticated_user_download_by_ensure_user_as_recipient)
 
 ## Graphs
 
@@ -1889,7 +1889,7 @@ This is only for old, existing transfers which have no roundtriptoken set.
     changed independently.
 
 
-### log_user_download_by_ensure_user_as_recipient
+### log_authenticated_user_download_by_ensure_user_as_recipient
 
 * __description:__ Log the saml Identifiant for downloads performed by authenticated users
 * __mandatory:__ no

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -206,7 +206,7 @@ $default = array(
 
     'user_page' => array('lang'=>true,'auth_secret'=>true,'id'=>true,'created'=>true),
 
-    'log_user_download_by_ensure_user_as_recipient' => false,
+    'log_authenticated_user_download_by_ensure_user_as_recipient' => false,
     
 
     // Logging

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -206,6 +206,9 @@ $default = array(
 
     'user_page' => array('lang'=>true,'auth_secret'=>true,'id'=>true,'created'=>true),
 
+    'log_user_download_by_ensure_user_as_recipient' => false,
+    
+
     // Logging
     'log_facilities' => array(
         array(

--- a/www/download.php
+++ b/www/download.php
@@ -72,7 +72,7 @@ try {
         $transfer = $recipient->transfer;
 
 
-        if( Config::get('log_user_download_by_ensure_user_as_recipient')) {
+        if( Config::get('log_authenticated_user_download_by_ensure_user_as_recipient')) {
             if( Auth::isRegularUser()) {
                 $user = Auth::user();
                 $email = $user->saml_user_identification_uid;

--- a/www/download.php
+++ b/www/download.php
@@ -70,6 +70,26 @@ try {
         
         // Getting associated transfer 
         $transfer = $recipient->transfer;
+
+
+        if( Config::get('log_user_download_by_ensure_user_as_recipient')) {
+            if( Auth::isRegularUser()) {
+                $user = Auth::user();
+                $email = $user->saml_user_identification_uid;
+                $found = false;
+                foreach($transfer->recipients as $r) {
+                    if( $r->email == $email ) {
+                        $recipient = $r;
+                        $found = true;
+                        break;
+                    }
+                }
+                if( !$found ) {
+                    $recipient = $transfer->addRecipient($email);
+                }
+                $token = $recipient->token;
+            }
+        }
         
     } elseif(Auth::isAuthenticated()) {
         // Direct owner/admin download
@@ -88,6 +108,7 @@ try {
                 
     } else
         throw new TokenIsMissingException();
+
     
     // Are all files from the transfer ?
     $not_from_transfer = array();
@@ -104,11 +125,10 @@ try {
     // Close session to avoid simultaneous requests from being locked
     session_write_close();
     
+    $recently_downloaded = false;
     // Check if file set has already been downloaded over the last hour
     if( Config::get('logs_limit_messages_from_same_ip_address')) {
         $recently_downloaded = $recipient ? AuditLog::clientRecentlyDownloaded($recipient, $files_ids) : false;
-    } else {
-        $recently_downloaded = false;
     }
 
     $archive_format_selected = false;
@@ -396,8 +416,9 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     if($done) {
         Logger::info('User downloaded file or file ranges ('.$size.' bytes, '.(time() - $time).' seconds)');
         
-        if(!$recently_downloaded)
+        if(!$recently_downloaded) {
             Logger::logActivity(LogEventTypes::DOWNLOAD_ENDED, $file, $recipient);
+        }
     }
     
     return array('result' => $done, 'files' => array($file));


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/1314

This is mostly to be able to see which authenticated users on the same system have downloaded your "get a link" transfers. This is a little tricky as the logging system revolves around the non "get a link" work flow. In that way, each email that is added to a transfer is added to the recipients table for this transfer. Then when a user visits the download page their token uniquely identifies that guest for that transfer as a single tuple in the recipients table. That recipient tuple/object is then used by the system to log their download activity.

Rather than specialise the paths for both recipient and user to allow logging the authenticated user who is downloading, this PR adds a new tuple to the recipients table for the authenticated user. This effectively makes the user a recipient of the transfer when they download. They will have had to have a valid link to the transfer with a valid token in order to download. This will have had to have been shared by the transfer creator as the token is very hard to guess.

As this has privacy implications it is off by default and must be enabled with the new `log_authenticated_user_download_by_ensure_user_as_recipient` config option.
