### PR TITLE
use the same bucket names for guests

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -248,12 +248,9 @@ class RestEndpointGuest extends RestEndpoint
         if( $guest->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME)) {
             $transfer_options[TransferOptions::GET_A_LINK] = false;
         }
-
-        if( Config::get('storage_type') == 'CloudS3' ) {
-            $v = Config::get('cloud_s3_bucket');
-            if( $v && $v != '' ) {
-                $transfer_options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
-            }
+        
+        if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
+            $options = StorageCloudS3::augmentTransferOptions( $options );
         }
         
         $guest->transfer_options = $transfer_options;

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -531,19 +531,7 @@ class RestEndpointTransfer extends RestEndpoint
             }
 
             if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
-                if (Config::get('cloud_s3_use_daily_bucket')) {
-                    $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = "";
-                    $v = Config::get('cloud_s3_bucket_prefix');
-                    if( $v && $v != '' ) {
-                        $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
-                    }
-                    $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] .= date("Y-m-d");
-                } else {
-                    $v = Config::get('cloud_s3_bucket');
-                    if( $v && $v != '' ) {
-                        $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
-                    }
-                }
+                $options = StorageCloudS3::augmentTransferOptions( $options );                
             }
 
             Logger::info($options);

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -395,4 +395,32 @@ class StorageCloudS3 extends StorageFilesystem
         return true;
     }
 
+    /**
+     * Add custom bucket name info to transfer options
+     * 
+     * @param array $options
+     * 
+     * @return array new options
+     * 
+     */
+    public static function augmentTransferOptions( $options )
+    {
+        if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
+            if (Config::get('cloud_s3_use_daily_bucket')) {
+                $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = "";
+                $v = Config::get('cloud_s3_bucket_prefix');
+                if( $v && $v != '' ) {
+                    $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
+                }
+                $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] .= date("Y-m-d");
+            } else {
+                $v = Config::get('cloud_s3_bucket');
+                if( $v && $v != '' ) {
+                    $options[TransferOptions::STORAGE_CLOUD_S3_BUCKET] = $v;
+                }
+            }
+        }
+
+        return $options;
+    }
 }


### PR DESCRIPTION
S3 storage: Use the same custom or daily bucket name code for both guests and authenticated users.

This relates to https://github.com/filesender/filesender/issues/1718.