### PR TITLE
rest: guests with no transfer options should have at least one default

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -252,7 +252,12 @@ class RestEndpointGuest extends RestEndpoint
         if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
             $options = StorageCloudS3::augmentTransferOptions( $options );
         }
-        
+
+        if(Auth::isRemote()) {
+            if (!array_key_exists(TransferOptions::ADD_ME_TO_RECIPIENTS, $transfer_options)) {
+                $transfer_options[TransferOptions::ADD_ME_TO_RECIPIENTS] = false;
+            }
+        }
         $guest->transfer_options = $transfer_options;
         
         // Set expiry date
@@ -271,7 +276,6 @@ class RestEndpointGuest extends RestEndpoint
         
         // Make guest available, this saves the object and send email to the guest
         $guest->makeAvailable();
-
         
         return array(
             'path' => '/guest/'.$guest->id,


### PR DESCRIPTION
When no transfer options are supplied when creating a guest via the REST API then incorrect behaviour was observed. By setting at least one key in the transfer options I noticed the correct behaviour after an upload as that guest.

This relates to https://github.com/filesender/filesender/issues/1773.