### PR TITLE
Display scroll bar on Translate_email page

### DIFF
--- a/templates/translate_email_page.php
+++ b/templates/translate_email_page.php
@@ -17,6 +17,7 @@
     $url = '?s=translate_email&amp;token='.$token.'&amp;lang=';
     
     if(count($available) > 1) {
+        echo '<div class="languages">';
         echo '<div class="buttons">';
         
         echo '<span class="spaced">'.Lang::tr('translate_to').'</span>';
@@ -29,6 +30,7 @@
             }
         }
         
+        echo '</div>';
         echo '</div>';
     }
     

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -352,6 +352,10 @@ label.invalid {
 }
 
 
+.languages {
+    overflow-x: auto;
+}
+
 .buttons {
     display: table;
     border-collapse: separate;


### PR DESCRIPTION
When there are many available languages(default), Translate_email page display breaks through to the right.