### PR TITLE
dev3 ui3 might as well link right to github there

### DIFF
--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -397,7 +397,7 @@
 
                                 <ul class="fs-list fs-list--inline">
                                     <li>
-                                        <a href="">
+                                        <a href="https://raw.githubusercontent.com/filesender/filesender/master3/scripts/client/filesender.py">
                                             {tr:download_python_cli}
                                         </a>
                                     </li>


### PR DESCRIPTION
Not ideal as the download attribute doesn't work cross domain etc, but at least it gives the data to the user.

relates to https://github.com/filesender/filesender/issues/1602