### PR TITLE
generate the filesender.py configuration file on demand

### DIFF
--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -326,7 +326,7 @@ class RestServer
                 }
                 exit;
             }
-            
+
             header('Content-Type: application/json');
             if (($method == 'post') && $data) {
                 RestUtilities::sendResponseCode(201);

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -227,7 +227,7 @@ username = $username
 apikey = $authsecret
 END;
             
-            header('Content-Type: text/javascript');
+            header('Content-Type: text/plain');
             echo $doc;
             exit;
         }

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -210,6 +210,27 @@ class RestEndpointUser extends RestEndpoint
                 'data' => ''
             );
         }
+
+        if( $property == 'filesender-python-client-configuration-file' ) {
+
+            $username = $user->saml_user_identification_uid;
+            $authsecret = $user->auth_secret;
+            $site_url = Config::get('site_url');
+            
+            $doc = <<<END
+[system]            
+base_url = $site_url/rest.php
+default_transfer_days_valid = 10
+
+[user]
+username = $username
+apikey = $authsecret
+END;
+            
+            header('Content-Type: text/javascript');
+            echo $doc;
+            exit;
+        }
         
         if ($property == 'quota') {
             // Get user quota info (if enabled)

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -402,7 +402,7 @@
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="">
+                                        <a href="https://sam/filesender/rest.php/user/@me/filesender-python-client-configuration-file" download="filesender.py.ini" >
                                             {tr:download_python_cli_configuration}
                                         </a>
                                     </li>


### PR DESCRIPTION
This allows downloading that config on the user page for quick setup of the filesender.py client.

This relates to https://github.com/filesender/filesender/issues/1602