### PR TITLE
Handle when get a link is not available.

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -336,7 +336,7 @@ if(Auth::isGuest()) {
                                         <?php if($show_get_a_link_or_email_choice) { ?>
 
                                             <div class="fs-radio-group">
-                                                <input type="radio" id="get_a_link" name="transfer-type" value="transfer-link">
+                                                <input type="radio" id="get_a_link" name="transfer-type" value="transfer-link" class="get_a_link_top_selector">
 
                                                 <label for="get_a_link" class="fs-radio">
                                                     <div class="fs-radio__option">

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1883,6 +1883,11 @@ $(function() {
 
         filesender.ui.setFileList(2, 3);
 
+        // If there is only one choice then we should already make it
+        if($('.get_a_link_top_selector').length==0) {
+            $('#transfer-email').prop("checked", true);
+        }
+        
         var get_a_link_checked = filesender.ui.isUserGettingALink();
         filesender.ui.handle_get_a_link_change();
         if( get_a_link_checked ) {


### PR DESCRIPTION
In that case we might as well select the email option as it is the only choice. This is an update to
https://github.com/filesender/filesender/issues/1621 because in the past you could proceed without selecting anything and would "get a link" by default. Now I am automatically selecting the only option if get a link is not available.

Note that the class get_a_link_top_selector is there for now because get a link is reshown in the options and thus the HTML ID get_a_link might not be unique. When get a link is not shown in the main options then this could be updated to directly use the ID instead.

This relates to https://github.com/filesender/filesender/issues/1621