### PR TITLE
server side zip: support utf8 filenames

### DIFF
--- a/lib/vendor/maennchen/zipstream-php/.gitignore
+++ b/lib/vendor/maennchen/zipstream-php/.gitignore
@@ -4,3 +4,10 @@ coverage.clover
 .idea
 phpunit.xml
 vendor
+.editorconfig
+.phive/
+.phpdoc/
+.tool-versions
+guides/
+phpdoc.dist.xml
+

--- a/lib/vendor/maennchen/zipstream-php/.php-cs-fixer.dist.php
+++ b/lib/vendor/maennchen/zipstream-php/.php-cs-fixer.dist.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * PHP-CS-Fixer config for ZipStream-PHP
+ * @author Nicolas CARPi <nico-git@deltablot.email>
+ * @copyright 2022 Nicolas CARPi
+ * @see https://github.com/maennchen/ZipStream-PHP
+ * @license MIT
+ * @package maennchen/ZipStream-PHP
+ */
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->exclude('.github')
+    ->exclude('.phpdoc')
+    ->exclude('docs')
+    ->exclude('tools')
+    ->exclude('vendor')
+    ->in(__DIR__);
+
+$config = new Config();
+return $config->setRules([
+        '@PER' => true,
+        '@PER:risky' => true,
+        '@PHP81Migration' => true,
+        '@PHPUnit84Migration:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'class_attributes_separation' => true,
+        'declare_strict_types' => true,
+        'dir_constant' => true,
+        'is_null' => true,
+        'no_homoglyph_names' => true,
+        'no_null_property_initialization' => true,
+        'no_php4_constructor' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'non_printable_character' => true,
+        'ordered_imports' => true,
+        'ordered_class_elements' => true,
+        'php_unit_construct' => true,
+        'pow_to_exponentiation' => true,
+        'psr_autoloading' => true,
+        'random_api_migration' => true,
+        'return_assignment' => true,
+        'self_accessor' => true,
+        'semicolon_after_instruction' => true,
+        'short_scalar_cast' => true,
+        'simplified_null_return' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_class_element_per_statement' => true,
+        'single_line_comment_style' => true,
+        'single_quote' => true,
+        'space_after_semicolon' => true,
+        'standardize_not_equals' => true,
+        'strict_param' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline' => true,
+        'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
+        'global_namespace_import' => [
+            'import_classes' => true,
+            'import_functions' => true,
+            'import_constants' => true,
+        ],
+    ])
+    ->setFinder($finder)
+    ->setRiskyAllowed(true);

--- a/lib/vendor/maennchen/zipstream-php/README.md
+++ b/lib/vendor/maennchen/zipstream-php/README.md
@@ -1,11 +1,16 @@
 # ZipStream-PHP
 
-[![Build Status](https://travis-ci.org/maennchen/ZipStream-PHP.svg?branch=master)](https://travis-ci.org/maennchen/ZipStream-PHP)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/maennchen/ZipStream-PHP/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/maennchen/ZipStream-PHP/)
-[![Code Coverage](https://scrutinizer-ci.com/g/maennchen/ZipStream-PHP/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/maennchen/ZipStream-PHP/)
+[![Main Branch](https://github.com/maennchen/ZipStream-PHP/actions/workflows/branch_main.yml/badge.svg)](https://github.com/maennchen/ZipStream-PHP/actions/workflows/branch_main.yml)
+[![Coverage Status](https://coveralls.io/repos/github/maennchen/ZipStream-PHP/badge.svg?branch=main)](https://coveralls.io/github/maennchen/ZipStream-PHP?branch=main)
 [![Latest Stable Version](https://poser.pugx.org/maennchen/zipstream-php/v/stable)](https://packagist.org/packages/maennchen/zipstream-php)
 [![Total Downloads](https://poser.pugx.org/maennchen/zipstream-php/downloads)](https://packagist.org/packages/maennchen/zipstream-php)
 [![Financial Contributors on Open Collective](https://opencollective.com/zipstream/all/badge.svg?label=financial+contributors)](https://opencollective.com/zipstream) [![License](https://img.shields.io/github/license/maennchen/zipstream-php.svg)](LICENSE)
+
+## Unstable Branch
+
+The `main` branch is not stable. Please see the
+[releases](https://github.com/maennchen/ZipStream-PHP/releases) for a stable
+version.
 
 ## Overview
 
@@ -21,7 +26,10 @@ Simply add a dependency on maennchen/zipstream-php to your project's composer.js
 composer require maennchen/zipstream-php
 ```
 
-## Usage and options
+## Usage
+
+For detailed instructions, please check the
+[Documentation](https://maennchen.dev/ZipStream-PHP/).
 
 Here's a simple example:
 
@@ -42,39 +50,20 @@ $zip->addFile('hello.txt', 'This is the contents of hello.txt');
 // add a file named 'some_image.jpg' from a local file 'path/to/image.jpg'
 $zip->addFileFromPath('some_image.jpg', 'path/to/image.jpg');
 
-// add a file named 'goodbye.txt' from an open stream resource
-$fp = tmpfile();
-fwrite($fp, 'The quick brown fox jumped over the lazy dog.');
-rewind($fp);
-$zip->addFileFromStream('goodbye.txt', $fp);
-fclose($fp);
-
 // finish the zip stream
 $zip->finish();
 ```
 
-You can also add comments, modify file timestamps, and customize (or
-disable) the HTTP headers. It is also possible to specify the storage method when adding files,
-the current default storage method is 'deflate' i.e files are stored with Compression mode 0x08.
-
-See the [Wiki](https://github.com/maennchen/ZipStream-PHP/wiki) for details.
-
-## Known issue
-
-The native Mac OS archive extraction tool might not open archives in some conditions. A workaround is to disable the Zip64 feature with the option `$opt->setEnableZip64(false)`. This limits the archive to 4 Gb and 64k files but will allow Mac OS users to open them without issue. See #116.
-
-The linux `unzip` utility might not handle properly unicode characters. It is recommended to extract with another tool like [7-zip](https://www.7-zip.org/). See #146.
-
 ## Upgrade to version 2.0.0
 
-* Only the self opened streams will be closed (#139)
-If you were relying on ZipStream to close streams that the library didn't open,
-you'll need to close them yourself now.
+- Only the self opened streams will be closed (#139)
+  If you were relying on ZipStream to close streams that the library didn't open,
+  you'll need to close them yourself now.
 
 ## Upgrade to version 1.0.0
 
-* All options parameters to all function have been moved from an `array` to structured option objects. See [the wiki](https://github.com/maennchen/ZipStream-PHP/wiki/Available-options) for examples.
-* The whole library has been refactored. The minimal PHP requirement has been raised to PHP 7.1.
+- All options parameters to all function have been moved from an `array` to structured option objects. See [the wiki](https://github.com/maennchen/ZipStream-PHP/wiki/Available-options) for examples.
+- The whole library has been refactored. The minimal PHP requirement has been raised to PHP 7.1.
 
 ## Usage with Symfony and S3
 
@@ -82,21 +71,23 @@ You can find example code on [the wiki](https://github.com/maennchen/ZipStream-P
 
 ## Contributing
 
-ZipStream-PHP is a collaborative project. Please take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+ZipStream-PHP is a collaborative project. Please take a look at the
+[.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) file.
 
 ## About the Authors
 
-* Paul Duncan <pabs@pablotron.org> - https://pablotron.org/
-* Jonatan Männchen <jonatan@maennchen.ch> - https://maennchen.dev
-* Jesse G. Donat <donatj@gmail.com> - https://donatstudios.com
-* Nicolas CARPi <nico-git@deltablot.email> - https://www.deltablot.com
-* Nik Barham <nik@brokencube.co.uk> - https://www.brokencube.co.uk
+- Paul Duncan <pabs@pablotron.org> - https://pablotron.org/
+- Jonatan Männchen <jonatan@maennchen.ch> - https://maennchen.dev
+- Jesse G. Donat <donatj@gmail.com> - https://donatstudios.com
+- Nicolas CARPi <nico-git@deltablot.email> - https://www.deltablot.com
+- Nik Barham <nik@brokencube.co.uk> - https://www.brokencube.co.uk
 
 ## Contributors
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute.
+[[Contribute](.github/CONTRIBUTING.md)].
 <a href="https://github.com/maennchen/ZipStream-PHP/graphs/contributors"><img src="https://opencollective.com/zipstream/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors

--- a/lib/vendor/maennchen/zipstream-php/composer.json
+++ b/lib/vendor/maennchen/zipstream-php/composer.json
@@ -22,20 +22,55 @@
     }
   ],
   "require": {
-    "php": ">= 7.1",
-    "symfony/polyfill-mbstring": "^1.0",
+    "php": "^8.0",
+    "ext-mbstring": "*",
     "psr/http-message": "^1.0",
     "myclabs/php-enum": "^1.5"
   },
   "require-dev": {
-    "phpunit/phpunit": ">= 7.5",
-    "guzzlehttp/guzzle": ">= 6.3",
+    "phpunit/phpunit": "^8.5.8 || ^9.4.2",
+    "guzzlehttp/guzzle": "^6.5.3 || ^7.2.0",
     "ext-zip": "*",
-    "mikey179/vfsstream": "^1.6"
+    "mikey179/vfsstream": "^1.6",
+    "vimeo/psalm": "^5.0",
+    "php-coveralls/php-coveralls": "^2.4",
+    "friendsofphp/php-cs-fixer": "^3.9"
+  },
+  "scripts": {
+    "format": "PHP_CS_FIXER_IGNORE_ENV=true php-cs-fixer fix",
+    "test": "composer run test:unit && composer run test:formatted && composer run test:lint",
+    "test:unit": "phpunit --coverage-clover=coverage.clover.xml --coverage-html cov",
+    "test:formatted": "composer run format -- --dry-run --stop-on-violation --using-cache=no",
+    "test:lint": "psalm --stats --show-info --find-unused-psalm-suppress",
+    "coverage:report": "php-coveralls --coverage_clover=coverage.clover.xml --json_path=coveralls-upload.json --insecure",
+    "install:tools": "phive install --trust-gpg-keys 0x67F861C3D889C656",
+    "docs:generate": "tools/phpdocumentor --sourcecode"
   },
   "autoload": {
     "psr-4": {
       "ZipStream\\": "src/"
     }
+  },
+  "archive": {
+    "exclude": [
+      "/composer.lock",
+      "/docs",
+      "/.gitattributes",
+      "/.github",
+      "/.gitignore",
+      "/guides",
+      "/.phive",
+      "/.php-cs-fixer.cache",
+      "/.php-cs-fixer.dist.php",
+      "/.phpdoc",
+      "/phpdoc.dist.xml",
+      "/.phpunit.result.cache",
+      "/phpunit.xml.dist",
+      "/psalm.xml",
+      "/test",
+      "/tools",
+      "/.tool-versions",
+      "/vendor"
+    ]
   }
 }

--- a/lib/vendor/maennchen/zipstream-php/phpunit.xml.dist
+++ b/lib/vendor/maennchen/zipstream-php/phpunit.xml.dist
@@ -1,17 +1,14 @@
-<phpunit bootstrap="test/bootstrap.php">
-    <testsuites>
-        <testsuite name="Application">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-
-    <logging>
-        <log type="coverage-clover" target="clover.xml"/>
-    </logging>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Application">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/lib/vendor/maennchen/zipstream-php/psalm.xml
+++ b/lib/vendor/maennchen/zipstream-php/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
@@ -34,7 +33,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />

--- a/lib/vendor/maennchen/zipstream-php/src/Bigint.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Bigint.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream;
@@ -23,22 +24,6 @@ class Bigint
     }
 
     /**
-     * Fill the bytes field with int
-     *
-     * @param int $value
-     * @param int $start
-     * @param int $count
-     * @return void
-     */
-    protected function fillBytes(int $value, int $start, int $count): void
-    {
-        for ($i = 0; $i < $count; $i++) {
-            $this->bytes[$start + $i] = $i >= PHP_INT_SIZE ? 0 : $value & 0xFF;
-            $value >>= 8;
-        }
-    }
-
-    /**
      * Get an instance
      *
      * @param int $value
@@ -58,7 +43,7 @@ class Bigint
      */
     public static function fromLowHigh(int $low, int $high): self
     {
-        $bigint = new Bigint();
+        $bigint = new self();
         $bigint->fillBytes($low, 0, 4);
         $bigint->fillBytes($high, 4, 4);
         return $bigint;
@@ -108,6 +93,7 @@ class Bigint
     /**
      * Check if is over 32
      *
+     * @psalm-suppress ArgumentTypeCoercion
      * @param bool $force
      * @return bool
      */
@@ -149,7 +135,7 @@ class Bigint
      * @param Bigint $other
      * @return Bigint
      */
-    public function add(Bigint $other): Bigint
+    public function add(self $other): self
     {
         $result = clone $this;
         $overflow = false;
@@ -165,8 +151,24 @@ class Bigint
             }
         }
         if ($overflow) {
-            throw new OverflowException;
+            throw new OverflowException();
         }
         return $result;
+    }
+
+    /**
+     * Fill the bytes field with int
+     *
+     * @param int $value
+     * @param int $start
+     * @param int $count
+     * @return void
+     */
+    protected function fillBytes(int $value, int $start, int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->bytes[$start + $i] = $i >= PHP_INT_SIZE ? 0 : $value & 0xFF;
+            $value >>= 8;
+        }
     }
 }

--- a/lib/vendor/maennchen/zipstream-php/src/DeflateStream.php
+++ b/lib/vendor/maennchen/zipstream-php/src/DeflateStream.php
@@ -1,70 +1,27 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream;
 
+/**
+ * @deprecated
+ */
 class DeflateStream extends Stream
 {
-    protected $filter;
-
-    /**
-     * @var Option\File
-     */
-    protected $options;
-
-    /**
-     * Rewind stream
-     *
-     * @return void
-     */
-    public function rewind(): void
+    public function __construct($stream)
     {
-        // deflate filter needs to be removed before rewind
-        if ($this->filter) {
-            $this->removeDeflateFilter();
-            $this->seek(0);
-            $this->addDeflateFilter($this->options);
-        } else {
-            rewind($this->stream);
-        }
+        parent::__construct($stream);
+        //trigger_error('Class ' . __CLASS__ . ' is deprecated, delation will be handled internally instead', E_USER_DEPRECATED);
     }
 
-    /**
-     * Remove the deflate filter
-     *
-     * @return void
-     */
     public function removeDeflateFilter(): void
     {
-        if (!$this->filter) {
-            return;
-        }
-        stream_filter_remove($this->filter);
-        $this->filter = null;
+        trigger_error('Method ' . __METHOD__ . ' is deprecated', E_USER_DEPRECATED);
     }
 
-    /**
-     * Add a deflate filter
-     *
-     * @param Option\File $options
-     * @return void
-     */
     public function addDeflateFilter(Option\File $options): void
     {
-        $this->options = $options;
-        // parameter 4 for stream_filter_append expects array
-        // so we convert the option object in an array
-        $optionsArr = [
-            'comment' => $options->getComment(),
-            'method' => $options->getMethod(),
-            'deflateLevel' => $options->getDeflateLevel(),
-            'time' => $options->getTime()
-        ];
-        $this->filter = stream_filter_append(
-            $this->stream,
-            'zlib.deflate',
-            STREAM_FILTER_READ,
-            $optionsArr
-        );
+        trigger_error('Method ' . __METHOD__ . ' is deprecated', E_USER_DEPRECATED);
     }
 }

--- a/lib/vendor/maennchen/zipstream-php/src/Exception.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/EncodingException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/EncodingException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/FileNotFoundException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/FileNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/FileNotReadableException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/FileNotReadableException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/IncompatibleOptionsException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/IncompatibleOptionsException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/OverflowException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/OverflowException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/Exception/StreamNotReadableException.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Exception/StreamNotReadableException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Exception;

--- a/lib/vendor/maennchen/zipstream-php/src/File.php
+++ b/lib/vendor/maennchen/zipstream-php/src/File.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream;
 
+use HashContext;
 use Psr\Http\Message\StreamInterface;
-use ZipStream\Exception\EncodingException;
 use ZipStream\Exception\FileNotFoundException;
 use ZipStream\Exception\FileNotReadableException;
 use ZipStream\Exception\OverflowException;
@@ -14,13 +15,15 @@ use ZipStream\Option\Version;
 
 class File
 {
-    const HASH_ALGORITHM = 'crc32b';
+    public const HASH_ALGORITHM = 'crc32b';
 
-    const BIT_ZERO_HEADER = 0x0008;
-    const BIT_EFS_UTF8 = 0x0800;
+    public const BIT_ZERO_HEADER = 0x0008;
 
-    const COMPUTE = 1;
-    const SEND = 2;
+    public const BIT_EFS_UTF8 = 0x0800;
+
+    public const COMPUTE = 1;
+
+    public const SEND = 2;
 
     private const CHUNKED_READ_BLOCK_SIZE = 1048576;
 
@@ -38,6 +41,7 @@ class File
      * @var Bigint
      */
     public $len;
+
     /**
      * @var Bigint
      */
@@ -75,8 +79,9 @@ class File
      * @var resource
      */
     private $deflate;
+
     /**
-     * @var resource
+     * @var HashContext
      */
     private $hash;
 
@@ -115,7 +120,7 @@ class File
         } else {
             $this->method = $this->zip->opt->getLargeFileMethod();
 
-            $stream = new DeflateStream(fopen($path, 'rb'));
+            $stream = new Stream(fopen($path, 'rb'));
             $this->processStream($stream);
             $stream->close();
         }
@@ -160,21 +165,17 @@ class File
             // Sets Bit 11: Language encoding flag (EFS).  If this bit is set,
             // the filename and comment fields for this file
             // MUST be encoded using UTF-8. (see APPENDIX D)
-            if (!mb_check_encoding($name, 'UTF-8') ||
-                !mb_check_encoding($comment, 'UTF-8')) {
-                throw new EncodingException(
-                    'File name and comment should use UTF-8 ' .
-                    'if one of them does not fit into ASCII range.'
-                );
+            if (mb_check_encoding($name, 'UTF-8') &&
+                mb_check_encoding($comment, 'UTF-8')) {
+                $this->bits |= self::BIT_EFS_UTF8;
             }
-            $this->bits |= self::BIT_EFS_UTF8;
         }
 
         if ($this->method->equals(Method::DEFLATE())) {
             $this->version = Version::DEFLATE();
         }
 
-        $force = (boolean)($this->bits & self::BIT_ZERO_HEADER) &&
+        $force = (bool)($this->bits & self::BIT_ZERO_HEADER) &&
             $this->zip->opt->isEnableZip64();
 
         $footer = $this->buildZip64ExtraBlock($force);
@@ -227,82 +228,12 @@ class File
     }
 
     /**
-     * Convert a UNIX timestamp to a DOS timestamp.
-     *
-     * @param int $when
-     * @return int DOS Timestamp
-     */
-    final protected static function dosTime(int $when): int
-    {
-        // get date array for timestamp
-        $d = getdate($when);
-
-        // set lower-bound on dates
-        if ($d['year'] < 1980) {
-            $d = array(
-                'year' => 1980,
-                'mon' => 1,
-                'mday' => 1,
-                'hours' => 0,
-                'minutes' => 0,
-                'seconds' => 0
-            );
-        }
-
-        // remove extra years from 1980
-        $d['year'] -= 1980;
-
-        // return date string
-        return
-            ($d['year'] << 25) |
-            ($d['mon'] << 21) |
-            ($d['mday'] << 16) |
-            ($d['hours'] << 11) |
-            ($d['minutes'] << 5) |
-            ($d['seconds'] >> 1);
-    }
-
-    protected function buildZip64ExtraBlock(bool $force = false): string
-    {
-
-        $fields = [];
-        if ($this->len->isOver32($force)) {
-            $fields[] = ['P', $this->len];          // Length of original data
-        }
-
-        if ($this->len->isOver32($force)) {
-            $fields[] = ['P', $this->zlen];         // Length of compressed data
-        }
-
-        if ($this->ofs->isOver32()) {
-            $fields[] = ['P', $this->ofs];          // Offset of local header record
-        }
-
-        if (!empty($fields)) {
-            if (!$this->zip->opt->isEnableZip64()) {
-                throw new OverflowException();
-            }
-
-            array_unshift(
-                $fields,
-                ['v', 0x0001],                      // 64 bit extension
-                ['v', count($fields) * 8]             // Length of data block
-            );
-            $this->version = Version::ZIP64();
-        }
-
-        return ZipStream::packFields($fields);
-    }
-
-    /**
      * Create and send data descriptor footer for this file.
      *
      * @return void
      */
-
     public function addFileFooter(): void
     {
-
         if ($this->bits & self::BIT_ZERO_HEADER) {
             // compressed and uncompressed size
             $sizeFormat = 'V';
@@ -337,6 +268,130 @@ class File
         }
     }
 
+    /**
+     * Send CDR record for specified file.
+     *
+     * @return string
+     */
+    public function getCdrFile(): string
+    {
+        $name = static::filterFilename($this->name);
+
+        // get attributes
+        $comment = $this->opt->getComment();
+
+        // get dos timestamp
+        $time = static::dosTime($this->opt->getTime()->getTimestamp());
+
+        $footer = $this->buildZip64ExtraBlock();
+
+        $fields = [
+            ['V', ZipStream::CDR_FILE_SIGNATURE],   // Central file header signature
+            ['v', ZipStream::ZIP_VERSION_MADE_BY],  // Made by version
+            ['v', $this->version->getValue()],      // Extract by version
+            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
+            ['v', $this->method->getValue()],       // Compression method
+            ['V', $time],                           // Timestamp (DOS Format)
+            ['V', $this->crc],                      // CRC32
+            ['V', $this->zlen->getLowFF()],         // Compressed Data Length
+            ['V', $this->len->getLowFF()],          // Original Data Length
+            ['v', strlen($name)],                   // Length of filename
+            ['v', strlen($footer)],                 // Extra data len (see above)
+            ['v', strlen($comment)],                // Length of comment
+            ['v', 0],                               // Disk number
+            ['v', 0],                               // Internal File Attributes
+            ['V', 32],                              // External File Attributes
+            ['V', $this->ofs->getLowFF()],           // Relative offset of local header
+        ];
+
+        // pack fields, then append name and comment
+        $header = ZipStream::packFields($fields);
+
+        return $header . $name . $footer . $comment;
+    }
+
+    /**
+     * @return Bigint
+     */
+    public function getTotalLength(): Bigint
+    {
+        return $this->totalLength;
+    }
+
+    /**
+     * Convert a UNIX timestamp to a DOS timestamp.
+     *
+     * @param int $when
+     * @return int DOS Timestamp
+     */
+    final protected static function dosTime(int $when): int
+    {
+        // get date array for timestamp
+        $d = getdate($when);
+
+        // set lower-bound on dates
+        if ($d['year'] < 1980) {
+            $d = [
+                'year' => 1980,
+                'mon' => 1,
+                'mday' => 1,
+                'hours' => 0,
+                'minutes' => 0,
+                'seconds' => 0,
+            ];
+        }
+
+        // remove extra years from 1980
+        $d['year'] -= 1980;
+
+        // return date string
+        return
+            ($d['year'] << 25) |
+            ($d['mon'] << 21) |
+            ($d['mday'] << 16) |
+            ($d['hours'] << 11) |
+            ($d['minutes'] << 5) |
+            ($d['seconds'] >> 1);
+    }
+
+    protected function buildZip64ExtraBlock(bool $force = false): string
+    {
+        $fields = [];
+        if ($this->len->isOver32($force)) {
+            $fields[] = ['P', $this->len];          // Length of original data
+        }
+
+        if ($this->len->isOver32($force)) {
+            $fields[] = ['P', $this->zlen];         // Length of compressed data
+        }
+
+        if ($this->ofs->isOver32()) {
+            $fields[] = ['P', $this->ofs];          // Offset of local header record
+        }
+
+        if (!empty($fields)) {
+            if (!$this->zip->opt->isEnableZip64()) {
+                throw new OverflowException();
+            }
+
+            array_unshift(
+                $fields,
+                ['v', 0x0001],                      // 64 bit extension
+                ['v', count($fields) * 8]             // Length of data block
+            );
+            $this->version = Version::ZIP64();
+        }
+
+        if ($this->bits & self::BIT_EFS_UTF8) {
+            // Put the tricky entry to
+            // force Linux unzip to lookup EFS flag.
+            $fields[] = ['v', 0x5653];  // Choose 'ZS' for proprietary usage
+            $fields[] = ['v', 0x0000];  // zero length
+        }
+
+        return ZipStream::packFields($fields);
+    }
+
     protected function processStreamWithZeroHeader(StreamInterface $stream): void
     {
         $this->bits |= self::BIT_ZERO_HEADER;
@@ -354,7 +409,7 @@ class File
             $data = $stream->read(self::CHUNKED_READ_BLOCK_SIZE);
             $total += strlen($data);
             if ($size > 0 && $total > $size) {
-                $data = substr($data, 0 , strlen($data)-($total - $size));
+                $data = substr($data, 0, strlen($data)-($total - $size));
             }
             $this->deflateData($stream, $data, $options);
             if ($options & self::SEND) {
@@ -366,7 +421,8 @@ class File
 
     protected function deflateInit(): void
     {
-        $this->hash = hash_init(self::HASH_ALGORITHM);
+        $hash = hash_init(self::HASH_ALGORITHM);
+        $this->hash = $hash;
         if ($this->method->equals(Method::DEFLATE())) {
             $this->deflate = deflate_init(
                 ZLIB_ENCODING_RAW,
@@ -407,71 +463,8 @@ class File
         $this->readStream($stream, self::COMPUTE);
         $stream->rewind();
 
-        // incremental compression with deflate_add
-        // makes this second read unnecessary
-        // but it is only available from PHP 7.0
-        if (!$this->deflate && $stream instanceof DeflateStream && $this->method->equals(Method::DEFLATE())) {
-            $stream->addDeflateFilter($this->opt);
-            $this->zlen = new Bigint();
-            while (!$stream->eof()) {
-                $data = $stream->read(self::CHUNKED_READ_BLOCK_SIZE);
-                $this->zlen = $this->zlen->add(Bigint::init(strlen($data)));
-            }
-            $stream->rewind();
-        }
-
         $this->addFileHeader();
         $this->readStream($stream, self::SEND);
         $this->addFileFooter();
-    }
-
-    /**
-     * Send CDR record for specified file.
-     *
-     * @return string
-     */
-    public function getCdrFile(): string
-    {
-        $name = static::filterFilename($this->name);
-
-        // get attributes
-        $comment = $this->opt->getComment();
-
-        // get dos timestamp
-        $time = static::dosTime($this->opt->getTime()->getTimestamp());
-
-        $footer = $this->buildZip64ExtraBlock();
-
-        $fields = [
-            ['V', ZipStream::CDR_FILE_SIGNATURE],   // Central file header signature
-            ['v', ZipStream::ZIP_VERSION_MADE_BY],  // Made by version
-            ['v', $this->version->getValue()],      // Extract by version
-            ['v', $this->bits],                     // General purpose bit flags - data descriptor flag set
-            ['v', $this->method->getValue()],       // Compression method
-            ['V', $time],                           // Timestamp (DOS Format)
-            ['V', $this->crc],                      // CRC32
-            ['V', $this->zlen->getLowFF()],         // Compressed Data Length
-            ['V', $this->len->getLowFF()],          // Original Data Length
-            ['v', strlen($name)],                   // Length of filename
-            ['v', strlen($footer)],                 // Extra data len (see above)
-            ['v', strlen($comment)],                // Length of comment
-            ['v', 0],                               // Disk number
-            ['v', 0],                               // Internal File Attributes
-            ['V', 32],                              // External File Attributes
-            ['V', $this->ofs->getLowFF()]           // Relative offset of local header
-        ];
-
-        // pack fields, then append name and comment
-        $header = ZipStream::packFields($fields);
-
-        return $header . $name . $footer . $comment;
-    }
-
-    /**
-     * @return Bigint
-     */
-    public function getTotalLength(): Bigint
-    {
-        return $this->totalLength;
     }
 }

--- a/lib/vendor/maennchen/zipstream-php/src/Option/Archive.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Option/Archive.php
@@ -1,15 +1,20 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Option;
 
+use Psr\Http\Message\StreamInterface;
+
 final class Archive
 {
-    const DEFAULT_DEFLATE_LEVEL = 6;
+    public const DEFAULT_DEFLATE_LEVEL = 6;
+
     /**
      * @var string
      */
     private $comment = '';
+
     /**
      * Size, in bytes, of the largest file to try
      * and load into memory (used by
@@ -20,6 +25,7 @@ final class Archive
      * @var int
      */
     private $largeFileSize = 20 * 1024 * 1024;
+
     /**
      * How to handle large files.  Legal values are
      * Method::STORE() (the default), or
@@ -32,6 +38,7 @@ final class Archive
      * @var Method
      */
     private $largeFileMethod;
+
     /**
      * Boolean indicating whether or not to send
      * the HTTP headers for this file.
@@ -39,12 +46,14 @@ final class Archive
      * @var bool
      */
     private $sendHttpHeaders = false;
+
     /**
      * The method called to send headers
      *
      * @var Callable
      */
     private $httpHeaderCallback = 'header';
+
     /**
      * Enable Zip64 extension, supporting very large
      * archives (any size > 4 GB or file count > 64k)
@@ -52,6 +61,7 @@ final class Archive
      * @var bool
      */
     private $enableZip64 = true;
+
     /**
      * Enable streaming files with single read where
      * general purpose bit 3 indicates local file header
@@ -62,6 +72,7 @@ final class Archive
      * @var bool
      */
     private $zeroHeader = false;
+
     /**
      * Enable reading file stat for determining file size.
      * When a 32-bit system reads file size that is
@@ -75,11 +86,13 @@ final class Archive
      * @var bool
      */
     private $statFiles = true;
+
     /**
      * Enable flush after every write to output stream.
      * @var bool
      */
     private $flushOutput = false;
+
     /**
      * HTTP Content-Disposition.  Defaults to
      * 'attachment', where
@@ -91,6 +104,7 @@ final class Archive
      * @var string
      */
     private $contentDisposition = 'attachment';
+
     /**
      * Note that this does nothing if you are
      * not sending HTTP headers.
@@ -98,13 +112,14 @@ final class Archive
      * @var string
      */
     private $contentType = 'application/x-zip';
+
     /**
      * @var int
      */
     private $deflateLevel = 6;
 
     /**
-     * @var resource
+     * @var StreamInterface|resource
      */
     private $outputStream;
 
@@ -157,12 +172,12 @@ final class Archive
         $this->sendHttpHeaders = $sendHttpHeaders;
     }
 
-    public function getHttpHeaderCallback(): Callable
+    public function getHttpHeaderCallback(): callable
     {
         return $this->httpHeaderCallback;
     }
 
-    public function setHttpHeaderCallback(Callable $httpHeaderCallback): void
+    public function setHttpHeaderCallback(callable $httpHeaderCallback): void
     {
         $this->httpHeaderCallback = $httpHeaderCallback;
     }
@@ -228,7 +243,7 @@ final class Archive
     }
 
     /**
-     * @return resource
+     * @return StreamInterface|resource
      */
     public function getOutputStream()
     {
@@ -236,7 +251,7 @@ final class Archive
     }
 
     /**
-     * @param resource $outputStream
+     * @param StreamInterface|resource $outputStream
      */
     public function setOutputStream($outputStream): void
     {

--- a/lib/vendor/maennchen/zipstream-php/src/Option/File.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Option/File.php
@@ -1,9 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Option;
 
 use DateTime;
+use DateTimeInterface;
 
 final class File
 {
@@ -11,18 +13,22 @@ final class File
      * @var string
      */
     private $comment = '';
+
     /**
      * @var Method
      */
     private $method;
+
     /**
      * @var int
      */
     private $deflateLevel;
+
     /**
-     * @var DateTime
+     * @var DateTimeInterface
      */
     private $time;
+
     /**
      * @var int
      */
@@ -83,17 +89,17 @@ final class File
     }
 
     /**
-     * @return DateTime
+     * @return DateTimeInterface
      */
-    public function getTime(): DateTime
+    public function getTime(): DateTimeInterface
     {
         return $this->time;
     }
 
     /**
-     * @param DateTime $time
+     * @param DateTimeInterface $time
      */
-    public function setTime(DateTime $time): void
+    public function setTime(DateTimeInterface $time): void
     {
         $this->time = $time;
     }

--- a/lib/vendor/maennchen/zipstream-php/src/Option/Method.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Option/Method.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Option;
@@ -11,9 +12,12 @@ use MyCLabs\Enum\Enum;
  * @method static STORE(): Method
  * @method static DEFLATE(): Method
  * @psalm-immutable
+ * @psalm-template int
+ * @extends Enum<int>
  */
 class Method extends Enum
 {
-    const STORE = 0x00;
-    const DEFLATE = 0x08;
+    public const STORE = 0x00;
+
+    public const DEFLATE = 0x08;
 }

--- a/lib/vendor/maennchen/zipstream-php/src/Option/Version.php
+++ b/lib/vendor/maennchen/zipstream-php/src/Option/Version.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace ZipStream\Option;
@@ -13,10 +14,14 @@ use MyCLabs\Enum\Enum;
  * @method static DEFLATE(): Version
  * @method static ZIP64(): Version
  * @psalm-immutable
+ * @psalm-template int
+ * @extends Enum<int>
  */
 class Version extends Enum
 {
-    const STORE = 0x000A; // 1.00
-    const DEFLATE = 0x0014; // 2.00
-    const ZIP64 = 0x002D; // 4.50
+    public const STORE = 0x000A; // 1.00
+
+    public const DEFLATE = 0x0014; // 2.00
+
+    public const ZIP64 = 0x002D; // 4.50
 }

--- a/lib/vendor/maennchen/zipstream-php/test/BigintTest.php
+++ b/lib/vendor/maennchen/zipstream-php/test/BigintTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace BigintTest;

--- a/lib/vendor/maennchen/zipstream-php/test/bootstrap.php
+++ b/lib/vendor/maennchen/zipstream-php/test/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 date_default_timezone_set('UTC');

--- a/lib/vendor/maennchen/zipstream-php/test/bug/BugHonorFileTimeTest.php
+++ b/lib/vendor/maennchen/zipstream-php/test/bug/BugHonorFileTimeTest.php
@@ -1,17 +1,18 @@
 <?php
+
 declare(strict_types=1);
 
 namespace BugHonorFileTimeTest;
 
 use DateTime;
-use PHPUnit\Framework\TestCase;
-use ZipStream\Option\{
-    Archive,
-    File
-};
-use ZipStream\ZipStream;
 
 use function fopen;
+
+use PHPUnit\Framework\TestCase;
+use ZipStream\Option\Archive;
+use ZipStream\Option\File;
+
+use ZipStream\ZipStream;
 
 /**
  * Asserts that specified last-modified timestamps are not overwritten when a


### PR DESCRIPTION
With this PR zip files made on the server side (unencrypted transfers) can contain utf8 in their file names.