### PR TITLE
Option to use File System Access API on Chromium browsers

### DIFF
--- a/classes/utils/Browser.class.php
+++ b/classes/utils/Browser.class.php
@@ -46,6 +46,7 @@ class Browser
     protected $isFirefox = false;
     protected $isSafari  = false;
     protected $allowStreamSaver  = false;
+    protected $allowFileSystemWritableFileStream = false;
     
     public function __construct()
     {
@@ -75,6 +76,11 @@ class Browser
             }
             
         }
+
+        if( Config::get('filesystemwritablefilestream_enabled')) {
+            $this->allowFileSystemWritableFileStream = true;
+        }
+        
     }
     static function instance()
     {
@@ -86,7 +92,7 @@ class Browser
     public function __get($property)
     {
         if (in_array($property, array(
-            'isChrome','isFirefox','allowStreamSaver',
+            'isChrome','isFirefox','allowStreamSaver','allowFileSystemWritableFileStream'
         ))) {
             return $this->$property;
         }

--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -115,8 +115,14 @@ class GUI
             array_push( $sources,
                         'lib/streamsaver/StreamSaver.js',
                         'js/crypter/streamsaver_sink.js',
+                        'js/crypter/archive_sink.js',
                         'js/crc32handler.js',
                         'js/zip64handler.js'
+            );
+        }
+        if( Browser::instance()->allowFileSystemWritableFileStream ) {
+            array_push( $sources,
+                        'js/crypter/filesystemwritablefilestream_sink.js'
             );
         }
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -2013,7 +2013,21 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __type:__ boolean
 * __default:__ true
 * __available:__ since version 2.19
-* __comment:__ 
+* __comment:__
+
+
+### fileSystemWritableFileStream_enabled
+* __description:__ Allow the use of the FileSystemWritableFileStream API to perform streaming download of encrypted files on supported browsers.
+* __mandatory:__ no 
+* __recommend_leaving_at_default:__ true
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.41
+* __comment:__
+    This feature is currently only available when you have streamsaver_enabled=true set. This will prefer to use the
+    FileSystemWritableFileStream API when available to stream data to disk. As at mid 2023 Edge and Chrome support
+    this feature, Firefox supports most but not all (so can not be used) and Safari does not support the feature.
+    In the future this may be separated from the streamsaver_enabled option so it can be enabled independently.
 
 ### recipient_reminder_limit
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -301,6 +301,8 @@ $default = array(
     'streamsaver_on_edge'   => true,
     'streamsaver_on_safari' => true,
 
+    'filesystemwritablefilestream_enabled' => false,
+    
     'upload_page_password_can_not_be_part_of_message_handling' => 'warning',
 
     'data_protection_user_frequent_email_address_disabled' => false,

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -196,6 +196,8 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
     guest_reminder_limit_per_day:  <?php echo Config::get('guest_reminder_limit_per_day') ?>,
     storage_type:  "<?php echo Config::get('storage_type') ?>",
     allow_streamsaver: <?php echo value_to_TF(Browser::instance()->allowStreamSaver) ?>,
+    allow_filesystemwritablefilestream: <?php echo value_to_TF(Browser::instance()->allowFileSystemWritableFileStream) ?>,
+
 
     upload_page_password_can_not_be_part_of_message_handling: "<?php echo Config::get('upload_page_password_can_not_be_part_of_message_handling') ?>",
 
@@ -220,3 +222,11 @@ $(function() {
 });
 
 <?php } ?>
+
+window.filesender.config.isFileSystemWritableFileStreamAvailableForDownload = function() {
+    return 'showSaveFilePicker' in window;
+};
+window.filesender.config.useFileSystemWritableFileStreamForDownload = function() {
+    return window.filesender.config.allow_filesystemwritablefilestream
+        && window.filesender.config.isFileSystemWritableFileStreamAvailableForDownload();
+}

--- a/www/js/crypter/archive_sink.js
+++ b/www/js/crypter/archive_sink.js
@@ -1,0 +1,170 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2023, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+if (typeof window === 'undefined')
+    window = {}; // dummy window for use in webworkers
+
+if (!('filesender' in window))
+    window.filesender = {};
+
+window.filesender.archive_sink = function ( cryptoapp, link, transferid, archiveName, pass, selectedFiles, arg_callbackError ) {
+    return {
+        complete:       false,
+        // keep a tally of bytes processed to make sure we get everything.
+        bytesProcessed: 0,
+        callbackError:  arg_callbackError,
+        zip:            null,
+        isFileOpen:     false,
+        selectedFiles:  selectedFiles,
+        cryptoapp:      cryptoapp,
+        link:           link,
+        transferid:     transferid,
+        pass:           pass,
+        activeFileID:   null,
+        progress:       null,
+        archiveName:    archiveName,
+        crypto_encrypted_archive_download_fileidlist: '',
+        onOpen:  function( blobSink, fileid ) { },
+        onClose: function( blobSink, fileid ) { },
+        onComplete: function( blobSink ) {},
+
+        currentFileNumber:    0,
+        totalFilesToDownload: 0,
+        
+        init: async function() {
+            var $this = this;
+            console.log("archive_sink init (top)");
+
+            if( !$this.zip ) {
+                $this.zip = window.filesender.zip64handler();
+                await $this.zip.init($this.archiveName);
+                console.log("archive_sink zip init complete ()");
+
+                $this.totalFilesToDownload = selectedFiles.length;                
+                $this.cryptoapp.setDownloadFileidlist( $this.selectedFiles );
+                $this.crypto_encrypted_archive_download_fileidlist = window.filesender.crypto_encrypted_archive_download_fileidlist;
+                window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+            }
+        },
+        error: function(error) {
+            var $this = this;
+
+            window.filesender.log('archive sink error()');
+            if($this.zip) {
+                $this.zip.abort();
+            }
+        },
+        openFile: function(filename,fileid) {
+            var $this = this;
+            if( $this.isFileOpen ) {
+                $this.closeFile();
+            }
+            $this.zip.openFile(filename);
+            $this.isFileOpen = true;
+            $this.activeFileID = fileid;
+            $this.onOpen( $this, $this.activeFileID );
+            $this.currentFileNumber++;
+        },
+        closeFile: function() {
+            var $this = this;
+            $this.zip.closeFile();
+            $this.isFileOpen = false;
+            $this.onClose( $this, $this.activeFileID );
+            $this.activeFileID = null;
+        },
+
+        downloadNext: function() {
+            var $this = this;
+
+            
+            if( $this.selectedFiles.length == 0 ) {
+                window.filesender.log("archive_sink blobSinkStreamedzip64 no more files to add to archive... done");
+                $this.complete = true;
+                $this.zip.closeFile();
+                window.filesender.log("archive_sink calling close zip...");
+                $this.closeZip();
+                $this.onComplete( $this );
+            }
+            else
+            {
+                var f = $this.selectedFiles.shift();
+                window.filesender.log("archive_sink zip adding next file with name " + f.filename );
+                $this.openFile(f.filename,f.fileid);
+
+                // last file in selection, tell server we are almost done.
+                if( $this.selectedFiles.length == 0 ) {
+                    window.filesender.log("archive_sink zip downloadNext(sel==1?) selfiles.len " + $this.selectedFiles.length );
+                    window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
+
+                    var transfer = new filesender.transfer();
+                    if (transfer.canUseTeraReceiver()) {
+                        window.filesender.crypto_encrypted_archive_download_fileidlist = '';
+                        if( window.filesender.terasender  ) {
+                            window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
+                        }
+                        
+                    }
+
+                    
+                }
+                
+                $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,
+                                                           $this.link+f.fileid,
+                                                           f.mime, f.filename, f.filesize, f.encrypted_filesize,
+                                                           f.key_version, f.salt,
+                                                           f.password_version, f.password_encoding, f.password_hash_iterations,
+                                                           f.client_entropy, f.fileiv, f.fileaead,
+                                                           $this.progress);
+            }
+            
+        },
+        closeZip: function() {
+            console.log("archive_sink closeZip");
+            var $this = this;
+            if( $this.isFileOpen ) {
+                $this.closeFile();
+            }
+            $this.zip.complete();
+        },
+        visit: async function(chunkid,decryptedData) {
+            var $this = this;
+            await $this.init();
+            $this.zip.visit(decryptedData);
+        },
+        done: function() {
+            var $this = this;
+            $this.downloadNext();
+        }
+    }
+};
+

--- a/www/js/crypter/filesystemwritablefilestream_sink.js
+++ b/www/js/crypter/filesystemwritablefilestream_sink.js
@@ -1,0 +1,87 @@
+// JavaScript Document
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2023, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+if (typeof window === 'undefined')
+    window = {}; // dummy window for use in webworkers
+
+if (!('filesender' in window))
+    window.filesender = {};
+
+window.filesender.filesystemwritablefilestream_sink = function ( arg_name, arg_expected_size, arg_callbackError ) {
+    return {
+        filename:       arg_name,
+        expected_size:  arg_expected_size,
+        fileStream:     null,
+        writer:         null,
+        complete:       false,
+        // keep a tally of bytes processed to make sure we get everything.
+        bytesProcessed: 0,
+        callbackError:  arg_callbackError,
+        name: function() { return "FileSystemWritableFileStream"; },
+        
+        init: async function() {
+            var $this = this;
+            console.log("FileSystemWritableFileStream init (top)");
+            
+            if( !$this.fileStream ) {
+                $this.fileStream = await window.showSaveFilePicker({
+                    suggestedName: this.filename,
+                    startIn: 'downloads',
+                });
+            }
+            if( !$this.writer ) {
+                $this.writer = await $this.fileStream.createWritable();
+            }
+
+            console.log("FileSystemWritableFileStream init (bottom)");
+        },
+        error: function(error) {
+        },
+        visit: async function(chunkid,decryptedData) {
+            var $this = this;
+            await $this.init();
+            
+            window.filesender.log("FileSystemWritableFileStream visit chunkid " + chunkid + "  data.len " + decryptedData.length );
+            await $this.writer.write( decryptedData );            
+        },
+        done: async function() {
+            var $this = this;
+            window.filesender.log("FileSystemWritableFileStream done()");
+            await $this.writer.close();            
+            $this.complete = true;
+        }
+    }
+};
+
+
+

--- a/www/js/crypter/streamsaver_sink.js
+++ b/www/js/crypter/streamsaver_sink.js
@@ -15,7 +15,7 @@ window.filesender.streamsaver_sink = function ( arg_name, arg_expected_size, arg
         bytesProcessed: 0,
         callbackError: arg_callbackError,
         name: function() { return "streamsaver"; },
-        init: function() {
+        init: async function() {
             var $this = this;
             
             if( !$this.fileStream ) {
@@ -41,9 +41,9 @@ window.filesender.streamsaver_sink = function ( arg_name, arg_expected_size, arg
         },
         error: function(error) {
         },
-        visit: function(chunkid,decryptedData) {
+        visit: async function(chunkid,decryptedData) {
             var $this = this;
-            $this.init();
+            await $this.init();
             
             window.filesender.log("blobSinkStreamed chunkid " + chunkid + "  data.len " + decryptedData.length );
             const readableStream = new Response( decryptedData ).body;
@@ -73,7 +73,7 @@ window.filesender.streamsaver_sink = function ( arg_name, arg_expected_size, arg
             
             pump();
         },
-        done: function() {
+        done: async function() {
             var $this = this;
             window.filesender.log("blobSinkStreamed.done(top)");
             $this.complete = true;
@@ -82,135 +82,4 @@ window.filesender.streamsaver_sink = function ( arg_name, arg_expected_size, arg
 };
 
 
-
-window.filesender.streamsaver_sink_zip64 = function ( cryptoapp, link, transferid, archiveName, pass, selectedFiles, arg_callbackError ) {
-    return {
-        complete: false,
-        // keep a tally of bytes processed to make sure we get everything.
-        bytesProcessed: 0,
-        callbackError: arg_callbackError,
-        zip:null,
-        isFileOpen: false,
-        selectedFiles: selectedFiles,
-        cryptoapp: cryptoapp,
-        link: link,
-        transferid: transferid,
-        pass: pass,
-        activeFileID: null,
-        progress: null,
-        archiveName: archiveName,
-        crypto_encrypted_archive_download_fileidlist: '',
-        onOpen:  function( blobSink, fileid ) { },
-        onClose: function( blobSink, fileid ) { },
-        onComplete: function( blobSink ) {},
-
-        currentFileNumber: 0,
-        totalFilesToDownload: 0,
-        
-        init: function() {
-            var $this = this;
-
-            if( !$this.zip ) {
-                $this.zip = window.filesender.zip64handler();
-                $this.zip.init($this.archiveName);
-
-                $this.totalFilesToDownload = selectedFiles.length;
-
-                $this.cryptoapp.setDownloadFileidlist( $this.selectedFiles );
-                $this.crypto_encrypted_archive_download_fileidlist = window.filesender.crypto_encrypted_archive_download_fileidlist;
-                window.filesender.crypto_encrypted_archive_download_fileidlist = '';
-            }
-
-            
-        },
-        error: function(error) {
-            var $this = this;
-
-            window.filesender.log('zip64 sink error()');
-            if($this.zip) {
-                $this.zip.abort();
-            }
-        },
-        openFile: function(filename,fileid) {
-            var $this = this;
-            if( $this.isFileOpen ) {
-                $this.closeFile();
-            }
-            $this.zip.openFile(filename);
-            $this.isFileOpen = true;
-            $this.activeFileID = fileid;
-            $this.onOpen( $this, $this.activeFileID );
-            $this.currentFileNumber++;
-        },
-        closeFile: function() {
-            var $this = this;
-            $this.zip.closeFile();
-            $this.isFileOpen = false;
-            $this.onClose( $this, $this.activeFileID );
-            $this.activeFileID = null;
-        },
-
-        downloadNext: function() {
-            var $this = this;
-            
-            if( $this.selectedFiles.length == 0 ) {
-                window.filesender.log("blobSinkStreamedzip64 no more files to add to archive... done");
-                $this.complete = true;
-                $this.zip.closeFile();
-                $this.closeZip();
-                $this.onComplete( $this );
-            }
-            else
-            {
-                var f = $this.selectedFiles.shift();
-                window.filesender.log("blobSinkStreamedzip64 adding next file with name " + f.filename );
-                $this.openFile(f.filename,f.fileid);
-
-                // last file in selection, tell server we are almost done.
-                if( $this.selectedFiles.length == 0 ) {
-                    window.filesender.log("aaa blobSinkStreamedzip64 downloadNext(sel==1?) selfiles.len " + $this.selectedFiles.length );
-                    window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
-
-                    var transfer = new filesender.transfer();
-                    if (transfer.canUseTeraReceiver()) {
-                        window.filesender.crypto_encrypted_archive_download_fileidlist = '';
-                        if( window.filesender.terasender  ) {
-                            window.filesender.crypto_encrypted_archive_download_fileidlist = $this.crypto_encrypted_archive_download_fileidlist;
-                        }
-                        
-                    }
-
-                    
-                }
-                
-                $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,
-                                                           $this.link+f.fileid,
-                                                           f.mime, f.filename, f.filesize, f.encrypted_filesize,
-                                                           f.key_version, f.salt,
-                                                           f.password_version, f.password_encoding, f.password_hash_iterations,
-                                                           f.client_entropy, f.fileiv, f.fileaead,
-                                                           $this.progress);
-            }
-            
-        },
-        closeZip: function() {
-            var $this = this;
-            if( $this.isFileOpen ) {
-                $this.closeFile();
-            }
-            $this.zip.complete();
-        },
-        visit: function(chunkid,decryptedData) {
-            var $this = this;
-            $this.init();
-            
-//            window.filesender.log("BBB blobSinkStreamedzip64.visit chunkid " + chunkid + "  data.len " + decryptedData.length );
-            $this.zip.visit(decryptedData);
-        },
-        done: function() {
-            var $this = this;
-            $this.downloadNext();
-        }
-    }
-};
 

--- a/www/js/pbkdf2dialog.js
+++ b/www/js/pbkdf2dialog.js
@@ -92,7 +92,7 @@ window.filesender.pbkdf2dialog = {
                         // Generated keys do not need repeated hashing
                         // so they should be too quick for a dialog to be needed
                         // See end of https://github.com/filesender/filesender/pull/375#issuecomment-439160499
-                        if( !($this.usingGeneratedKey())) {
+                        if( 'usingGeneratedKey' in $this && !($this.usingGeneratedKey())) {
                             $this.dialog = filesender.ui.alert(
                                 "info", lang.tr(trans).r({seconds: expected_delay}).out());
                         }

--- a/www/js/zip64handler.js
+++ b/www/js/zip64handler.js
@@ -79,20 +79,44 @@ window.filesender.zip64handler = function() {
         zip64_end_of_central_directory_record_offset2: 22,
         zip64_central_directory_record_length: 0,
         files: [],
+        fileStream: null,
         
-        init: function( filename ) {
+        init: async function( filename ) {
+            console.log("zip64 init (top)");
+            
             var $this = this;
             this.filename = filename;
             this.coffset = 0;
 
-            const ponyfill = window.WebStreamsPolyfill || {};
-            streamSaver.WritableStream = ponyfill.WritableStream;
-            streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
-            streamSaver.WritableStream = ponyfill.WritableStream;
+            window.filesender.log('zip64 handler newer streaming API information.'
+                                  + ' Use streamsaver: ' + window.filesender.config.use_streamsaver
+                                  + ' use FileSystemWritableFileStream (FSWF) ' + window.filesender.config.useFileSystemWritableFileStreamForDownload());
+            if( window.filesender.config.useFileSystemWritableFileStreamForDownload()) {
+                
+                if( !$this.fileStream ) {
+                    console.log("FileSystemWritableFileStream zinit (p1)");
+                    $this.fileStream = await window.showSaveFilePicker({
+                        suggestedName: this.filename,
+                        startIn: 'downloads',
+                    });
+                    console.log("FileSystemWritableFileStream zinit (p2)");
+                }
+                if( !$this.writer ) {
+                    $this.writer = await $this.fileStream.createWritable();
+                }
+                console.log("FileSystemWritableFileStream zip64 zinit (end)");
+                
+            } else if( window.filesender.config.use_streamsaver ) {
+                const ponyfill = window.WebStreamsPolyfill || {};
+                streamSaver.WritableStream = ponyfill.WritableStream;
+                streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
+                streamSaver.WritableStream = ponyfill.WritableStream;
 
-            streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
-            var fileStream = streamSaver.createWriteStream( filename );
-            $this.writer = fileStream.getWriter();
+                streamSaver.mitm = window.filesender.config.streamsaver_mitm_url;
+                var fileStream = streamSaver.createWriteStream( filename );
+                $this.writer = fileStream.getWriter();
+            }            
+
 
             $this.files = [];
         },
@@ -281,9 +305,10 @@ window.filesender.zip64handler = function() {
             $this.writeu16( comment.length );
             $this.writestr( comment );
         },
-        complete: function() {
+        complete: async function() {
             var $this = this;
 
+            console.log("ziphandler complete()!");
             $this.zip64_start_of_central_directory_record_offset = $this.coffset;
             for (let i = 0; i < this.files.length; i++) {
                 $this.add_cdr_file(this.files[i])
@@ -292,7 +317,9 @@ window.filesender.zip64handler = function() {
 	    $this.add_cdr_eof_zip64();
 	    $this.add_cdr_eof_locator_zip64();
             $this.write_end_cdr_record();
-            $this.writer.close();
+            console.log("ziphandler complete() closing writer");
+            await $this.writer.close();
+            console.log("ziphandler complete() closed writer");
         },
         abort: function() {
             var $this = this;


### PR DESCRIPTION
This feature is currently only available when you have both `fileSystemWritableFileStream_enabled=true` and `streamsaver_enabled=true` set in your config.php. This will prefer to use the FileSystemWritableFileStream API when available to stream data to disk. As at mid 2023 Edge and Chrome support this feature, Firefox supports most but not all (so can not be used) and Safari does not support the feature. In the future this may be separated from the streamsaver_enabled option so it can be enabled independently.

There are two ways I see when FileSystemWritableFileStream API is being used. Firstly, in Chrome when downloading an encrypted file or transfer you will see a file dialog appear asking where to save the file. Secondly, and far more subtle, in the web console you will see messages about FSWF.

As mentioned above this option can be used with streamsaver_enabled=true and in such cases FSWF is preferred and then streamsaver is used when the browser does not support FSWF.

This is related to https://github.com/filesender/filesender/issues/1496.