### PR TITLE
Update for 100 file limitation in directories dropped in Chrome

### DIFF
--- a/www/js/dragdrop-dirtree.js
+++ b/www/js/dragdrop-dirtree.js
@@ -43,11 +43,20 @@ filesender.dragdrop = {
         else if (item.isDirectory) {
             // Get folder contents
             let dirReader = item.createReader();
-            dirReader.readEntries(function(entries) {
+
+            // In chrome you have to keep calling readEntries() until zero are returned
+            // if you want to get them all.
+            var handleitems = function(entries) {
+                if( !entries.length ) {
+                    return;
+                }
                 for (let i=0; i<entries.length; i++) {
                     filesender.dragdrop.recurseTree(entries[i], path + item.name + "/");
                 }
-            });
+                dirReader.readEntries( handleitems );
+            };
+                
+            dirReader.readEntries(handleitems);
         }
     },
 


### PR DESCRIPTION
Its a strange API now having an array of entries returned and the need to do multiple calls until zero are returned. One might have thought a visitor function perhaps with an explicit limit number or function might have been a better choice but such is evolution.

This relates to https://github.com/filesender/filesender/issues/1715