### PR TITLE
Fix erroneous file extension getter

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -237,7 +237,7 @@ window.filesender.transfer = function() {
     }
 
     this.getExtention = function(file) {
-        var fileSplit = file.name.split('.');
+        var fileSplit = file.name.replace(/^.+[\/\\]/, '').split('.');
         if (fileSplit.length>1) {
             return fileSplit.pop();
         }


### PR DESCRIPTION
File extension getter was returning erroneous extension in the case of a directory whose name contains a dot with an extension-less file inside. Example : a `v1.6` folder containing a `OUT` file, the javascript file's name property is `v1.6/OUT`, thus the `getExtension` was returning `6/OUT`, which does not match the file extension regexp and was thus banned. This fix strips the path from the file name before splitting the basename and the extension.