### PR TITLE
fix for php8

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -576,7 +576,7 @@ if(Auth::isGuest()) {
                         if( $name == 'add_me_to_recipients' ) {
                             $upload_options_handled[$name] = 1;
                             $forcedOption = false;
-                            $displayoption($name, $cfg, Auth::isGuest(),$forcedOption,"message");
+                            $displayoption($name, $cfg, Auth::isGuest(),$forcedOption,array("message"));
                         }
                     }
                     ?>


### PR DESCRIPTION
not sure if "message" as string value is correct, but it needs to be an array, otherwise you get this php 8 error : 

`2023/08/18 16:06:03 [error] 8771#8771: *131 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given in /opt/filesender-3.0.beta2/templates/upload_page.php:501
`