### PR TITLE
Added simple help description to the client CLI

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -29,6 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import textwrap
 try:
   import requests
   import time
@@ -82,15 +83,15 @@ if 'user' in config:
 #argv
 parser = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    description=f'''\
+    description=textwrap.dedent(f'''\
       File Sender CLI client.
       Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py
-    ''',
-    epilog=f'''\
+    '''),
+    epilog=textwrap.dedent(f'''\
       A config file can be added to {homepath}/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.
 
       Example (Config file is present): 
-      python filesender.py -r reciever@example.com file1.txt'''
+      python filesender.py -r reciever@example.com file1.txt''')
 )
 parser.add_argument("files", help="path to file(s) to send", nargs='+')
 parser.add_argument("-v", "--verbose", action="store_true")

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -29,8 +29,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
-import textwrap
 try:
+  import textwrap #used to format help description and epilog
   import requests
   import time
   import re

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -80,7 +80,18 @@ if 'user' in config:
 
 
 #argv
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=f'''\
+      File Sender CLI client.
+      Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py
+    ''',
+    epilog=f'''\
+      A config file can be added to {homepath}/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.
+
+      Example (Config file is present): 
+      python filesender.py -r reciever@example.com file1.txt'''
+)
 parser.add_argument("files", help="path to file(s) to send", nargs='+')
 parser.add_argument("-v", "--verbose", action="store_true")
 parser.add_argument("-i", "--insecure", action="store_true")


### PR DESCRIPTION
Hi, 
I made some mistakes with the previous pull request https://github.com/filesender/filesender/pull/1412 
(I didn't realize it would keep up to date with my latest commits to my own fork.)

 The following changes change the output help output of the command line. 

Running `python filesender.py --help` currently will output:
```
usage: filesender.py [-h] [-v] [-i] [-p] [-s SUBJECT] [-m MESSAGE] [-g] [--threads THREADS] [--timeout TIMEOUT] [--retries RETRIES] -u USERNAME -a APIKEY -r RECIPIENTS files [files ...]

positional arguments:
  files                 path to file(s) to send

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose
  -i, --insecure
  -p, --progress
  -s SUBJECT, --subject SUBJECT
  -m MESSAGE, --message MESSAGE
  -g, --guest
  --threads THREADS
  --timeout TIMEOUT
  --retries RETRIES

required named arguments:
  -u USERNAME, --username USERNAME
  -a APIKEY, --apikey APIKEY
  -r RECIPIENTS, --recipients RECIPIENTS
```
  
  With these changes, it outputs:
 ```
python filesender.py --help
usage: filesender.py [-h] [-v] [-i] [-p] [-s SUBJECT] [-m MESSAGE] [-g] [--threads THREADS] [--timeout TIMEOUT] [--retries RETRIES]
                     [-u USERNAME] [-a APIKEY] -r RECIPIENTS
                     files [files ...]

File Sender CLI client.
Source code: https://github.com/filesender/filesender/blob/master/scripts/client/filesender.py

positional arguments:
  files                 path to file(s) to send

options:
  -h, --help            show this help message and exit
  -v, --verbose
  -i, --insecure
  -p, --progress
  -s SUBJECT, --subject SUBJECT
  -m MESSAGE, --message MESSAGE
  -g, --guest
  --threads THREADS
  --timeout TIMEOUT
  --retries RETRIES
  -u USERNAME, --username USERNAME
  -a APIKEY, --apikey APIKEY

required named arguments:
  -r RECIPIENTS, --recipients RECIPIENTS

A config file can be added to C:\Users\Joey/.filesender/filesender.py.ini to avoid having to specify username and apikey on the command line.

Example (Config file is present): 
python filesender.py -r reciever@example.com file1.txt
```