### PR TITLE
RateLimitHistorys table cleanup

### DIFF
--- a/classes/data/RateLimitHistory.class.php
+++ b/classes/data/RateLimitHistory.class.php
@@ -298,7 +298,21 @@ class RateLimitHistory extends DBObject
         throw new PropertyAccessException($this, $property);
     }
     
-  
+
+    public static function cleanup()
+    {
+        $dbtype = Config::get('db_type'); 
+
+        // Keep these logs for 31 days
+        $lifetime = Config::get('ratelimithistory_lifetime');
+        if (!is_null($lifetime) && $lifetime > 0) {
+            // delete auditlogs entries that are too old
+            $statement = DBI::prepare("delete from ".self::getDBTable()." where created < :cutoff ");
+            $statement->execute(array(':cutoff' => date('Y-m-d H:i:s', time() - ($lifetime*24*3600))));
+        }
+    }
+
+    
 }
 
     

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -271,6 +271,7 @@ A note about colours;
 * [statlog_log_user_additional_attributes](#statlog_log_user_additional_attributes)
 * [auth_sp_fake_additional_attributes_values](#auth_sp_fake_additional_attributes_values)
 * [auditlog_lifetime](#auditlog_lifetime)
+* [ratelimithistory_lifetime](#ratelimithistory_lifetime)
 * [report_format](#report_format)
 * [exception_additional_logging_regex](#exception_additional_logging_regex)
 * [clientlogs_stashsize](#clientlogs_stashsize)
@@ -2934,6 +2935,16 @@ $config['log_facilities'] =
 * __type:__ boolean/int (days).  Set to false to disable.
 * __default:__ 31
 * __available:__ since version 2.0
+* __1.x name:__
+* __comment:__ Use this setting to control the privacy footprint of your FileSender service.
+
+### ratelimithistory_lifetime
+
+* __description:__ The ratelimithistory entries are kept in the database for this long. Should be at least a day, default is a month.
+* __mandatory:__ no
+* __type:__ boolean/int (days).  Set to false to disable.
+* __default:__ 31
+* __available:__ since version 2.42
 * __1.x name:__
 * __comment:__ Use this setting to control the privacy footprint of your FileSender service.
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -182,6 +182,7 @@ $default = array(
     'statlog_lifetime' => 0,
     'statlog_log_user_organization' => false,
     'auditlog_lifetime' => 31,
+    'ratelimithistory_lifetime' => 31,
     
     'storage_usage_warning' => 20,
     

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -236,6 +236,10 @@ StatLog::clean();
 if( $verbose ) echo "cron.php Clean old auditlog events...\n";
 AuditLog::cleanup();
 
+// Clean old ratelimithistory events
+if( $verbose ) echo "cron.php Clean old ratelimithistory events...\n";
+RateLimitHistory::cleanup();
+
 // Clean up S3 buckets if storage backend is set to CloudS3 and configuration
 // option cloud_s3_use_daily_bucket has been set to true
 if (Utilities::startsWith(strtolower(Config::get('storage_type')), 'clouds3') && Config::get('cloud_s3_use_daily_bucket')) {


### PR DESCRIPTION
delete entries older than 31 days by default in the cron job.
This relates to https://github.com/filesender/filesender/issues/1677