### PR TITLE
new invitations page show can only send to me

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -156,7 +156,7 @@ use ( $new_guests_can_only_send_to_creator,
  
                                     <div class="guest_options options_box">
                                     <?php
-                                    foreach(Guest::availableOptions(true) as $name => $cfg) {
+                                    foreach(Guest::availableOptions() as $name => $cfg) {
                                         if( $name == 'can_only_send_to_me' || $name == 'valid_only_one_time') {
                                             $displayoption($name, $cfg, false);
                                         }


### PR DESCRIPTION
This was dependant on the config / advanced setting before. Now it shows regardless of that setting on guest_options/can_only_send_to_me

This relates to https://github.com/filesender/filesender/issues/1604