### PR TITLE
d3ui3: Move if the total count and size is shown into the translation layer

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -829,3 +829,8 @@ $lang['see_invitation_details'] = 'See invitation details';
 $lang['go_to_invitations'] = 'Go to all my invitations';
 $lang['optional_message'] = 'Optional message';
 $lang['enter_transfer_name'] = 'Enter the transfer name (optional)';
+$lang['files_transferred_display'] = '{filecount}';
+$lang['size_transferred_display'] = '{size_human_readable}';
+
+
+

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1710,8 +1710,16 @@ filesender.ui.updateSizeInfo = function () {
     var filecount = filesender.ui.transfer.getFileCount();
     var sizetxt   = filesender.ui.formatBytes(size);
 
-    filesender.ui.nodes.stats.number_of_files.find('.value').text(filecount + '/' + filesender.config.max_transfer_files);
-    filesender.ui.nodes.stats.size.find('.value').text(sizetxt + '/' + filesender.ui.formatBytes(filesender.config.max_transfer_size));
+    var params = { filecount: filecount,
+                   max_transfer_files: filesender.config.max_transfer_files,
+                   max_transfer_size: filesender.config.max_transfer_size,
+                   sizetxt: sizetxt,
+                   size_human_readable: sizetxt,
+                   size: size
+                 };
+
+    filesender.ui.nodes.stats.number_of_files.find('.value').text(lang.tr('files_transferred_display').r( params ));
+    filesender.ui.nodes.stats.size.find('.value').text(lang.tr('size_transferred_display').r( params ));    
     filesender.ui.nodes.stats.filecount.text(filecount);
     filesender.ui.nodes.stats.sendingsize.text(sizetxt);
 


### PR DESCRIPTION
This moves the policy of if the total number of files is shown into the translation layer.

This relates to https://github.com/filesender/filesender/issues/1585