### PR TITLE
Language default and fallback fixes

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -240,8 +240,10 @@ class Lang
                 }
             }
             
-            // Absolute default
-            $stack[] = 'en';
+            // Absolute default, but avoid adding "en" if already set as default
+            if (!in_array('en', $stack)) {
+                $stack[] = 'en';
+            }
             
             // Add to cached stack (most significant first)
             $main = array_shift($stack);
@@ -458,14 +460,20 @@ class Lang
             $stack = self::getCodeStack();
             Logger::warn('No translation found for '.$id.' in '.$stack['main'].' language');
             
-            if (array_key_exists($id, self::$translations['fallback'])) {
-                Logger::warn('No fallback translation found for '.$id.' in '.implode(', ', $stack['fallback']).' languages');
-            
-                $tr = self::$translations['fallback'][$id];
-                $src = 'fallback';
-            } else {
-                return new Translation('{'.$id.'}', false);
-            }
+            // fallback is an array of lang codes, so loop through those
+            foreach (self::$translations['fallback'] as $fallback_lang) {
+                if (array_key_exists($id, $fallback_lang)) {
+                    $tr = $fallback_lang[$id];
+                    $src = 'fallback';
+                    // we stop on first match
+                    continue;
+                }       
+            }           
+
+            if (empty($src) && !empty(self::$translations['fallback'])) {
+                Logger::warn('No fallback translation found for '.$id.' in '.implode(', ', $self::$translations['fallback']).' languages');
+                return new Translation('{'.$id.'}', false); 
+            }       
         }
         
         // File based ? Then loads it up and cache contents


### PR DESCRIPTION
Avoid adding en as fallback if already the default. Also "fallback" is an arrya of language codes, so loop through those to find the translation and stop on first match