### PR TITLE
dev3 ui3 fix for password and message when getting a link

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -962,9 +962,6 @@ filesender.ui.isUserAddMeToRecipients = function() {
 
 filesender.ui.doesUploadMessageContainPassword = function() {
 
-    if( filesender.ui.isUserGettingALink() )
-        return false;
-
     if(filesender.ui.nodes.encryption.toggle.is(':checked')) {
         var p = filesender.ui.nodes.encryption.password.val();
         var m = filesender.ui.nodes.message.val();


### PR DESCRIPTION
The the dev2 code did not allow a message when you were getting a link so it didn't need to worry about checking that as the message element was hidden too. So we check all the time now and resolve https://github.com/filesender/filesender/issues/1592 while we are at it :)