### PR TITLE
multiple load balancer fix ip, use the first ip not the last

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -354,7 +354,7 @@ class Utilities
             return '127.0.0.1';
         }
         
-        return array_pop($ips);
+        return $ips[0];
     }
     
     /**


### PR DESCRIPTION
in the event i use two load balancers the X-Forward-For shows as:
```
[HTTP_X_FORWARDED_FOR] => <<User IP>>, <<FIRST LB>>
```
This fix sets it to the first load balancer so we get the users IP and not the first load balancer