### PR TITLE
verify host by default. If an insure mode is desired it should be made explicit in a subsequent PR.

### DIFF
--- a/scripts/client/FilesenderRestClient.class.php
+++ b/scripts/client/FilesenderRestClient.class.php
@@ -178,8 +178,8 @@ class FilesenderRestClient {
             'Content-Type: '.$content_type
         ));
         curl_setopt($h, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($h, CURLOPT_SSL_VERIFYHOST, false);
-        curl_setopt($h, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($h, CURLOPT_SSL_VERIFYHOST, true);
+        curl_setopt($h, CURLOPT_SSL_VERIFYPEER, true);
         
         switch($method) {
             case 'get' : break;


### PR DESCRIPTION
I have some modes in the nodejs client to allow this sort of SSL stuff for development but it is enabled by explicit triggers in configuration and environment. Such a feature is likely handy for this client too but should be a configuration setting for developers.