### PR TITLE
d3uid3 bring back show/hide password option

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -562,6 +562,11 @@ if( !Auth::isGuest()) {
                                                         </div>
                                                     </div>
                                                 </div>
+                                                <div class="fieldcontainer" id="encryption_password_show_container">  
+                                                    <input id="encryption_show_password" name="encryption_show_password" type="checkbox" checked="1" >  
+                                                    <label class="cursor" for="encryption_show_password">{tr:file_encryption_show_password}</label>
+                                                </div>
+                                                
                                                 <div class="fs-transfer__password-bottom">
                                                     <small>{tr:password_share_tip}</small>
                                                 </div>

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -2075,6 +2075,9 @@ $(function() {
             // as soon as they edit anything it can no longer be considered "generated".
             filesender.ui.transfer.encryption_password_version = crypto.crypto_password_version_constants.v2018_text_password;
             filesender.ui.transfer.encryption_password_encoding = 'none';
+            if($('#encryption_password_show_container').is(":hidden")) {
+                $('#encryption_password_show_container').show();
+            }
             
             filesender.ui.files.checkEncryptionPassword($(this),true);
             filesender.ui.evalUploadEnabled();


### PR DESCRIPTION
We can always prune it off again. If we are doing that for design we should be aware and accept the security degradation in any non single person office that is involved in an upload. I imagine there are many shared spaces in higher education where being able to see a password as it is typed on a keyboard is much harder than just taking a photo of it on the screen.

This relates to https://github.com/filesender/filesender/issues/1581