### PR TITLE
security allow csrf check before doing a saml logout

### DIFF
--- a/classes/auth/SamlLogoutCheck.php
+++ b/classes/auth/SamlLogoutCheck.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once(__DIR__ . '/../../includes/init.php');
+Logger::setProcess(ProcessTypes::GUI);
+include_once(__DIR__ . '/../../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
+
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' ) {
+    throw new exception('You must use HTTP POST to logout.');
+}
+
+
+Security::validateAgainstCSRF();
+

--- a/classes/utils/FileSendercsrfProtectorLogger.class.php
+++ b/classes/utils/FileSendercsrfProtectorLogger.class.php
@@ -35,8 +35,8 @@ if (!defined('FILESENDER_BASE')) {
     die('Missing environment');
 }
 
-include_once('../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
-include_once('../lib/vendor/owasp/csrf-protector-php/libs/csrf/LoggerInterface.php');
+include_once(__DIR__ . '/../../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
+include_once(__DIR__ . '/../../lib/vendor/owasp/csrf-protector-php/libs/csrf/LoggerInterface.php');
 
 class FileSendercsrfProtectorLogger implements LoggerInterface {
     

--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -98,7 +98,7 @@ class Security
     {
         $checkToken = Utilities::isTrue(Config::get('owasp_csrf_protector_enabled'));
         $method = Utilities::getHTTPMethod();
-
+        
         //
         // Remote API users and applications do not need to do CSRF
         //
@@ -113,7 +113,8 @@ class Security
         }
         
         if( $checkToken ) {
-            include_once('../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
+            include_once(__DIR__ . '/../../lib/vendor/owasp/csrf-protector-php/libs/csrf/csrfprotector.php');
+            
             if( !self::$filesender_csrf_protector_logger ) {
                 self::$filesender_csrf_protector_logger = new FileSendercsrfProtectorLogger();
             }

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -52,8 +52,24 @@ $maybe_display_aggregate_statistics_menu = false;
 
             if (Auth::isAuthenticated() && Auth::isSP()) {
                 $url = AuthSP::logoffURL();
-                if($url)
-                    echo '<li><a href="'.Utilities::sanitizeOutput($url).'" id="topmenu_logoff">'.Lang::tr('logoff').'</a></li>';
+
+                if( Config::get('auth_sp_type') == "saml" ) {
+                    
+                    $link = Utilities::sanitizeOutput($url);
+                    $txt = Lang::tr('logoff');
+                    echo <<<EOT
+                    <li>
+                      <form action="$link" method="post" >
+                        <button class="logoutbutton" type="submit" >$txt</button>
+                      </form>
+                    </li>
+EOT;
+                } else {
+                    if($url) {
+                        echo '<li><a href="'.Utilities::sanitizeOutput($url).'" id="topmenu_logoff">'.Lang::tr('logoff').'</a></li>';
+                    }
+                }
+                
             }else if (!Auth::isGuest()){
                 if(Config::get('auth_sp_embedded')) {
                     pagemenuitem('logon');

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1746,3 +1746,21 @@ div.not_displayed {
     margin-bottom: 0.3em;
     line-height: 1.1em;
 }
+
+
+.logoutbutton {
+    background: none!important;
+    color: #E6E6E6;
+    display: block;
+    font-style: normal;
+    font-weight: normal;
+    padding: 0.6em 1em;
+    text-decoration: none;
+    border-width: 0px;
+    text-shadow: 0 0 0.2em #000;
+    transition: all 0.2s ease 0s;
+}
+
+.logoutbutton:hover {
+    background-color: rgb(51,51,51)!important;
+}


### PR DESCRIPTION
Together with a callback from SimpleSAMLPhp this update allows CSRF checks on logout.
This relates to 4.1.6 of Computest Jan. 2, 2023 Version 1.0.