### PR TITLE
many files: adding them is quicker, download is via POST

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -337,7 +337,7 @@ class File extends DBObject
         $file->logsCache = array();
         $file->transfer_id = $transfer->id;
         $file->transferCache = $transfer;
-        
+
         // Generate uid until it is indeed unique
         $file->uid = Utilities::generateUID(function ($uid, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.File::getDBTable().' WHERE uid = :uid');
@@ -348,7 +348,7 @@ class File extends DBObject
             }
             return !$data;
         });
-
+        
         $file->storage_class_name = Storage::getDefaultStorageClass();
 
         if (!is_null($size)) {
@@ -400,7 +400,7 @@ class File extends DBObject
      */
     public static function fromTransfer(Transfer $transfer)
     {
-        $s = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE transfer_id = :transfer_id');
+        $s = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE transfer_id = :transfer_id order by name desc');
         $s->execute(array(':transfer_id' => $transfer->id));
         $tree_files = array();
         $files = array();

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -465,7 +465,6 @@ class RestEndpointTransfer extends RestEndpoint
                 }
             }
 
-            
             // Must have files ...
             if (!count($data->files)) {
                 throw new TransferNoFilesException();

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -81,7 +81,6 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
 
     $downloadLinks = array();
     $archiveDownloadLink = '#';
-    $archiveDownloadLinkRAW = '';
     $archiveDownloadLinkFileIDs = '';
     
     if(empty($transfer->options['encryption'])) {
@@ -94,10 +93,6 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             $fileIds[] = $file->id;
         }
         $archiveDownloadLink = Utilities::http_build_query(array(
-            'token' => $token,
-            'files_ids' => implode(',', $fileIds),
-        ), 'download.php?' );
-        $archiveDownloadLinkRAW = Utilities::http_build_query(array(
             'token' => $token,
         ), 'download.php?' );
         $archiveDownloadLinkFileIDs = implode(',', $fileIds);
@@ -303,14 +298,14 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             </div>
             
             <div class="archive_download_frame">
-            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" class="archive_download" title="{tr:archive_download}">
+            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_download" title="{tr:archive_download}">
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_download}
             </a>
             </div>
             <?php if($canDownloadAsTar) { ?>
             <div class="archive_tar_download_frame">
-            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
+            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_tar_download}
             </a>
@@ -318,7 +313,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             <?php } ?>
 
             <div class="archive_download_framex hidden">
-                <form id="dlarchivepost" action="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" method="post">
+                <form id="dlarchivepost" action="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" method="post">
                     <input class="hidden archivefileids" name="files_ids" value="<?php echo $archiveDownloadLinkFileIDs; ?>" />
                     <input id="dlarchivepostformat" class="hidden " name="archive_format" value="zip" />
                     <button type="submit"

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -81,6 +81,9 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
 
     $downloadLinks = array();
     $archiveDownloadLink = '#';
+    $archiveDownloadLinkRAW = '';
+    $archiveDownloadLinkFileIDs = '';
+    
     if(empty($transfer->options['encryption'])) {
         $fileIds = array();
         foreach($transfer->files as $file) {
@@ -94,6 +97,10 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             'token' => $token,
             'files_ids' => implode(',', $fileIds),
         ), 'download.php?' );
+        $archiveDownloadLinkRAW = Utilities::http_build_query(array(
+            'token' => $token,
+        ), 'download.php?' );
+        $archiveDownloadLinkFileIDs = implode(',', $fileIds);
     }
 
     $isEncrypted = isset($transfer->options['encryption']) && $transfer->options['encryption'];
@@ -307,8 +314,20 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_tar_download}
             </a>
+            </div>            
+            <?php } ?>
+
+            <div class="archive_download_framex hidden">
+                <form id="dlarchivepost" action="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" method="post">
+                    <input class="hidden archivefileids" name="files_ids" value="<?php echo $archiveDownloadLinkFileIDs; ?>" />
+                    <input id="dlarchivepostformat" class="hidden " name="archive_format" value="zip" />
+                    <button type="submit"
+                            name="your_name" value="your_value"
+                            class="btn-link">DOWNLOAD
+                    </button>
+                </form>
             </div>
-            <?php } ?>    
+            
             <span class="downloadprogress"/>
         </div>
     <?php } ?>    

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -303,14 +303,14 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             </div>
             
             <div class="archive_download_frame">
-            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_download" title="{tr:archive_download}">
+            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" class="archive_download" title="{tr:archive_download}">
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_download}
             </a>
             </div>
             <?php if($canDownloadAsTar) { ?>
             <div class="archive_tar_download_frame">
-            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
+            <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLinkRAW) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
                 <span class="fa fa-2x fa-download"></span>
                 {tr:archive_tar_download}
             </a>

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -42,6 +42,15 @@ $(function() {
     }
     
     window.filesender.pbkdf2dialog.setup( true );
+
+    var updateSelectedFilesForArchiveDownload = function()  {
+        var ids = [];
+        page.find('.file[data-selected="1"]').each(function() {
+            ids.push($(this).attr('data-id'));
+        });
+        var idlist = ids.join(',');
+        $('.archivefileids').attr('value', idlist );
+    }
     
     // Bind file selectors
     page.find('.file .select').on('click', function() {
@@ -85,10 +94,17 @@ $(function() {
         var dlcb = function(notify) {
             notify = notify ? '&notify_upon_completion=1' : '';
             return function() {
-                filesender.ui.redirect( filesender.config.base_path
-                                        + 'download.php?token=' + token
-                                        + '&archive_format=' + archive_format
-                                        + '&files_ids=' + ids.join(',') + notify);
+                if( archive_format ) {
+                    console.log("Starting download using POST method...");
+                    $('#dlarchivepostformat').attr( 'value', archive_format );
+                    updateSelectedFilesForArchiveDownload();
+                    $('#dlarchivepost').submit();
+                } else {
+                    filesender.ui.redirect( filesender.config.base_path
+                                            + 'download.php?token=' + token
+                                            + '&archive_format=' + archive_format
+                                            + '&files_ids=' + ids.join(',') + notify);
+                }
             };
         };
         if (!encrypted && confirm){

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -223,16 +223,20 @@ filesender.ui.files = {
                 file_name = files[i].webkitRelativePath;
             }
             
-            var latest_node = filesender.ui.files.addFile(file_name, files[i], source_node);
+            var latest_node = filesender.ui.files.addFile(file_name, files[i], false, source_node);
             if (latest_node) {
                 node = latest_node;
             }
         }
+        
+        filesender.ui.evalUploadEnabled();
+        filesender.ui.nodes.files.list.scrollTop(filesender.ui.nodes.files.list.prop('scrollHeight'));
+        
         this.sortErrorLinesToTop();
         return node;
     },
     
-    addFile: function(filepath, fileblob, source_node) {
+    addFile: function(filepath, fileblob, isSingleOperation, source_node) {
         var filesize = fileblob.size;
         var node = null;
             var info = filepath + ' : ' + filesender.ui.formatBytes(filesize);
@@ -297,7 +301,7 @@ filesender.ui.files = {
                     filesender.ui.evalUploadEnabled();
                 }).appendTo(node);
                 
-                var added_cid = filesender.ui.transfer.addFile(filepath, fileblob, function(error) {
+                var added_cid = filesender.ui.transfer.addFile(filepath, fileblob, true, function(error) {
                     var tt = 1;
                     if(error.details && error.details.filename) filesender.ui.files.invalidFiles.push(error.details.filename);
                     node.addClass('invalid');
@@ -314,8 +318,10 @@ filesender.ui.files = {
                 
                 if(added_cid === false) return node;
             }
-                
-            filesender.ui.evalUploadEnabled();
+
+            if( isSingleOperation ) {
+                filesender.ui.evalUploadEnabled();
+            }
             node.attr('data-cid', added_cid);
 
             var bar = $('<div class="progressbar" />').appendTo(node);
@@ -385,7 +391,9 @@ filesender.ui.files = {
             
             node.attr('index', filesender.ui.transfer.files.length - 1);
         
-        filesender.ui.nodes.files.list.scrollTop(filesender.ui.nodes.files.list.prop('scrollHeight'));
+        if( isSingleOperation ) {
+            filesender.ui.nodes.files.list.scrollTop(filesender.ui.nodes.files.list.prop('scrollHeight'));
+        }
         
         return node;
     },
@@ -1120,7 +1128,7 @@ filesender.ui.startUpload = function() {
     this.transfer.aup_checked = false;
     if(filesender.ui.nodes.aup.length)
         this.transfer.aup_checked = filesender.ui.nodes.aup.is(':checked');
-    
+
     if( filesender.config.upload_display_per_file_stats ) {
         window.setInterval(function() {
             if( !window.filesender.pbkdf2dialog.already_complete ) {


### PR DESCRIPTION
The download of an unencrypted archive is now performed via a POST request. The existing way was using an http redirect to start this particular form of download. The problem with that is the file_id list could be very long and might overflow what is acceptable on a GET and thus fail for some proxy setups etc. Using POST allows the fileid list to be moved off the URL and thus remain relatively long but also functional in such environments.

Adding many files is now a fair bit quicker. For the test environment it went from 3.3s down to 1.8s. Still not ideal but better. Note that there is still a significant speed difference between "add a directory" and add file(s) and selecting all 1500 test files. I have narrowed this down to a Collection call that is only made on the former and requires 20-30ms per file.

File::fromTransfer adds a sorting order by name. I would really prefer this to be a natural sort à la `ls -lv` but that improvement will be the subject of a future PR.

This relates to https://github.com/filesender/filesender/issues/1483.