### PR TITLE
Display "none" when no options on Transfers page

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -367,7 +367,7 @@ if (!function_exists('clickableHeader')) {
                         <tr class="transfer_options">
                             <td class="desc">{tr:options}</td>
                             <td><div class="options">
-                                <?php if(count($transfer->options)) { ?>
+                                <?php if(count(array_filter($transfer->options))) { ?>
                                     <ul class="options">
                                         <li>
                                             <?php echo implode('</li><li>', array_map(function($o) {


### PR DESCRIPTION
When no transfer options are selected, "none" is not displayed on Transfers page.