### PR TITLE
Download flow consolidation for v2.x

### DIFF
--- a/classes/data/AuditLog.class.php
+++ b/classes/data/AuditLog.class.php
@@ -76,6 +76,11 @@ class AuditLog extends DBObject
             'type' => 'string',
             'size' => 39,
         ),
+        'transaction_id' => array(
+            'type' => 'string',
+            'size' => 36,
+            'null' => true
+        ),
         'created' => array(
             'type' => 'datetime'
         )
@@ -89,6 +94,9 @@ class AuditLog extends DBObject
         'Author_ID' => array(
             'author_type' => array(),
             'author_id'   => array()
+        ),
+        'Transaction_ID' => array(
+            'transaction_id' => array()
         ),
         'Created' => array(
             'created' => array()
@@ -151,6 +159,7 @@ class AuditLog extends DBObject
     protected $author_id = null;
     protected $created = null;
     protected $ip = null;
+    protected $transaction_id = null;
     
     
     /**
@@ -207,6 +216,13 @@ class AuditLog extends DBObject
         $auditLog->target_id = $target->id;
         $auditLog->target_type = get_class($target);
         
+        if(array_key_exists('transaction_id', $_REQUEST)) {
+            $transaction_id = $_REQUEST['transaction_id'];
+            if(Utilities::isValidUID($transaction_id)) {
+                $auditLog->transaction_id = $transaction_id;
+            }
+        }
+
         if (!$author) {
             $author = Auth::user();
         }

--- a/www/download.php
+++ b/www/download.php
@@ -132,6 +132,17 @@ try {
     // Close session to avoid simultaneous requests from being locked
     session_write_close();
     
+    // Ensure transaction id
+    $transaction_id = '';
+    if(array_key_exists('transaction_id', $_GET))
+        $transaction_id = $_GET['transaction_id'];
+
+    if(!$transaction_id || !Utilities::isValidUID($transaction_id)) {
+        $transaction_id = Utilities::generateUID();
+        header('Location: '.Utilities::http_build_query(array_merge($_GET, ['transaction_id' => $transaction_id]), 'download.php?'));
+        exit;
+    }
+
     $recently_downloaded = false;
     // Check if file set has already been downloaded over the last hour
     if( Config::get('logs_limit_messages_from_same_ip_address')) {


### PR DESCRIPTION
Upon first access to a download link a transaction identifier is generated (using filesender's uuid generator) and user is redirected to the current download along with the identifier.

AuditLogs get an additional transaction identifier property that automatically logs any (valid) transaction identifier contained in the request.

This makes it so subsequent download events (resumes, ends) are flagged as part of the same transaction in the auditlogs, and thus makes it possible to identify bogus clients and compute more reliable statistics.

This replaces #1681 (base branch fix)