### PR TITLE
d3ui3 Bring back pause, play, stop on upload as option

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -124,6 +124,7 @@ A note about colours;
 * [autocomplete](#autocomplete)
 * [autocomplete_max_pool](#autocomplete_max_pool)
 * [autocomplete_min_characters](#autocomplete_min_characters)
+* [upload_show_play_pause](#upload_show_play_pause)
 * [upload_display_bits_per_sec](#upload_display_bits_per_sec)
 * [upload_display_per_file_stats](#upload_display_per_file_stats)
 * [upload_force_transfer_resume_forget_if_encrypted](#upload_force_transfer_resume_forget_if_encrypted)
@@ -1345,6 +1346,15 @@ User language detection is done in the following order:
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__
+
+### upload_show_play_pause
+
+* __description:__ Show buttons to allow an upload to pause, resume, and stop
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 3.0
+* __comment:__ 
 
 ### upload_display_bits_per_sec
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -355,6 +355,8 @@ $default = array(
     'download_verification_code_valid_duration' => 60*15,
     'download_verification_code_random_bytes_used' => 8,
     'download_show_download_links' => false,
+
+    'upload_show_play_pause' => false,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -801,6 +801,22 @@ if( !Auth::isGuest()) {
                                         </tbody>
                                     </table>
                                 </div>
+                                <?php if(Config::get('upload_show_play_pause')) { ?>
+                                <div class="buttons">
+                                    <button type="button" id="fs-transfer__pause" class="fs-button fs-button--info fs-button--icon-right pausebutton">
+                                        {tr:pause}
+                                        <i class="fa fa-pause"></i>
+                                    </button>
+                                    <button type="button" id="fs-transfer__resume" class="fs-button fs-button--info fs-button--icon-right resumebutton" disabled="1">
+                                        {tr:resume}
+                                        <i class="fa fa-play"></i>
+                                    </button>
+                                    <button type="button" id="fs-transfer__stop" class="fs-button fs-button--info fs-button--icon-right stopbutton">
+                                        {tr:stop}
+                                        <i class="fa fa-stop"></i>
+                                    </button>
+                                </div>
+                                <?php } ?>
                             </div>
                         </div>
                     </div>

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -2524,6 +2524,46 @@ $(function() {
     var failed = filesender.ui.transfer.isThereFailedInRestartTracker();
     var auth = $('body').attr('data-auth-type');
 
+    form.find('.stopbutton').on('click', function(e) {
+        if(filesender.supports.reader) {
+            pause( true );
+        }
+        filesender.ui.confirm(lang.tr('confirm_stop_upload'),
+                              function() { // ok
+                                  filesender.ui.transfer.stop(function() {
+                                      filesender.ui.goToPage('upload');
+                                  });
+                              },
+                              function() { // cancel
+                                  filesender.ui.transfer.resume();
+                                  filesender.ui.nodes.buttons.pause.removeClass('not_displayed');
+                                  filesender.ui.nodes.buttons.resume.addClass('not_displayed');
+                              });
+        return false;
+    });
+
+    form.find('.pausebutton').on('click', function(e) {
+        filesender.ui.cancelAutomaticResume();
+
+        pause( true );
+        filesender.ui.nodes.stats.average_speed.find('.value').text(lang.tr('paused'));
+        filesender.ui.nodes.stats.estimated_completion.find('.value').text('');
+        filesender.ui.setTimeSinceDataWasLastSentMessage(lang.tr('paused'));
+        form.find('.resumebutton').prop("disabled",false);
+        form.find('.pausebutton').prop("disabled",true);
+        return false;
+    });
+        
+    form.find('.resumebutton').on('click', function(e) {
+        var force = filesender.ui.automatic_resume_retries > 0;
+        resume( force, true );
+        form.find('.pausebutton').prop("disabled", false);
+        form.find('.resumebutton').prop("disabled", true);
+            
+        return false;
+    });
+    
+
     if(auth == 'guest') {
         var transfer_options = JSON.parse(form.find('input[id="guest_transfer_options"]').val());
         for(option in filesender.ui.nodes.options) {


### PR DESCRIPTION
For countries, cities, or towns with slower internet access it is extremely useful to be able to pause an upload so that a long upload does not block voip or video calls.

Even if an NREN has significant bandwidth expectations for most users some of those users may travel to areas with limited bandwidth and may then appreciate the ability to pause an upload.

At any rate, as maintainer I find it useful enough for myself and users to have made it at least available as an option. I think people can comprehend the interface and ignore that part unless it is of use.