### PR TITLE
Allow options to be put in advanced or not through config.php

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -523,6 +523,12 @@ if( !Auth::isGuest()) {
                                                     $displayoption($name, $cfg, Auth::isGuest(), $forcedOption,array("message"));
                                                 }
                                             }
+                                            foreach(Transfer::availableOptions(false) as $name => $cfg) {
+                                                if( !array_key_exists($name,$upload_options_handled)) {
+                                                    $displayoption($name, $cfg, Auth::isGuest());
+                                                }
+                                            }
+                                            
                                             ?>
                                         </div>
                                     </div>


### PR DESCRIPTION
This brings back support of the advanced setting in config.php/transfer_options. So setting advanced to true will put the option into the advanced subpart of the UI and being advanced=false will make the option a main item.

This gives the sys admin the flexibility to choose how that part of the UI will appear. We could make the default config.php have advanced=true for all the transfer_options to make the default shipping of FileSender as it was in the UI redesign.

$config['transfer_options'] = array(
        'email_me_copies' => array(
            'available' => true,
            'advanced' => true,
            'default' => false
        ),

This relates to https://github.com/filesender/filesender/issues/1595