### PR TITLE
d3sq: Review the data-flow - use of uninitialized value.

### DIFF
--- a/classes/storage/StorageCloudAzure.class.php
+++ b/classes/storage/StorageCloudAzure.class.php
@@ -183,7 +183,6 @@ class StorageCloudAzure extends StorageFilesystem
      */
     public static function deleteFile(File $file)
     {
-        $chunk_size     = strlen($data);
         $container_name = $file->uid;
 
         try {


### PR DESCRIPTION
The chunk size was not actually referenced but it was also meaningless without the data being present in this method.