### PR TITLE
Update for a log entry in language fallback mode and cleaner language selector.

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -459,19 +459,21 @@ class Lang
         } else {
             $stack = self::getCodeStack();
             Logger::warn('No translation found for '.$id.' in '.$stack['main'].' language');
-            
+
+            $fallbackid = null;
             // fallback is an array of lang codes, so loop through those
             foreach (self::$translations['fallback'] as $fallback_lang) {
                 if (array_key_exists($id, $fallback_lang)) {
                     $tr = $fallback_lang[$id];
                     $src = 'fallback';
+                    $fallbackid = $id;
                     // we stop on first match
                     continue;
                 }       
             }           
 
             if (empty($src) && !empty(self::$translations['fallback'])) {
-                Logger::warn('No fallback translation found for '.$id.' in '.implode(', ', $self::$translations['fallback']).' languages');
+                Logger::warn('No fallback translation found for '.$id.' in '.$fallbackid.' languages');
                 return new Translation('{'.$id.'}', false); 
             }       
         }

--- a/templates/header.php
+++ b/templates/header.php
@@ -68,9 +68,15 @@ $headerclass = "header";
                             echo '       <ul>';
                             $opts = array();
                             $code = Lang::getCode();
+                            $prevname = null;
+                            
                             foreach(Lang::getAvailableLanguages() as $id => $dfn) {
                                 $selected = ($id == $code) ? 'selected="selected"' : '';
+                                if( $prevname && $prevname == $dfn['name'] ) {
+                                    continue;
+                                }
                                 $opts[] = '<option value="'.$id.'" '.$selected.'>'.Utilities::sanitizeOutput($dfn['name']).'</option>';
+                                $prevname = $dfn['name'];
                             }
                         
                             echo '<li><label>'.Lang::tr('user_lang').'</label><select id="language_selector">'.implode('', $opts).'</select></li>';


### PR DESCRIPTION
lang: the self reference there wasnt good. Only log the id to avoid super verbose logs
lang: Consecutive entries with the same language name are avoided in the language drop down.