### PR TITLE
Add option for download_show_download_links

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -36,6 +36,7 @@ A note about colours;
 * [download_verification_code_enabled](#download_verification_code_enabled)
 * [download_verification_code_valid_duration](#download_verification_code_valid_duration)
 * [download_verification_code_random_bytes_used](#download_verification_code_random_bytes_used)
+* [download_show_download_links](#download_show_download_links)
 
 
 ## Security settings
@@ -434,6 +435,14 @@ A note about colours;
 * __available:__ since version 2.41
 * __comment:__ Default should be ok.
 
+### download_show_download_links
+
+* __description:__ show direct download urls on download page
+* __mandatory:__ no.
+* __type:__ bool
+* __default:__ false
+* __available:__ since version 2.42
+* __comment:__ Default should be ok.
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -342,6 +342,8 @@ $default = array(
     'download_verification_code_enabled' => false,
     'download_verification_code_valid_duration' => 60*15,
     'download_verification_code_random_bytes_used' => 8,
+
+    'download_show_download_links' => false,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -166,8 +166,8 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
         <h2>{tr:verify_your_email_address_to_download}</h2>
 
         <table columns="2" border="1">
-	    <col style="width:25%">
-	    <col style="width:75%">            
+	    <col class="verify_email_to_download_col1">
+	    <col class="verify_email_to_download_col2">
             <tr>
                 <td>
                     <a href="#" class="verificationcodesendtoemail">

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -52,6 +52,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
     }
 }
 
+$showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links'));
 
 ?>
 <div class="box">
@@ -289,6 +290,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:download}
             </a>
             <span class="downloadprogress"/>
+            <?php if($showdownloadlinks) { ?>
             <br>
             <span class="directlink">
             <?php
@@ -299,6 +301,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
               }
             ?>
             </span>
+            <?php } ?>
         </div>
     <?php } ?>
         <?php if($canDownloadArchive) { ?>
@@ -315,6 +318,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:archive_download}
             </a>
             </div>
+            <?php if($showdownloadlinks) { ?>
             <br>
             <span class="directlinkArchive">
             <?php
@@ -326,6 +330,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
             ?>
             </span>
             <br><br>
+            <?php } ?>
             <?php if($canDownloadAsTar) { ?>
             <div class="archive_tar_download_frame">
             <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
@@ -333,6 +338,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:archive_tar_download}
             </a>
             </div>            
+            <?php if($showdownloadlinks) { ?>
             <br>
             <span class="directlinkArchive">
             <?php
@@ -343,6 +349,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
               }
             ?>
             </span>
+            <?php } ?>
             <?php } ?>
 
             <div class="archive_download_framex hidden">

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -54,7 +54,7 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
 
 
 ?>
-<div class="boxnoframe">
+<div class="box">
     <h1>{tr:download_page}</h1>
     
     <?php
@@ -289,6 +289,16 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:download}
             </a>
             <span class="downloadprogress"/>
+            <br>
+            <span class="directlink">
+            <?php
+              if (isSet($transfer->options['encryption']) && $transfer->options['encryption']) {
+                echo 'Direct Links are not avaliable for encrypted files';
+              } else {
+                echo 'Direct Link: '.Config::get('site_url').'download.php?token='.$token.'&files_ids='.$file->id;
+              }
+            ?>
+            </span>
         </div>
     <?php } ?>
         <?php if($canDownloadArchive) { ?>
@@ -305,6 +315,17 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:archive_download}
             </a>
             </div>
+            <br>
+            <span class="directlinkArchive">
+            <?php
+              if ($isEncrypted) {
+                echo 'Direct Links are not avaliable for encrypted files';
+              } else {
+                echo 'Direct Link: '.Utilities::sanitizeOutput($archiveDownloadLink);
+              }
+            ?>
+            </span>
+            <br><br>
             <?php if($canDownloadAsTar) { ?>
             <div class="archive_tar_download_frame">
             <a rel="nofollow" href="<?php echo Utilities::sanitizeOutput($archiveDownloadLink) ?>" class="archive_tar_download" title="{tr:archive_tar_download}">
@@ -312,6 +333,16 @@ if( Utilities::isTrue(Config::get('download_verification_code_enabled'))) {
                 {tr:archive_tar_download}
             </a>
             </div>            
+            <br>
+            <span class="directlinkArchive">
+            <?php
+              if ($isEncrypted) {
+                echo 'Direct Links are not avaliable for encrypted files';
+              } else {
+                echo 'Direct Link: '.Utilities::sanitizeOutput($archiveDownloadLink);
+              }
+            ?>
+            </span>
             <?php } ?>
 
             <div class="archive_download_framex hidden">

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1263,7 +1263,7 @@ table.guests .guest .to .errors .details {
 }
 
 .download_page .files .file {
-    height: 2.5em;
+    height: 5em;
     margin: 0.25em;
     padding: 1.2em 0.5em 0.5em 0.5em;
 }
@@ -1298,7 +1298,7 @@ table.guests .guest .to .errors .details {
 
 
 .download_page .archive {
-    margin-top: 4em;
+    margin-top: 2em;
     text-align: center;
 }
 

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1341,12 +1341,12 @@ table.guests .guest .to .errors .details {
     float: right;
     padding-right: 10px;
     color: #999999;
-    font-size: 0.7em;
+    font-size: 10px;
 }
 
 .directlinkArchive {
     color: #999999;
-    font-size: 0.7em;
+    font-size: 10px;
 }
 
 /* Admin sections */

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1331,10 +1331,22 @@ table.guests .guest .to .errors .details {
 }
 
 .downloadprogress {
-       float:right;
-       font-size:1.7em;
-       padding-right:20px;
-       min-width: 100px;
+    float:right;
+    font-size:1.7em;
+    padding-right:20px;
+    min-width: 100px;
+}
+
+.directlink {
+    float: right;
+    padding-right: 10px;
+    color: #999999;
+    font-size: 0.7em;
+}
+
+.directlinkArchive {
+    color: #999999;
+    font-size: 0.7em;
 }
 
 /* Admin sections */

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1298,7 +1298,7 @@ table.guests .guest .to .errors .details {
 
 
 .download_page .archive {
-    margin-top: 1em;
+    margin-top: 4em;
     text-align: center;
 }
 

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1808,4 +1808,10 @@ div.not_displayed {
     style: align:center;
     vertical-align: middle;
 }
+.verify_email_to_download_col1 {
+    width: 25%;
+}
+.verify_email_to_download_col2 {
+    width: 75%;
+}
 

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -1263,7 +1263,7 @@ table.guests .guest .to .errors .details {
 }
 
 .download_page .files .file {
-    height: 5em;
+    height: 3em;
     margin: 0.25em;
     padding: 1.2em 0.5em 0.5em 0.5em;
 }


### PR DESCRIPTION
Add new option download_show_download_links where default is false. This allows FileSender to show direct download links on the download page (where possible)

How it looks with default filesender settings:
![image](https://github.com/filesender/filesender/assets/11512591/b74edf0b-a372-4752-b11e-36b0275d11d8)

How it looks with download_show_download_links set to true:
![image](https://github.com/filesender/filesender/assets/11512591/aa0f196c-c72e-4918-bfc9-f523fe2df2d8)
