### PR TITLE
Ignore error if a bounced email with broken Content-type field

### DIFF
--- a/classes/utils/FeedbackMail.class.php
+++ b/classes/utils/FeedbackMail.class.php
@@ -148,6 +148,7 @@ class FeedbackMailHeaders
                     $sparts = array_map('trim', explode(';', $value));
                     $value = array_shift($sparts);
                     foreach ($sparts as $subtype) {
+                        if (strlen($subtype) == 0) continue;
                         list($skey, $sval) = array_map('trim', explode('=', $subtype, 2));
                         $skey = str_replace('-', '_', strtolower($skey));
                         if (preg_match('`^"(.+)"$`', $sval, $m)) {


### PR DESCRIPTION
When task/emailfeedback.php receives a bounced email with broken Content-type field, it fails to the process. For example, the end of Content-type field is ";".

```
--------------I305M09060309060P_297316237437599
Content-Type: text/plain; charset=UTF-8;
Content-Transfer-Encoding: 8bit
```
=> PHP Notice:  Undefined offset: 1 in /opt/filesender/filesender-2.21/classes/utils/FeedbackMail.class.php on line 151