### PR TITLE
change GUI.class.php filterSources to use is_file instead of file_exists

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -263,7 +263,7 @@ class GUI
     private static function filterSources($sources)
     {
         return array_filter($sources, function ($source) {
-            return file_exists(FILESENDER_BASE.'/www/'.$source);
+            return is_file(FILESENDER_BASE.'/www/'.$source);
         });
     }
     


### PR DESCRIPTION
classes/utils/GUI.class.php filterSources is used to verify that all files passed to it as an argument exist in the web root.

This check was done with file_exists function. file_exists also returns true if the name is a directory. php has as separate is_file function that returns true only if the name exists and is a regular file.

This fixes a cosmetic issue: templates/header.php was sending `<link type="text/css" rel="stylesheet" href="/css/" />` to the browser because we do not have a separate `site_css` defined in config.php. 
