### PR TITLE
no merge: notifications: they dont seem to show the first time on safari

### DIFF
--- a/www/js/notification.js
+++ b/www/js/notification.js
@@ -41,6 +41,7 @@ window.filesender.notification = {
     use: false,
     asked: false,
     n: [],
+    pending_notifications: [],
 
 
     /**
@@ -73,7 +74,16 @@ window.filesender.notification = {
                 // remember that this might not be the notification object in this context
                 window.filesender.notification.available = false;
             } else {
-                window.filesender.notification.available = true;
+                setTimeout(() => {
+                    console.log("handlePermission() have permission so showing any delayed notifications now.");
+                    window.filesender.notification.available = true;
+                    window.filesender.notification.pending_notifications.forEach(function(e) {
+                        var newn = new Notification( e.title, { body: e.msg, icon: e.image });
+                        window.filesender.notification.n.push(newn);
+                    });
+                    window.filesender.notification.pending_notifications = [];
+                }, 100);
+                
             }
         }
 
@@ -105,6 +115,7 @@ window.filesender.notification = {
      */
     notify: function( title, msg, image ) {
         if( !this.available ) {
+            window.filesender.notification.pending_notifications.push( { title: title, msg: msg, image: image } );
             return;
         }
 

--- a/www/js/notification.js
+++ b/www/js/notification.js
@@ -50,6 +50,11 @@ window.filesender.notification = {
     ask: function( force = false ) {
         this.available = false;
 
+        console.log("AAA ask()");
+        console.log("AAA ask() force", force );
+        console.log("AAA ask() asked ", this.asked );
+        console.log("AAA ask() Notification.permission ", Notification.permission );
+        
         // only try to ask once.
         if( this.asked &&
             (Notification.permission === 'denied' || Notification.permission === 'default'))

--- a/www/js/notification.js
+++ b/www/js/notification.js
@@ -70,6 +70,7 @@ window.filesender.notification = {
         }
         
         function handlePermission(permission) {
+            console.log("handlePermission() have result: ", Notification.permission);
             if(Notification.permission === 'denied' || Notification.permission === 'default') {
                 // remember that this might not be the notification object in this context
                 window.filesender.notification.available = false;
@@ -91,12 +92,15 @@ window.filesender.notification = {
         if (!('Notification' in window)) {
             console.log("This browser does not support notifications.");
         } else {
+            console.log("ask() in the else part.");
             if(checkNotificationPromise()) {
+                console.log("ask() in checkNotificationPromise() part.");
                 Notification.requestPermission()
                     .then((permission) => {
                         handlePermission(permission);
                     })
             } else {
+                console.log("ask() in the Notification.requestPermission direct part.");
                 Notification.requestPermission(function(permission) {
                     handlePermission(permission);
                 });


### PR DESCRIPTION
It is possible that the successful granting of permissions promise might be called after the code calls notify(). In that case we should stash the notification so that when the promise is resolved we can show the user.

This relates to https://github.com/filesender/filesender/issues/1429