### PR TITLE
d3ui3 Use saved transfer settings if user wants

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -628,6 +628,10 @@ class User extends DBObject
         }
         
         $score = $props->$option;
+
+        if( $this->save_transfer_preferences ) {
+            return $score;
+        }
         
         if (abs($score) < 3) {
             return $default;

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -547,6 +547,7 @@ class RestEndpointTransfer extends RestEndpoint
             }
 
             Logger::info($options);
+            $optionsToMaybeSave = $options;
             // Get_a_link transfers have no recipients so mail related options make no sense, remove them if set
             if ($options[TransferOptions::GET_A_LINK]) {
                 unset($options[TransferOptions::EMAIL_ME_COPIES]);
@@ -730,6 +731,14 @@ class RestEndpointTransfer extends RestEndpoint
             $transfer->save(); 
 
 
+            if (!Auth::isGuest()) {
+                $user = Auth::user();
+                if( $user->save_transfer_preferences ) {
+                    $user->transfer_preferences = $optionsToMaybeSave;
+                    $user->save();
+                }
+            }
+            
             // Get banned extensions
             $banned_exts = Config::get('ban_extension');
             if (is_string($banned_exts)) {

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -151,6 +151,18 @@ if(Auth::isGuest()) {
         $expire_time_is_editable = false;
     }
 }
+
+$userHasGALPreference = false;
+if( !Auth::isGuest()) {
+    $user = Auth::User();
+    if( $user->save_transfer_preferences ) {
+        $ops = (array)$user->transfer_preferences;
+        if( array_key_exists( 'get_a_link', $ops )) {
+            $userHasGALPreference = $ops["get_a_link"];
+        }
+    }
+}
+
 ?>
 
 <div class="container">
@@ -160,7 +172,9 @@ if(Auth::isGuest()) {
           accept-charset="utf-8"
           method="post"
           autocomplete="off"
-          data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>">
+          data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>"
+          data-user-has-gal-preference="<?php echo $userHasGALPreference ? '1' : '0' ?>"
+    >
 
         <div class="fs-transfer">
             <h1>
@@ -499,7 +513,7 @@ if(Auth::isGuest()) {
                                 </div>
 
                                 <div class="row">
-                                    <div class="col-12">
+                                    <div class="col-12 lifted_options">
                                         <div data-related-to="message">
                                             <?php
                                             foreach(Transfer::availableOptions(false) as $name => $cfg) {

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1853,6 +1853,10 @@ $(function() {
         var i = $(this);
         filesender.ui.nodes.options[i.attr('name')] = i;
     });
+    form.find('.lifted_options [data-option] input').each(function() {
+        var i = $(this);
+        filesender.ui.nodes.options[i.attr('name')] = i;
+    });
 
     form.find('.uploadoption').each(function() {
         var i = $(this);
@@ -1899,6 +1903,11 @@ $(function() {
 
         filesender.ui.setFileList(2, 3);
 
+        if( form.attr('data-user-has-gal-preference') == '1' ) {
+            $('#transfer-link').prop("checked", true);
+            filesender.ui.onChangeTransferType("transfer-link");
+        }
+        
         // If there is only one choice then we should already make it
         if($('.get_a_link_top_selector').length==0) {
             $('#transfer-email').prop("checked", true);


### PR DESCRIPTION
This uses transfer_preferences if save_transfer_preferences=true in the database when creating a new upload.

The older code would record how frequently things were selected and try to work out what to do from there. The new code just uses what was being used in the last transfer for the next one.

This relates to https://github.com/filesender/filesender/issues/1596