### PR TITLE
DND eval if send button should be enabled

### DIFF
--- a/www/js/dragdrop-dirtree.js
+++ b/www/js/dragdrop-dirtree.js
@@ -66,6 +66,9 @@ filesender.dragdrop = {
                 filesender.dragdrop.recurseTree(tree);
             }
         }
+        window.setTimeout(
+            function() { filesender.ui.evalUploadEnabled(); },
+            100 );
 
         // calling this directly doesn't seem to sort on Firefox/Linux 2018
         window.setTimeout(


### PR DESCRIPTION
We need to do this in a timeout otherwise the eval is run before the DOM has settled during adding of files.

This is an update to https://github.com/filesender/filesender/pull/1505 without reverting the speedup when adding 1000s of files.