### PR TITLE
Fix invalid filename error not being displayed at upload 

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -301,7 +301,7 @@ filesender.ui.files = {
                     filesender.ui.evalUploadEnabled();
                 }).appendTo(node);
                 
-                var added_cid = filesender.ui.transfer.addFile(filepath, fileblob, true, function(error) {
+                var added_cid = filesender.ui.transfer.addFile(filepath, fileblob, function(error) {
                     var tt = 1;
                     if(error.details && error.details.filename) filesender.ui.files.invalidFiles.push(error.details.filename);
                     node.addClass('invalid');


### PR DESCRIPTION
Fix invalid filename error not being displayed at upload (upload_page.js), errorhandler function not called.

Invalid filename errors are not displayed to users. They think that there is no issue with this file. 
Not an issue when uploading one file but when uploading multiple files, the one with invalid filename is ignored/not uploaded and users are not aware of.

![filesender_upload_page js](https://github.com/filesender/filesender/assets/56732988/effa9f8a-2418-4adf-9f3f-0f1c3aa10806)

This issue has been introduced  as of version 2.41