### PR TITLE
Fix parameter of SystemMail::quickSend()

### DIFF
--- a/classes/utils/SystemMail.class.php
+++ b/classes/utils/SystemMail.class.php
@@ -62,7 +62,7 @@ class SystemMail extends ApplicationMail
      * @param string $translation_id
      * @param mixed ... additional translation variables
      */
-    public static function quickSend($translation_id /*, ... */)
+    public static function quickSend($translation_id, $to='' /*, ... */)
     {
         $vars = array_slice(func_get_args(), 1);
         


### PR DESCRIPTION
Fatal error at `scripts/task/cron.php` when calling `SystemMail::quickSend()` because the parameter is different from that of the inherited `ApplicationMail::quickSend()`

```
PHP Fatal error:  Declaration of SystemMail::quickSend($translation_id) must be compatible with ApplicationMail::quickSend($translation_id, $to) in /opt/filesender/filesender-2.39/classes/utils/SystemMail.class.php on line 65
```