### PR TITLE
bootstrap: show the collapse area in the transfer details again

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -41,7 +41,9 @@ $(function() {
         var el = $(this);
         var tr = el.closest('tr');
         var details = el.closest('table').find('.transfer_details[data-id="' + tr.attr('data-id') + '"]');
-        
+
+        var collapse = details.find('.collapse');
+        collapse.show('fast');
         tr.hide('fast');
         details.show('fast');
     });


### PR DESCRIPTION
This should fix https://github.com/filesender/filesender/issues/1468