### PR TITLE
simplesamlphp do not force the login url but use the class to get it

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -208,7 +208,7 @@ class AuthSPSaml
         $url = Utilities::http_build_query(array(
             'AuthId' => self::$config['authentication_source'],
             'ReturnTo' => $target,
-        ), self::$config['simplesamlphp_url'].'module.php/core/as_login.php?');
+        ), self::$simplesamlphp_auth_simple->getLoginURL($target));
 
         return $url;
     }
@@ -231,7 +231,7 @@ class AuthSPSaml
         $url = Utilities::http_build_query(array(
             'AuthId' => self::$config['authentication_source'],
             'ReturnTo' => $target,
-        ), self::$config['simplesamlphp_url'].'module.php/core/as_logout.php?');
+        ), self::$simplesamlphp_auth_simple->getLogoutURL($target));
         
         return $url;
     }


### PR DESCRIPTION
The URL for login and logout changed in SimpleSAMLphp 2.x and the code in FileSender had hard coded the locations for login and logout. This PR changes that to ask SimpleSAMLphp for those URLs instead which should allow the code to function against either a SimpleSAMLphp 1.x or SimpleSAMLphp 2.x installation.

This relates to  https://github.com/filesender/filesender/issues/1467