### PR TITLE
S3: Add bulk delete option

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -797,6 +797,7 @@ class Transfer extends DBObject
             // In case we keep audit data for some time only delete actual file data in storage
             foreach ($this->files as $file) {
                 try {
+		    Logger::debug('Attempt to call Storage::deleteFile for ' . $file);
                     Storage::deleteFile($file);
                 } catch (Exception $e) {
                     if( $force ) {

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -218,6 +218,10 @@ class StorageCloudS3 extends StorageFilesystem
         $offset = 0;
         $bucket_name = self::getBucketName( $file );
         $object_name = self::getObjectName( $file, $offset );
+	$bulk_delete = Config::get('cloud_s3_bulk_delete');
+	$bulk_size = Config::get('cloud_s3_bulk_size');
+
+	Logger::debug('CloudS3 deleteFile(), file_path: ' . $file_path . ' bucket_name: ' . $bucket_name . ' object_name: ' . $object_name . ' bulk: ' . $bulk_delete . '/' . $bulk_size);
         
         try {
             $client = self::getClient();
@@ -228,11 +232,44 @@ class StorageCloudS3 extends StorageFilesystem
                 $objects = $client->getIterator('ListObjects', array('Bucket' => $bucket_name, 'Prefix' => $file->uid));    
             }
 
-            foreach ($objects as $object) {
-                $result = $client->deleteObject(array(
-                    'Bucket' => $bucket_name,
-                    'Key'    => $object['Key']
-                ));
+	    if( $bulk_delete ) {
+
+	        // Build bulk request the way AWS client wants it
+                foreach ($objects as $object) {
+                    $delete_queue[] = [
+                        'Key' => $object['Key'],
+                    ];
+                }
+
+		if( $delete_queue ) {
+
+		    // Create batches of requested batchsize
+                    $chunked_queue = array_chunk($delete_queue, $bulk_size);
+                    Logger::debug('bulk has ' . count($chunked_queue) . ' requests');
+
+
+                    // Perform actual chunk removal
+                    foreach($chunked_queue as $delete_batch) {
+
+                        Logger::debug('bulk deleting ' . count($delete_batch) . ' chunks');
+                        $result = $client->deleteObjects([
+                           'Bucket' => $bucket_name,
+                           'Delete' => [
+                               'Objects' => $delete_batch,
+                           ],
+                        ]);
+                    }
+		}
+
+            } else {
+
+		Logger::debug('Executing non-bulk delete');
+                foreach ($objects as $object) {
+                    $result = $client->deleteObject(array(
+                        'Bucket' => $bucket_name,
+                        'Key'    => $object['Key']
+                    ));
+                }
             }
             
             if( !self::usingCustomBucketName( $file ) ) {

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -78,6 +78,8 @@ A note about colours;
 * [cloud_s3_bucket](#cloud_s3_bucket)
 * [cloud_s3_use_daily_bucket](#cloud_s3_use_daily_bucket)
 * [cloud_s3_bucket_prefix](#cloud_s3_bucket_prefix)
+* [cloud_s3_bulk_delete](#cloud_s3_bulk_delete)
+* [cloud_s3_bulk_size](#cloud_s3_bulk_size)
 
 ## Shredding
 
@@ -977,6 +979,26 @@ php scripts/task/S3bucketmaintenance.php --verbose
 * __comment:__ If cloud_s3_use_daily_bucket has been set, you can define the prefix for daily buckets with
 this option. Daily bucket names are formed by concatenating cloud_s3_bucket_prefix + YYYY-MM-DD,
 for example a prefix of "Test-" could create bucket "Test-2023-04-30". An empty prefix would create "2023-04-30".
+
+### cloud_s3_bulk_delete
+
+* __description:__ Toggle bulk delete or serial chunk delete
+* __mandatory:__ no.
+* __type:__ bool
+* __default:__ false
+* __available:__ since version 2.45
+* __comment:__ When deleting a file, this chooses between deleting one chunk per request, or sending a bulk request
+deleting up to [cloud_s3_bulk_size](#cloud_s3_bulk_size) chunks per request.
+
+### cloud_s3_bulk_size
+
+* __description:__ Maximum number of chunks to delete per bulk delete request
+* __mandatory:__ no.
+* __type:__ integer
+* __default:__ 1000
+* __available:__ since version 2.45
+* __comment:__ When [cloud_s3_bulk_delete](#cloud_s3_bulk_delete) is true, this is the maximum size of the delete request.
+Default value to maintain AWS S3 compatibility is 1000. Other storage platforms may use different defaults. OpenStack Swift defaults to 10000, for instance
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -239,6 +239,8 @@ $default = array(
     'cloud_s3_bucket' => '',
     'cloud_s3_use_daily_bucket' => false,
     'cloud_s3_bucket_prefix' => '',
+    'cloud_s3_bulk_delete' => false,
+    'cloud_s3_bulk_size' => 1000,
 
     'disable_directory_upload' => true,
     'directory_upload_button_enabled' => true,


### PR DESCRIPTION
This adds bulk delete for S3 storage to filesender.

Bulk delete allows deletion of multiple chunks simultaneously, up to a configured maximum. The purpose of this feature is to increase speed while deleting chunks from S3, due to lower overhead on the S3 side.
In tests, with default values, the deletion speed of a file with an exact multiple 1000 chunks was 8x faster than normal.

Bulk delete is controlled by two configurables:

The feature is toggled by boolean `cloud_s3_bulk_delete`, which defaults to false, for backward compatibility
There is one option, called `cloud_s3_bulk_size`, which defaults 1000, and is the number of objects that is deleted in one request.
