### PR TITLE
option for more info when delete fails

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -177,6 +177,7 @@ class File extends DBObject
     protected $iv = '';
     protected $aead = null;
     protected $have_avresults = false;
+    protected $storage_class_name = ''; // set in constructor
    
     /**
      * Related objects cache

--- a/classes/exceptions/StorageFilesystemExceptions.class.php
+++ b/classes/exceptions/StorageFilesystemExceptions.class.php
@@ -126,6 +126,10 @@ class StorageFilesystemCannotDeleteException extends StorageFilesystemException
      */
     public function __construct($path, $file = null)
     {
+        $e = error_get_last();
+        if (self::additionalLoggingDesired('StorageFilesystemCannotDeleteException')) {
+            Logger::warn("StorageFilesystemCannotDeleteException reason: " . json_encode($e, JSON_PRETTY_PRINT, 10 ));
+        }
         parent::__construct('cannot_delete', $path, $file);
     }
 }
@@ -143,7 +147,10 @@ class StorageFilesystemCannotWriteException extends StorageFilesystemException
      */
     public function __construct($path, $file = null, $data = null, $offset = 0, $written = 0)
     {
+        $e = error_get_last();
+        
         if (self::additionalLoggingDesired('StorageFilesystemCannotWriteException')) {
+            Logger::warn("StorageFilesystemCannotWriteException reason: " . json_encode($e, JSON_PRETTY_PRINT, 10 ));
             $msg = 'StorageFilesystemCannotWriteException';
             $this->additionalLogFile($msg, $file);
             if ($data) {


### PR DESCRIPTION
Setting the below your config.php will result in more debug including the reason that file delete has failed.
```
$config['exception_additional_logging_regex'] = '.*Exception';
```

Tested with `chattr +i ` on the file in `/opt/filesender/files` and attempting to delete the file with the web ui. This clearly showed a message of `Operation not permitted`.

This relates to https://github.com/filesender/filesender/issues/1785.