### PR TITLE
Remove logoff buttton agian as was the original 3.0 design

### DIFF
--- a/templates/menu.php
+++ b/templates/menu.php
@@ -53,32 +53,7 @@ if(Config::get('lang_selector_enabled') && (count(Lang::getAvailableLanguages())
                     pagemenuitem('privacy');
                 }
 
-                if (Auth::isAuthenticated() && Auth::isSP())
-                {
-                    $faicon = 'fa-sign-out';
-                    $icon = '<i class="fa '.$faicon.'"></i> ';
-
-                    $url = AuthSP::logoffURL();
-                    if( Config::get('auth_sp_type') == "saml" ) {
-
-                        $link = Utilities::sanitizeOutput($url);
-                        $txt = Lang::tr('logoff');
-                        echo <<<EOT
-                        <li>
-                          <form action="$link" method="post" >
-                            <button class="fs-link" type="submit" >
-                                ${icon}
-                                <span>$txt</span>
-                            </button>
-                          </form>
-                        </li>
-EOT;
-                    } else {
-                        if($url) {
-                            echo '<li><a class="fs-link" href="'.Utilities::sanitizeOutput($url).'" id="topmenu_logoff">'.$icon.Lang::tr('logoff').'</a></li>';
-                        }
-                    }
-                }
+            
                 if (!Auth::isAuthenticated() && !Auth::isSP() && !Auth::isGuest())
                 {
                     $faicon = 'fa-sign-in';


### PR DESCRIPTION
This is a reverse of https://github.com/filesender/filesender/pull/1704

The design originally had no logoff button. For SAML we should really move to SAML Single Logout (SLO) if we want to retain the logoff feature.