### PR TITLE
Use uuidv7 for storage and uuidv4 for key-based identification

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -339,8 +339,8 @@ class File extends DBObject
         $file->transfer_id = $transfer->id;
         $file->transferCache = $transfer;
 
-        // Generate uid until it is indeed unique
-        $file->uid = Utilities::generateUID(function ($uid, $tries) {
+        // Generate timestamped uid until it is indeed unique
+        $file->uid = Utilities::generateUID(true, function ($uid, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.File::getDBTable().' WHERE uid = :uid');
             $statement->execute(array(':uid' => $uid));
             $data = $statement->fetch();

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -285,7 +285,7 @@ class Guest extends DBObject
         $guest->created = $time;
         
         // Generate token until it is indeed unique
-        $guest->token = Utilities::generateUID(function ($token, $tries) {
+        $guest->token = Utilities::generateUID(false, function ($token, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.Guest::getDBTable().' WHERE token = :token');
             $statement->execute(array(':token' => $token));
             $data = $statement->fetch();

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -190,7 +190,7 @@ class Recipient extends DBObject
         $recipient->created = time();
         
         // Generate token until it is indeed unique
-        $recipient->token = Utilities::generateUID(function ($token, $tries) {
+        $recipient->token = Utilities::generateUID(false, function ($token, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.Recipient::getDBTable().' WHERE token = :token');
             $statement->execute(array(':token' => $token));
             $data = $statement->fetch();

--- a/classes/data/ShredFile.class.php
+++ b/classes/data/ShredFile.class.php
@@ -135,7 +135,7 @@ class ShredFile extends DBObject
         }
 
         // Generate uid until it is indeed unique
-        $file->name = Utilities::generateUID(function ($uid, $tries) {
+        $file->name = Utilities::generateUID(true, function ($uid, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.File::getDBTable().' WHERE uid = :uid');
             $statement->execute(array(':uid' => $uid));
             $data = $statement->fetch();

--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -206,7 +206,7 @@ class TranslatableEmail extends DBObject
         $email->created = time();
         
         // Generate token until it is indeed unique
-        $email->token = Utilities::generateUID(function ($token, $tries) {
+        $email->token = Utilities::generateUID(false, function ($token, $tries) {
             $statement = DBI::prepare('SELECT * FROM '.TranslatableEmail::getDBTable().' WHERE token = :token');
             $statement->execute(array(':token' => $token));
             $data = $statement->fetch();

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -54,6 +54,7 @@ class Utilities
     /**
      * Generate a unique ID to be used as token
      *
+     * @param bool $timestamped requests a timestamped (uuidv7) or non-timestamped (uuidv4) uid
      * @param callable $unicity_checker callback used to check for uid unicity (takes uid as sole argument, returns bool telling if uid is unique), null if check not needed
      * @param int $max_tries maximum number of tries before giving up and throwing
      *
@@ -62,7 +63,7 @@ class Utilities
      * @throws UtilitiesUidGeneratorBadUnicityCheckerException
      * @throws UtilitiesUidGeneratorTriedTooMuchException
      */
-    public static function generateUID($unicity_checker = null, $max_tries = 1000)
+    public static function generateUID($timestamped = false, $unicity_checker = null, $max_tries = 1000)
     {
         // Do we need to generate a unicity-checked random UID ?
         if ($unicity_checker) {
@@ -86,7 +87,7 @@ class Utilities
             return $uid;
         }
 
-        $uuid = Ramsey\Uuid\Uuid::uuid7();
+        $uuid = $timestamped ? Ramsey\Uuid\Uuid::uuid7() : Ramsey\Uuid\Uuid::uuid4();
         return $uuid->toString();
 /*
         // Generate 16 bytes of random data (128 bits)


### PR DESCRIPTION
Recent use of uuidv7 for all uids led to a significant loss of entropy for key-based identification (recipients, guests ...)

While the use of uuidv7 for storage is not an issue, its use for identification may be because of its weakness, these changes keep the use of uuidv7 for storage names but use uuidv4 with more entropy when generating identification keys (recipient tokens, guests tokens, email translation tokens, web interface security tokens ...)