### PR TITLE
UI3 guest handling update: email shown, no get a link

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -45,6 +45,10 @@ use ( $new_guests_can_only_send_to_creator,
     if($name == 'get_a_link' && $new_guests_can_only_send_to_creator ) {
         return;
     }
+    // don't allow guests to get a link to their upload
+    if($name == 'get_a_link' ) {
+        return;
+    }
 
     $default = $cfg['default'];
     if(Auth::isSP()) {

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -72,9 +72,11 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 
 if(Auth::isGuest()) {
     $show_get_a_link_or_email_choice = false;
+    $allow_recipients = true;
 
     if($guest->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME)) {
         $guest_can_only_send_to_creator = true;
+        $allow_recipients = false;
     }
 }
 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1670,7 +1670,6 @@ filesender.ui.onChangeTransferType = function (transferType) {
         TRANSFER_LINK: 'transfer-link',
         TRANSFER_EMAIL: 'transfer-email'
     }
-
     if (transferType) {
         $('.fs-transfer__transfer-fields').addClass('fs-transfer__transfer-fields--show');
         $('.fs-transfer__transfer-settings').addClass('fs-transfer__transfer-settings--show');
@@ -1895,6 +1894,7 @@ $(function() {
         // If there is only one choice then we should already make it
         if($('.get_a_link_top_selector').length==0) {
             $('#transfer-email').prop("checked", true);
+            filesender.ui.onChangeTransferType("transfer-email");
         }
         
         var get_a_link_checked = filesender.ui.isUserGettingALink();


### PR DESCRIPTION
The full email fields are shown for a guest upload. They are removed for guests who can only send to the inviting party. That needs retesting.

For now I have disabled the ability for a guest to perform an upload and "get a link" to the file. It is a code path that needs revalidation to allow a guest to upload a file and get a link to it instead of sending emails etc.