### PR TITLE
ui3: SAML if relogin is needed return to details page correctly

### DIFF
--- a/templates/logon_page.php
+++ b/templates/logon_page.php
@@ -5,7 +5,14 @@
         <?php
         $page = null;
         if (array_key_exists('s', $_REQUEST)) {
-            $page = Utilities::http_build_query(array('s' => $_REQUEST['s']));
+            $args = array('s' => $_REQUEST['s']);
+            if( $_REQUEST['s'] == 'transfer_detail' ) {
+                $args = array_merge( $args, array('transfer_id' => $_REQUEST['transfer_id']));
+            }
+            if( $_REQUEST['s'] == 'invitation_detail' ) {
+                $args = array_merge( $args, array('guest_id' => $_REQUEST['guest_id']));
+            }
+            $page = Utilities::http_build_query( $args );
         }
         echo GUI::getLoginButton($page);
         ?>


### PR DESCRIPTION
Some parameters need to be feed to the ReturnTo parameter in order for the user to return back to the transfer and guest details page correctly.

This can be triggered without waiting for a SAML session timeout by copying the URL, explicit logout. Then paste the original URL again and FileSender will ask you to authenticate. Without this PR you will either get an error on the transfer detail page or a guest not found general error on the guest detail page. With this PR you will see the expected page as the return from saml will complete properly.

This relates to https://github.com/filesender/filesender/issues/1725