### PR TITLE
Cloud docs update

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -701,7 +701,7 @@ $config['rate_limits'] = array(
 * __available:__ since version 2.0
 * __comment:__ each supported storage type will have a specific class defined in classes/storage.  Each is named Storage<Foo>.class.php, for example StorageFilesystem.class.php for the type filesystem.  The values for "Foo" are the permissible values for this directive. The primary choices for value are filesystem and filesystemChunked. Note that you need to respect the non leading capital letters in the class name such as the "C" in filesystemChunked. Future storage types could include e.g. **object**, **amazon_s3** and others.
 
-   Please also see the [cloud configuration page](https://docs.filesender.org/filesender/v2.0/cloud/) if you are using cloud backed storage.
+   If you are using cloud backed storage please also see the [cloud configuration page](https://docs.filesender.org/filesender/v2.0/cloud/).
 
 ### storage_filesystem_path
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -701,6 +701,8 @@ $config['rate_limits'] = array(
 * __available:__ since version 2.0
 * __comment:__ each supported storage type will have a specific class defined in classes/storage.  Each is named Storage<Foo>.class.php, for example StorageFilesystem.class.php for the type filesystem.  The values for "Foo" are the permissible values for this directive. The primary choices for value are filesystem and filesystemChunked. Note that you need to respect the non leading capital letters in the class name such as the "C" in filesystemChunked. Future storage types could include e.g. **object**, **amazon_s3** and others.
 
+   Please also see the [cloud configuration page](https://docs.filesender.org/filesender/v2.0/cloud/) if you are using cloud backed storage.
+
 ### storage_filesystem_path
 
 * __description:__ when using storage type **filesystem** this is the absolute path to the file system where uploaded files are stored until they expire.  Your FileSender storage root.

--- a/docs/v2.0/cloud/index.md
+++ b/docs/v2.0/cloud/index.md
@@ -10,11 +10,11 @@ Amazon S3 is another possible cloud target.
 
 It was reported that performance with the S3 backend (and maybe others)
 can be greatly increased by bumping up upload_chunk_size and related values.
-For example:
+For example using 40mb chunks:
 
 ```
 $config['upload_chunk_size'] = 1024 * 1024 * 40;
-$config['upload_crypted_chunk_size'] = $config['upload_chunk_size'] + 32;
+$config['upload_crypted_chunk_size'] = $config['upload_chunk_size'] + $config['upload_crypted_chunk_padding_size'];
 $config['download_chunk_size'] = $config['upload_chunk_size'];
 ```
 

--- a/docs/v2.0/cloud/index.md
+++ b/docs/v2.0/cloud/index.md
@@ -14,8 +14,8 @@ For example using 40mb chunks:
 
 ```
 $config['upload_chunk_size'] = 1024 * 1024 * 40;
-$config['upload_crypted_chunk_size'] = $config['upload_chunk_size'] + $config['upload_crypted_chunk_padding_size'];
 $config['download_chunk_size'] = $config['upload_chunk_size'];
+$config['upload_crypted_chunk_size'] = $config['upload_chunk_size'] + $config['upload_crypted_chunk_padding_size'];
 ```
 
 Increasing upload_chunk_size also requires you to verify PHP's memory

--- a/docs/v2.0/cloud/index.md
+++ b/docs/v2.0/cloud/index.md
@@ -8,6 +8,19 @@ FileSender 2.0 can store the uploaded file data in the cloud. Support
 is currently being developed for storing data in Azure blobs and
 Amazon S3 is another possible cloud target.
 
+It was reported that performance with the S3 backend (and maybe others)
+can be greatly increased by bumping up upload_chunk_size and related values.
+For example:
+
+```
+$config['upload_chunk_size'] = 1024 * 1024 * 40;
+$config['upload_crypted_chunk_size'] = $config['upload_chunk_size'] + 32;
+$config['download_chunk_size'] = $config['upload_chunk_size'];
+```
+
+Increasing upload_chunk_size also requires you to verify PHP's memory
+limit is equal or bigger than about 5x upload_chunk_size.
+
 ## Azure
 
 At the moment a new container is created for each file and files are


### PR DESCRIPTION
This takes the advice on clunk size from https://github.com/filesender/filesender/pull/1455 and brings it into the cloud docs page. The configuration page now also links to the cloud page to hint to the admin that relevant information is contained in that page.

