### PR TITLE
get a link is a top element only and not in options anymore

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -89,6 +89,9 @@ $displayoption = function( $name, $cfg, $disable = false, $forcedOption = false,
     if( in_array($name, $optionsToFilter)) {
         return;
     }
+    if( $name == "get_a_link" ) {
+        return;
+    }
 
     $default = $cfg['default'];
     if( !$forcedOption ) {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -952,7 +952,10 @@ filesender.ui.recipients = {
 };
 
 filesender.ui.isUserGettingALink = function() {
-    var gal = ('get_a_link' in filesender.ui.nodes.options) ? filesender.ui.nodes.options.get_a_link.is(':checked') : false;
+    var gal = false;
+    if($('.get_a_link_top_selector').length) {
+        gal = $('.get_a_link_top_selector').is(':checked');
+    }    
     return gal;
 }
 filesender.ui.isUserAddMeToRecipients = function() {
@@ -990,7 +993,6 @@ filesender.ui.evalUploadEnabled = function() {
         ok = false;
         uploadFileStageOk = false;
     }
-
 
     if(
         filesender.ui.nodes.need_recipients &&
@@ -1212,6 +1214,7 @@ filesender.ui.startUpload = function() {
             this.transfer.options[o] = v;
         }
     }
+    this.transfer.options['get_a_link'] = filesender.ui.isUserGettingALink();
 
     var crypto = window.filesender.crypto_app();
     this.transfer.encryption_key_version = filesender.config.encryption_key_version_new_files;


### PR DESCRIPTION
IIRC there was some magic in the old dev3 to not reshow get a link in the options though that might have bit rotted over the years.

I have removed it from the options that are shown and made the rest of the code check if getting a link is an option and if so if it is selected at the top of the page. Basically making that specific toggle more of a global than just another option and only presented in one place in the UI.

This may break other things but it is probably best to do that now and as other ripples are found I can address them.

This addresses https://github.com/filesender/filesender/issues/1589 and may cause side effects that require minor code updates to address.