### PR TITLE
Fix download recipient for only-send-to-me guests

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1552,8 +1552,19 @@ class Transfer extends DBObject
         if (!$this->getOption(TransferOptions::GET_A_LINK)) {
             // Unless get_a_link mode process options
             
-            if ($this->getOption(TransferOptions::ADD_ME_TO_RECIPIENTS) && !$this->isRecipient($this->user_email)) {
-                $this->addRecipient($this->user_email);
+            if ($this->getOption(TransferOptions::ADD_ME_TO_RECIPIENTS)) {
+                $rcpt = $this->user_email;
+
+                if(Auth::isGuest()) {
+                    $guest = AuthGuest::getGuest();
+                    if($guest->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME)) {
+                        $rcpt = $guest->user_email;
+                    }
+                }
+
+                if(!$this->isRecipient($rcpt)) {
+                    $this->addRecipient($rcpt);
+                }
             }
             
             // Send notification of availability to recipients


### PR DESCRIPTION
Creating a guest voucher with both the "only send to me" guest option and "add me to recipient" transfer option led to a download link being sent to the guest anyway because "me" was always evaluated as the transfer's creator, this fix makes it so that "me" becomes the guest creator when both options are used.

This bug caused a problem when a user sent an invitation to a mailing list to gather sensitive documents and the list was automatically added as a recipient of the download links ...