### PR TITLE
Return to original page upon session timeout

### DIFF
--- a/templates/logon_page.php
+++ b/templates/logon_page.php
@@ -3,7 +3,11 @@
     
     <div class="logon">
         <?php
-        echo GUI::getLoginButton();
+        $page = null;
+        if (array_key_exists('s', $_REQUEST)) {
+            $page = Utilities::http_build_query(array('s' => $_REQUEST['s']));
+        }
+        echo GUI::getLoginButton($page);
         ?>
     </div>
 </div>


### PR DESCRIPTION
When a session times out while a non-upload page is open and I log back on, it takes me to the upload page instead of the originally opened page.