### PR TITLE
add SonarQube CI

### DIFF
--- a/.github/workflows/sq.yml
+++ b/.github/workflows/sq.yml
@@ -1,0 +1,15 @@
+name: SonarQube CI
+on: push
+jobs:
+  sonarQubeTrigger:
+    name: SonarQube Trigger
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+    - name: SonarQube Scan
+      uses: kitabisa/sonarqube-action@v1.2.1
+      with:
+        host: ${{ secrets.SONARQUBE_HOST }}
+        login: ${{ secrets.SONARQUBE_TOKEN }}


### PR DESCRIPTION
this PR enables sonarqube scanner on you project. 

In order to work, you'll need to setup, two variables.  
You should also create two secrets at Organization level (so they will be shared among your projects):  https://github.com/organizations/ORGANIZATION/settings/secrets/actions (replace ORGANIZATION with the name of your organization).
* SONARQUBE_HOST this is not really a secret: https://sonarqube.software.geant.org/
* SONARQUBE_TOKEN you need to create a token at this URL: https://sonarqube.software.geant.org/account/security

Feel free to edit the triggers according to your needs. Now the scan is set to be triggered on any push, for every branch. 