### PR TITLE
Switch poeditor project id for filesender3

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -1,9 +1,47 @@
+# Language and translations
 
-The FileSender project uses www.poeditor.com to manage the different
+The FileSender project uses [POEditor](https://www.poeditor.com) to manage the different
 languages FileSender supports. The translations on poeditor.com are
 considered the definite master copy. Please see the documentation on
 the Web for information about how to contribute to the translations
 for FileSender. https://docs.filesender.org/v2.0/i18n/
+
+## Terms, translations and reference language
+
+For translating the UI and email, there is a difference between terms, translations 
+and reference language:
+
+### Term
+
+A term is a unique identifier for something that needs to be translated. This 
+term is used in FileSender where we want to replace the term with a translated 
+version
+
+An example is:
+`my_transfers`
+
+### Translation
+
+A translation is the representation of a term in a language. 
+The example translation of the term `my_transfers` in the language Dutch is 
+`Mijn overdrachten`
+
+### Reference language
+
+The reference language is the language that a term is *always* translated in.
+This language is also shown as a hint in POEditor
+
+# Automations
+
+Whenever a change is done to the `development3` branch, automated language 
+checks are performed:
+
+- Did the change introduce new terms? These terms are then automatically 
+added to POEditor and tagged as `new`
+- Did the change remove terms? These terms are then automatically marked in 
+POEditor as 'obsolete', and will be removed after 3 releases.
+
+# Scripts
 
 There is also a method to bring new language terms from files in the
 language directory of a pull request into poeditor. Please see the
@@ -20,8 +58,7 @@ The naming scheme of the language files in this directory and mapping of
 browser tags to language files is based on Best Current Practices as defined
 by BCP 47 and related ICU/ISO guidelines:
 
-File naming
-===========
+# File naming
 
 <language>_<COUNTRY>.php
 
@@ -34,11 +71,14 @@ Unicode/ICU definitions, see
 http://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers and
 http://userguide.icu-project.org/locale).
 
-Browser tags mapping
-====================
+## Reference language naming
+
+The reference language is named `master` in the language tree. Since we are currently 
+using en_GB as reference language, this is effectively a copy.
+
+# Browser tags mapping
 
 Mapping from browser language tags to language files is done in locale.php.
 Note that browser tags for language preference use the "-" hyphen as defined
 in BCP 47: http://tools.ietf.org/html/bcp47 Tags for Identifying Languages
 Tags specified in locale.php should be all lowercase.
-

--- a/scripts/language/README.md
+++ b/scripts/language/README.md
@@ -1,11 +1,7 @@
-
-
-
-Sending strings from php files to poeditor
-------------------------------------------
+# Sending strings from PHP files to POEditor
 
 If you have a PR for example that contains language translations for
-new strings you might like to import these into poeditor through
+new strings you might like to import these into POEditor through
 scripts.
 
 You will need to store the poeditor API TOKEN in a file in your home
@@ -14,7 +10,7 @@ directory to import strings. For example, using something like:
 ```
 $ vi ~/.filesender/poeditor-apikey
 export API_TOKEN="fixme"
-export PROJECT_ID="48000"
+export PROJECT_ID="633591"
 ```
 
 The project id should be fine to set as shown above as this will inform
@@ -54,16 +50,16 @@ php convert-php-to-poeditor-json.php en_AU /tmp/test.json '/^about.*/'
 Feel free to trim or filter the exported JSON file to only contain the
 translations you are interested in uploading. To then upload those
 translations to poeditor use the following. en-au is the poeditor
-language code. The 48000 number tells the script to upload to the main
+language code. The 633591 number tells the script to upload to the main
 translation project on poeditor. If you are unsure of the outcome you
 might like to first use the number 380345 which will upload to the
 "Testing" poeditor translation project so you can see what happens
 without impacting existing real translations.
 
 ```
-# commentline    main project = 48000    test project = 380345
+# commentline    main project = 633591    test project = 380345
 
-./send-json-translations-for-language-to-poeditor.sh 48000 en-au /tmp/test.json
+./send-json-translations-for-language-to-poeditor.sh 633591 en-au /tmp/test.json
 ```
 
 
@@ -80,10 +76,10 @@ output can be sent using send-json-translations-for-language-to-poeditor.sh as d
 ```
 php convert-php-to-poeditor-json.php \
        en_AU /tmp/test.json '/.*/' 0 \
-       /tmp/filesender-poeditor-imports-wmsnC/FileSender_2.0_English_AU.php
+       /tmp/filesender-poeditor-imports-wmsnC/FileSender_3.0_English_AU.php
 ```
 
-To generate the FileSender_2.0_English_AU.php file from the current data on poeditor
+To generate the FileSender_3.0_English_AU.php file from the current data on poeditor
 one can use the below. See import-all-from-poeditor.sh for a list of poeditor language codes
 that are currently imported in bulk.
 

--- a/scripts/language/send-json-translations-for-language-to-poeditor.sh
+++ b/scripts/language/send-json-translations-for-language-to-poeditor.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 . ~/.filesender/poeditor-apikey
 
 
-projectid=${1:?supply poeditor project id as arg1. Main project is 48000 test project is 380345 };
+projectid=${1:?supply poeditor project id as arg1. Main project is 633591 test project is 380345 };
 langcode=${2:?supply poeditor language code as arg2};
 jsonfile=${3:?supply path to json file created with convert-php-to-poeditor-json.php as arg3};
 

--- a/scripts/language/send-newterms-json-to-poeditor.sh
+++ b/scripts/language/send-newterms-json-to-poeditor.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 . ~/.filesender/poeditor-apikey
 
 
-projectid=${1:?supply poeditor project id as arg1. Main project is 48000 test project is 380345 };
+projectid=${1:?supply poeditor project id as arg1. Main project is 633591 test project is 380345 };
 jsonfile=${2:?supply path to json file created with export-terms-to-new-and-deleted-lists.sh as arg2};
 
 curl -X POST https://api.poeditor.com/v2/terms/add \


### PR DESCRIPTION
This switches references from the old projectid to the new one for filesender3.
The project is currently invite-only, since I'm finishing things like CI for languages.

With CI for languages enabled, we can automate two tasks that are now done semi-automated:

1. Scan for changes in any language file, and handle changes to the terms. I'm currently developing this in https://github.com/AvesIT/filesender/pull/new/2023/10/lang_ci_testing
2. Upon creation of a release-branch, download all languages from poeditor and update the source code as needed. This is yet to be implemented, stay tuned!
