### PR TITLE
Added simple help description to the client CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ import-all-poeditor-langs-and-push.sh
 scripts/client/test.php
 scripts/testing/test1.php
 
+www/js/filesender-config.js

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import textwrap
 try:
   import requests
   import time
@@ -82,15 +83,15 @@ if 'user' in config:
 #argv
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    description=f'''\
+    description=textwrap.dedent(f'''\
       File Sender CLI client.
       Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py
-    ''',
-    epilog=f'''\
+    '''),
+    epilog=textwrap.dedent(f'''\
       A config file can be added to {homepath}/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.
 
       Example (Config file is present): 
-      python filesender.py -r reciever@example.com file1.txt'''
+      python filesender.py -r reciever@example.com file1.txt''')
 )
 parser.add_argument("files", help="path to file(s) to send", nargs='+')
 parser.add_argument("-v", "--verbose", action="store_true")

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -29,8 +29,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import textwrap
 try:
+  import textwrap #used to format help description and epilog
   import requests
   import time
   import re

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -80,7 +80,18 @@ if 'user' in config:
 
 
 #argv
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=f'''\
+      File Sender CLI client.
+      Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py
+    ''',
+    epilog=f'''\
+      A config file can be added to {homepath}/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.
+
+      Example (Config file is present): 
+      python filesender.py -r reciever@example.com file1.txt'''
+)
 parser.add_argument("files", help="path to file(s) to send", nargs='+')
 parser.add_argument("-v", "--verbose", action="store_true")
 parser.add_argument("-i", "--insecure", action="store_true")

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -60,10 +60,7 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
         transfer.addFile('test.txt', blob, undefined);
 
         //set the recipient
-        transfer.addRecipient('joey@joeyn.dev', undefined);
-
-        //set the from email
-        transfer.from = 'johannes.nicholas@utas.edu.au';
+        transfer.addRecipient('someone@example.com', undefined);
     
         //set the expiry date for 7 days in the future
         let expiry = (new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
@@ -71,7 +68,7 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
         transfer.expires = expiry.toISOString().split('T')[0];
 
         //set the security token
-        global.window.filesender.client.security_token = "5ce498c5-e5e0-48ee-8e6a-61e906eabc85";
+        global.window.filesender.client.security_token = "security token here";
 
         //start the transfer
         transfer.start();

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -18,16 +18,45 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
 
    // after download completed close filestream
    file.on("finish", () => {
-       file.close();
-       console.log("Config downloaded");
+        file.close();
+        console.log("Config downloaded");
+
+        //get all the required files
+        XRegExp = require('../lib/xregexp/xregexp-all.js');
+        require('./filesender-config.js');
+        require('./client.js');
+        require('./filesender.js');
+        require('./transfer.js');
+
+        //add some required functions
+        window.filesender.ui = {};
+        window.filesender.ui.error = function(error,callback) {
+            console.log('[error] ' + error.message);
+            console.log(error);
+        }
+        window.filesender.ui.log = function(message) {
+            console.log('[log] ' + message);
+        }
+        window.filesender.ui.validators = {};
+        window.filesender.ui.validators.email = /^[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[a-z]{2,})$/i
+
+       
+       
+        //create a new transfer
+        var transfer = new window.filesender.transfer()
+
+        //add a file to the transfer
+        const blob = new Blob(['This file was generated as a test.']);
+        transfer.addFile('test.txt', blob, undefined);
+
+        //set the recipient
+        transfer.addRecipient('joey@joeyn.dev', undefined);
+    
+
+
    });
 });
 
 
-require('./filesender-config.js');
-require('./filesender.js');
-require('./transfer.js');
 
-//delete the config file
-fs.unlinkSync("./filesender-config.js");
 

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -1,0 +1,5 @@
+// Command line interface to be run through node.js
+
+global.window = global;
+
+require('./filesender.js');

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -31,6 +31,7 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
         require('./client.js');
         require('./filesender.js');
         require('./transfer.js');
+        require('./lang.js');
         
 
         //add some required functions
@@ -45,6 +46,15 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
         global.window.filesender.ui.log = function(message) {
             console.log('[log] ' + message);
         }
+        global.window.filesender.ui.popup = function(message, buttons, options) {
+            console.log('[popup] ' + message);
+            return {
+                text: function(text) {
+                    console.log('[popup text] ' + text);
+                }
+            }
+        }
+        filesender.client.authentication_required.text
         global.window.filesender.ui.validators = {};
         global.window.filesender.ui.validators.email = /^[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[a-z]{2,})$/i
 

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -1,5 +1,33 @@
 // Command line interface to be run through node.js
 
+
+const http = require('https'); //used to download the config file
+const fs = require('fs'); //used to save the config file
+
+//Base url of the filesender instance we are connecting to
+let base_url = 'https://cloudstor.aarnet.edu.au/sender'
+
+// Set up the global window object
 global.window = global;
 
+//get the config file
+console.log("Downloading config...");
+const file = fs.createWriteStream("filesender-config.js");
+const request = http.get(base_url+"/filesender-config.js.php", function(response) {
+   response.pipe(file);
+
+   // after download completed close filestream
+   file.on("finish", () => {
+       file.close();
+       console.log("Config downloaded");
+   });
+});
+
+
+require('./filesender-config.js');
 require('./filesender.js');
+require('./transfer.js');
+
+//delete the config file
+fs.unlinkSync("./filesender-config.js");
+

--- a/www/js/cli.js
+++ b/www/js/cli.js
@@ -7,6 +7,10 @@ const fs = require('fs'); //used to save the config file
 //Base url of the filesender instance we are connecting to
 let base_url = 'https://cloudstor.aarnet.edu.au/sender'
 
+const { JSDOM } = require( "jsdom" );
+const { window } = new JSDOM( "", {url: base_url + "/?s=upload"} );
+global.$ = global.jQuery = require( "jquery" )( window );
+
 // Set up the global window object
 global.window = global;
 
@@ -27,23 +31,29 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
         require('./client.js');
         require('./filesender.js');
         require('./transfer.js');
+        
 
         //add some required functions
-        window.filesender.ui = {};
-        window.filesender.ui.error = function(error,callback) {
+        global.window.filesender.ui = {};
+        global.window.filesender.ui.error = function(error,callback) {
             console.log('[error] ' + error.message);
             console.log(error);
         }
-        window.filesender.ui.log = function(message) {
+        global.window.filesender.ui.rawError = function(text) {
+            console.log('[raw error] ' + text);
+        }
+        global.window.filesender.ui.log = function(message) {
             console.log('[log] ' + message);
         }
-        window.filesender.ui.validators = {};
-        window.filesender.ui.validators.email = /^[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[a-z]{2,})$/i
+        global.window.filesender.ui.validators = {};
+        global.window.filesender.ui.validators.email = /^[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[a-z]{2,})$/i
 
-       
-       
+        global.window.location = {}
+        global.window.location.href = base_url + "/?s=upload";
+        
+        
         //create a new transfer
-        var transfer = new window.filesender.transfer()
+        var transfer = new global.window.filesender.transfer()
 
         //add a file to the transfer
         const blob = new Blob(['This file was generated as a test.']);
@@ -51,8 +61,20 @@ const request = http.get(base_url+"/filesender-config.js.php", function(response
 
         //set the recipient
         transfer.addRecipient('joey@joeyn.dev', undefined);
-    
 
+        //set the from email
+        transfer.from = 'johannes.nicholas@utas.edu.au';
+    
+        //set the expiry date for 7 days in the future
+        let expiry = (new Date(Date.now() + 7 * 24 * 60 * 60 * 1000));
+        //format as a string in the yyyy-mm-dd format
+        transfer.expires = expiry.toISOString().split('T')[0];
+
+        //set the security token
+        global.window.filesender.client.security_token = "5ce498c5-e5e0-48ee-8e6a-61e906eabc85";
+
+        //start the transfer
+        transfer.start();
 
    });
 });


### PR DESCRIPTION
Hi, 
This is my first pull request to this project.
Feel free to provide feedback or recommendations.

The following changes change the output help output of the command line. 

Running `python filesender.py --help` currently will output:
```
usage: filesender.py [-h] [-v] [-i] [-p] [-s SUBJECT] [-m MESSAGE] [-g] [--threads THREADS] [--timeout TIMEOUT] [--retries RETRIES] -u USERNAME -a APIKEY -r RECIPIENTS files [files ...]

positional arguments:
  files                 path to file(s) to send

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  -i, --insecure
  -p, --progress
  -s SUBJECT, --subject SUBJECT
  -m MESSAGE, --message MESSAGE
  -g, --guest
  --threads THREADS
  --timeout TIMEOUT
  --retries RETRIES

required named arguments:
  -u USERNAME, --username USERNAME
  -a APIKEY, --apikey APIKEY
  -r RECIPIENTS, --recipients RECIPIENTS
```
  
  With these changes, it outputs:
 ```
usage: filesender.py [-h] [-v] [-i] [-p] [-s SUBJECT] [-m MESSAGE] [-g] [--threads THREADS] [--timeout TIMEOUT] [--retries RETRIES] -u USERNAME -a APIKEY -r RECIPIENTS files [files ...]

File Sender CLI client.
Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py

positional arguments:
  files                 path to file(s) to send

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  -i, --insecure
  -p, --progress
  -s SUBJECT, --subject SUBJECT
  -m MESSAGE, --message MESSAGE
  -g, --guest
  --threads THREADS
  --timeout TIMEOUT
  --retries RETRIES

required named arguments:
  files                 path to file(s) to send

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  -i, --insecure
  -p, --progress
  -s SUBJECT, --subject SUBJECT
  -m MESSAGE, --message MESSAGE
  -g, --guest
  --threads THREADS
  --timeout TIMEOUT
  --retries RETRIES

required named arguments:
  -u USERNAME, --username USERNAME
  -a APIKEY, --apikey APIKEY
  -r RECIPIENTS, --recipients RECIPIENTS

A config file can be added to C:\Users\Joey/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.

Example (Config file is present):
python filesender.py -r reciever@example.com file1.txt
```
  