### PR TITLE
Concurency and resilience changes to filesender.py

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -137,7 +137,7 @@ except requests.exceptions.SSLError as exc:
     print(exc)
     print('Running with --insecure flag, ignoring warning...')
     info_response = requests.get(base_url+'/info', verify=False)
-    config_response = requests.get(base_url[-9]+'/filesender-config.js.php',verify=True)
+    config_response = requests.get(base_url[-9]+'/filesender-config.js.php',verify=False)
 
 upload_chunk_size = info_response.json()['upload_chunk_size']
 
@@ -421,7 +421,6 @@ try:
     if debug:
       print('putChunks: '+path)
     with open(path, mode='rb', buffering=0) as fin:
-      total_chunks = size
       progressed_cunks = 0
       with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as e:
         fut = [e.submit((lambda x:putChunk(transfer, f, fin.read(upload_chunk_size), x)), i) for i in range(0,size,upload_chunk_size)]

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -125,7 +125,7 @@ if args.apikey is not None:
 #configs
 try:
   info_response = requests.get(base_url+'/info', verify=True)
-  config_response = requests.get(base_url[0:-9]+'/filesender-config.js.php',verify=True) #ideally these are also in info. but who knows php...
+  config_response = requests.get(base_url[0:-9]+'/filesender-config.js.php',verify=True)#for terasender config not in info.
 except requests.exceptions.SSLError as exc:
   if not insecure:
     print('Error: the SSL certificate of the server you are connecting to cannot be verified:')

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -161,9 +161,9 @@ except Exception as e:
 if user_threads:
   worker_count = min(int(user_threads), worker_count)
 if user_timeout:
-  worker_timeout = min(worker_timeout, user_timeout)
+  worker_timeout = min(int(worker_timeout), user_timeout)
 if user_retries:
-  worker_retries  = min(worker_retries, user_retries)
+  worker_retries  = min(int(worker_retries), user_retries)
 
 
 if debug:

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -161,9 +161,9 @@ except Exception as e:
 if user_threads:
   worker_count = min(int(user_threads), worker_count)
 if user_timeout:
-  worker_timeout = min(int(worker_timeout), user_timeout)
+  worker_timeout = min(int(user_timeout),worker_timeout)
 if user_retries:
-  worker_retries  = min(int(worker_retries), user_retries)
+  worker_retries  = min(int(user_retries),worker_retries)
 
 
 if debug:


### PR DESCRIPTION
This Pull request covers two changes:

- Allowing chunks to retry when something goes wrong on either the client or the server.
Errors on the file-sender server or a brief interruption in internet service will currently cancel the whole transfer. 
Simply retrying the request after a delay will resolve this issue the majority of the time.
It will try up to either terasender_worker_max_chunk_retries or a user flag. 

- Adding concurrent workers to increase performance dramatically.
For this we are using a thread pool to try and improve network utilization / remove downtime between chunks.
If terasender is disabled it will revert to a single threaded chunk by chunk transfer.  
The number of workers is user configurable via the --thread argument up to the terasender_worker_count defined by the server.

From testing on a fast internet connection uploading a single 1gb file has lowed from 1min 25 second average to just 22 seconds!

One main problem with this is currently all the servers arguments are being grabbed via filesender-config.js.php instead of just via the info endpoint.