### PR TITLE
Dev3 UI3 Allow generated passwords to not have PBKDF2 performed on them

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -657,6 +657,11 @@ filesender.ui.files = {
 
     },
 
+    usingGeneratedPassword: function() {
+        var crypto = window.filesender.crypto_app();
+        return filesender.ui.transfer.encryption_password_version == crypto.crypto_password_version_constants.v2019_generated_password_that_is_full_256bit;
+    },
+    
     checkEncryptionPassword: function(input,slideMessage) {
         input = $(input);
         var crypto = window.filesender.crypto_app();
@@ -690,8 +695,7 @@ filesender.ui.files = {
             }
         }
 
-        var v = filesender.ui.nodes.encryption.use_generated.is(':checked');
-        if( v ) {
+        if( filesender.ui.files.usingGeneratedPassword()) {
             $('.passwordvalidation').each(function( index ) {
                 $(this).hide();
             });
@@ -2049,6 +2053,10 @@ $(function() {
     filesender.ui.nodes.encryption.password.on(
         'keyup',
         delayAndCallOnlyOnce(function(e) {
+            // as soon as they edit anything it can no longer be considered "generated".
+            filesender.ui.transfer.encryption_password_version = crypto.crypto_password_version_constants.v2018_text_password;
+            filesender.ui.transfer.encryption_password_encoding = 'none';
+            
             filesender.ui.files.checkEncryptionPassword($(this),true);
             filesender.ui.evalUploadEnabled();
         }, checkEncryptionPassword_delay )
@@ -2322,11 +2330,8 @@ $(function() {
         password = encoded.value;
         filesender.ui.nodes.encryption.password.val(password);
 
-        // filesender.ui.transfer.encryption_password_encoding = encoded.encoding;
-        // filesender.ui.transfer.encryption_password_version  = encoded.version;
-
-        filesender.ui.transfer.encryption_password_version = crypto.crypto_password_version_constants.v2018_text_password;
-        filesender.ui.transfer.encryption_password_encoding = 'none';
+        filesender.ui.transfer.encryption_password_encoding = encoded.encoding;
+        filesender.ui.transfer.encryption_password_version  = encoded.version;
 
         filesender.ui.nodes.encryption.show_hide.prop('checked',true);
         filesender.ui.nodes.encryption.show_hide.trigger('change');


### PR DESCRIPTION
It is redundant to perform PBKDF2 on a randomly generated password of sufficient length. Given that this was a feature introduced in 2019 on the advice of a professional cryptographer I think it should be retained until explicitly removed.

Allowing for generated passwords to avoid PBKDF2 allows for secure site setups. For example, large numbers of PBKDF2 rounds can be set which will require significant time to perform and obtain the commensurate security under attack. As generated passwords do not require PBKDF2 the user has the choice of a custom password and a significant delay or a more random generated password and immediate upload. For example one might set PBKDF2 rounds such that they require minutes to perform.

I would also love to retain this for future PGP integration as that will allow even more secure setups with the generated password automatically encrypted and sent to the recipient with their explicitly nominated PGP key.

This relates to https://github.com/filesender/filesender/issues/1614