### PR TITLE
set HSTS in the apache template config

### DIFF
--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -14,6 +14,7 @@ Alias /filesender /opt/filesender/filesender/www
         Header always append X-Frame-Options SAMEORIGIN
         Header always edit Set-Cookie "^((?!csrfptoken).)+$" "$0; HttpOnly"
         Header always edit Set-Cookie (.*) "$1; SameSite=Strict "
+        Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains"
         
 	Options SymLinksIfOwnerMatch
         Options -Indexes

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -407,6 +407,10 @@ been added to the apache template shown below. This will prevent the
 SimpleSAML authentication cookies being sent to the site from cross
 site requests.
 
+The apache template configuration file also sets the HTTP
+Strict-Transport-Security (HSTS) header for all FileSender responses
+not just php pages.
+
 
 
 # Step 5-apache - Configure Apache


### PR DESCRIPTION
The HSTS header is now broadly set for js and other files in the configuration template.
This relates to 4.1.8. of Computest Jan. 2, 2023 Version 1.0.
