### PR TITLE
d3ui3: Two config options in user settings

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -128,6 +128,17 @@ class User extends DBObject
             'type' => 'datetime',
             'null' => true
         ),
+        
+        'save_frequent_email_address' => array(
+            'type' => 'bool',
+            'null'    => false,
+            'default' => true,
+        ),
+        'save_transfer_preferences' => array(
+            'type' => 'bool',
+            'null'    => false,
+            'default' => true,
+        ),
     );
 
 
@@ -175,6 +186,8 @@ class User extends DBObject
     protected $guest_expiry_default_days = null;
     protected $service_aup_accepted_version = 0;
     protected $service_aup_accepted_time = null;
+    protected $save_frequent_email_address = true;
+    protected $save_transfer_preferences = true;
 
     
     /** 
@@ -420,6 +433,9 @@ class User extends DBObject
         if( Config::get('data_protection_user_frequent_email_address_disabled')) {
             return array();
         }
+        if( !$this->save_frequent_email_address ) {
+            return array();
+        }
 
         // Get max number of returned recipients from config
         $size = Config::get('autocomplete');
@@ -495,6 +511,10 @@ class User extends DBObject
         if( Config::get('data_protection_user_frequent_email_address_disabled')) {
             $recipients = array();
         }
+        if( !$this->save_frequent_email_address ) {
+            $recipients = array();
+        }
+
         
         // Save if something changed
         if ($recipients !== $this->frequent_recipients) {
@@ -657,6 +677,8 @@ class User extends DBObject
             'transfer_preferences', 'guest_preferences', 'frequent_recipients', 'created', 'last_activity',
             'email_addresses', 'name', 'quota', 'authid'
           , 'guest_expiry_default_days', 'service_aup_accepted_version', 'service_aup_accepted_time'
+          , 'save_frequent_email_address', 'save_transfer_preferences'
+            
         ))) {
             return $this->$property;
         }
@@ -719,7 +741,7 @@ class User extends DBObject
         } elseif ($property == 'guest_preferences') {
             $this->guest_preferences = $value;
         } elseif ($property == 'frequent_recipients') {
-            if( Config::get('data_protection_user_frequent_email_address_disabled')) {
+            if( Config::get('data_protection_user_frequent_email_address_disabled') || !$this->save_frequent_email_address ) {
                 // keep nothing.
                 $this->frequent_recipients = array();
             } else {
@@ -752,10 +774,16 @@ class User extends DBObject
             $this->service_aup_accepted_version = $value;
         } elseif ($property == 'service_aup_accepted_time') {
             $this->service_aup_accepted_time = $value;
+        } elseif ($property == 'save_frequent_email_address') {
+            $this->save_frequent_email_address = $value;
+        } elseif ($property == 'save_transfer_preferences') {
+            $this->save_transfer_preferences = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }
     }
+
+    
 
     /**
      * Delete the user related objects that the database delete will not remove.
@@ -788,7 +816,14 @@ class User extends DBObject
         if( Config::get('data_protection_user_frequent_email_address_disabled')) {
             $this->frequent_recipients = array();
         }
+        if( !$this->save_frequent_email_address ) {
+            $this->frequent_recipients = array();
+        }
+        Logger::dump("AAA beforesave ", $this->transfer_preferences );
         if( Config::get('data_protection_user_transfer_preferences_disabled')) {
+            $this->transfer_preferences = null;
+        }
+        if( !$this->save_transfer_preferences ) {
             $this->transfer_preferences = null;
         }
     }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -729,7 +729,7 @@ class RestEndpointTransfer extends RestEndpoint
             // Mandatory to add recipients and files
             $transfer->save(); 
 
-            
+
             // Get banned extensions
             $banned_exts = Config::get('ban_extension');
             if (is_string($banned_exts)) {

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -35,6 +35,8 @@ if (!defined('FILESENDER_BASE')) {
     die('Missing environment');
 }
 
+
+
 /**
  * REST transfer endpoint
  */
@@ -319,7 +321,14 @@ END;
         
         // Update data
         $data = $this->request->input;
-        
+
+        if( $data->save_transfer_preferences || $data->save_frequent_email_address ) {
+
+            $user->save_frequent_email_address = Utilities::validateCheckboxValue( $data->save_frequent_email_address );
+            $user->save_transfer_preferences   = Utilities::validateCheckboxValue( $data->save_transfer_preferences );
+
+            $user->save();
+        }
         if ($data->lang) {
             // Lang property update, fail if not allowed
             

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -789,4 +789,11 @@ class Utilities
         }
         return json_decode( $t, null, 4, JSON_THROW_ON_ERROR );
     }
+    
+    public static function validateCheckboxValue( $v )
+    {
+        if( $v == 'true' || $v )
+            return true;
+        return false;
+    }
 }

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -1,3 +1,12 @@
+<?php
+
+function isChecked( $v ) {
+    return $v ? 'checked="checked"' : '';
+}
+
+$user = Auth::user();
+
+?>
 <div class="fs-settings">
     <div class="container">
         <div class="row">
@@ -75,14 +84,14 @@
                     ?>
 
                     <div class="fs-switch fs-switch--small">
-                        <input id="previous-settings" type="checkbox" />
+                        <input id="previous-settings" type="checkbox" name="save_transfer_preferences"  <?php echo isChecked($user->save_transfer_preferences); ?> />
                         <label for="previous-settings">
                             {tr:previous_settings}
                         </label>
                     </div>
 
                     <div class="fs-switch fs-switch--small">
-                        <input id="save-recipients-emails" type="checkbox" />
+                        <input id="save-recipients-emails" name="save_frequent_email_address" type="checkbox"  <?php echo isChecked($user->save_frequent_email_address); ?> />
                         <label for="save-recipients-emails">
                             {tr:save_recipients_emails}
                         </label>

--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -174,27 +174,31 @@ $(function() {
 
         const inputs = $(':input');
 
+        const p = {};
         for (let i = 0; i < inputs.length; i++) {
             const element = $(inputs[i]);
 
             let name = element.attr('name');
-
             if (name) {
-                if (name.substr(0, 5) == 'user_') {
-                    name = name.substr(5);
+                if (name.substr(0, 5) == 'user_' || name.substr(0, 5) == 'save_') {
+                    if (name.substr(0, 5) == 'user_') {
+                        name = name.substr(5);
+                        p[name] = element.val();
+                    }
+                    if (name.substr(0, 5) == 'save_') {
+                        p[name] = element.is(':checked');
+                    }
 
-                    const p = {};
-                    p[name] = element.val();
-
-                    filesender.client.updateUserPreferences(p, function() {
-                        console.log('success');
-                    }).catch((e) => {
-                        hasError = true;
-                    });
                 }
             }
         }
+        filesender.client.updateUserPreferences(p, function() {
+            console.log('success');
+        }).catch((e) => {
+            hasError = true;
+        });
 
+        
         if (!hasError) {
             filesender.ui.notify('success', lang.tr('preferences_updated'));
             location.reload();


### PR DESCRIPTION
This saves the options
  "Use transfer settings from previous upload as default settings for
  next transfer."
and
 "Save email recipients from past use (used to automatically complete
  email fields)."

There is an update to wipe email recipients if that option is off.

The transfer settings are saved if that option is on but they are not currently respected by the upload page. That is a future PR.

This relates to https://github.com/filesender/filesender/issues/1597 and https://github.com/filesender/filesender/issues/1596