### PR TITLE
d3ui3 Use an array to allow the wording to change more readily

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -749,6 +749,7 @@ $lang['active_transfers'] = 'Active transfers';
 $lang['expired_transfers'] = 'Expired transfers';
 $lang['transferred_these_files'] = 'transferred these files';
 $lang['transfer_expires_in'] = 'This transfer expires in';
+$lang['transfer_expires_in_x_days'] = 'This transfer expires in {days_to_expire} days';
 $lang['transfer_sent_on'] = 'Transfer sent on';
 $lang['expiration_date'] = 'Expiration date';
 $lang['transfer_size'] = 'Transfer size';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -139,7 +139,7 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
             <div class="col">
                 <div class="fs-download__title">
                     <h1><?php echo Template::sanitizeOutputEmail($transfer->user_email) ?> {tr:transferred_these_files}</h1>
-                    <p>{tr:transfer_expires_in} <?php echo $days_to_expire ?> {tr:days}</p>
+                    <p><?php  echo Lang::tr('transfer_expires_in_x_days')->r(array('days_to_expire' => $days_to_expire, 'days' => $days_to_expire)) ?></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This allows the number of days to be shown in a different location in the string for langauges that can benefit from that for a more natural translation.

I have updated poeditr for en and en_au as well

This relates to https://github.com/filesender/filesender/issues/1647