### PR TITLE
allow css/logo to be set in config (maybe using auth_config_regex_files)

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -67,7 +67,8 @@ class GUI
             'lib/jquery-ui/jquery-ui.min.css',
             'lib/font-awesome/css/font-awesome.min.css',
             'css/default.css',
-            'skin/styles.css'
+            'skin/styles.css',
+            'css/' . Config::get('site_css')
         ));
     }
     
@@ -210,7 +211,8 @@ class GUI
     {
         $locations = self::filterSources(array(
             'images/logo.png',
-            'skin/logo.png'
+            'skin/logo.png',
+            Config::get('site_logo')
         ));
         
         return array_pop($locations);

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -31,6 +31,8 @@ A note about colours;
 * [mime_type_default](#mime_type_default)
 * [service_aup_min_required_version](#service_aup_min_required_version)
 * [tmp_path](#tmp_path)
+* [site_css](#site_css)
+* [site_logo](#site_logo)
 
 ## Security settings
 * [use_strict_csp](#use_strict_csp)
@@ -452,6 +454,26 @@ A note about colours;
 * __default:__ FILESENDER_BASE.'/tmp/',
 * __available:__ since before version 2.30
 * __comment:__ Only some code has been migrated to using this configuration setting. It is intended to be a location that files might be temporarily stored while processing is happening.
+
+
+### site_css
+
+* __description:__ An additional css file to load after system ones to allow css updates by the admin. One might consider using this with the auth_config_regex_files option to change the look of a site depending on its use.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ ''
+* __available:__ since version 2.40
+* __comment:__  This will be taken relative to the css/ directory automatically.
+
+### site_logo
+
+* __description:__ An additional logo image to use. One might consider using this with the auth_config_regex_files option to change the look of a site depending on its use.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ ''
+* __available:__ since version 2.40
+* __comment:__  Note that this is relative to the www directory. So you might want to add the prefix images/ or skin/ depending on how your system is set up to find the image.
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -43,6 +43,8 @@ $default = array(
     'lang_selector_enabled' => false, // Display language selector (requires lang_url_enabled = true)
     'lang_save_url_switch_in_userpref' => false, // Save lang switching in user preferences (requires lang_url_enabled = true and lang_userpref_enabled = true)
     'site_name' => 'FileSender', // Default site name to user
+    'site_css' => '', // [optional] This allows an additional css file to be loaded per site using auth_config_regex_files
+    'site_logo' => '', // [optional] This allows a different logo image to be used per site using auth_config_regex_files
     'email_use_html' => true,   // By default, use HTML on mails
     'relay_unknown_feedbacks' => 'sender',   // Report email feedbacks with unknown type but with identified target (recipient or guest) to target owner
     'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds 

--- a/templates/header.php
+++ b/templates/header.php
@@ -53,7 +53,6 @@ $headerclass = "header";
             <div id="<?php echo $headerclass; ?>">
                 <a href="<?php echo GUI::path() ?>">
                     <?php GUI::includeLogo() ?>
-                    
                     <?php if(Config::get('site_name_in_header')) { ?>
                     <div class="site_name"><?php echo Config::get('site_name') ?></div>
                     <div class="site_baseline"><?php echo Config::get('site_baseline') ?></div>

--- a/www/css/test-css-override.css
+++ b/www/css/test-css-override.css
@@ -1,0 +1,8 @@
+
+#header {
+    background: #666 url(../images/banner900.png)  top left;
+    height: 90px;
+    background-size: cover;
+    background-repeat: no-repeat;    
+    margin-bottom: 1em;
+}


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/1406

This allows setting and additional css file (and top logo) using config settings. Using auth_config_regex_files allows that config setting to be performed differently for different sites.
