### PR TITLE
rest: new nodejs rest client with encryption support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ scripts/testing/test1.php
 
 /.phpactor.json
 /docs/.bundle/
+
+scripts/client/nodeclient/node_modules/
+scripts/client/nodeclient/package-lock.json
+

--- a/classes/auth/AuthRemote.class.php
+++ b/classes/auth/AuthRemote.class.php
@@ -123,6 +123,7 @@ class AuthRemote
             $args = $_GET;
             unset($args['signature']);
             if (count($args)) {
+                unset($args['_']);                
                 $signed .= '?'.implode('&', RestUtilities::flatten($args));
             }
             

--- a/scripts/client/nodeclient/README.md
+++ b/scripts/client/nodeclient/README.md
@@ -1,0 +1,87 @@
+
+This is a javascript REST client for FileSender. It allows uploading
+and downloading of encrypted transfers from the command line.
+Transfers can also be seen from the web interface and downloaded with
+the same passphrase.
+
+The javascript REST client uses the same javascript code that the
+browser uses to perform the transfer. This includes the encryption and
+decryption of data performed by crypto_app.js. The REST client uses a
+nodejs implementation of WebCrypto to enable this functionality.
+
+Download is performed using the same URL that would be loaded in the
+browser, information is retrieved from the supplied token. All saved
+files are placed into a new subdirectory with the token value as the
+directory name. By default all the files of an encrypted transfer are
+downloaded into that new subdirectory.
+
+Configuration is done using the same filesender.py.ini file as the
+python client uses. In the future perhaps a filesender.js.ini will be
+checked too and if it exists used in preference to the
+filesender.py.ini file.
+
+If you are using self signed certificates then the strictssl
+configuration option might be useful along with the
+NODE_TLS_REJECT_UNAUTHORIZED environment variable.
+
+For example:
+
+```
+$ export NODE_TLS_REJECT_UNAUTHORIZED='0'
+$ cat ~/.filesender/filesender.py.ini
+[system]
+base_url = https://example.com/filesender/rest.php
+default_transfer_days_valid = 10
+strictssl = false
+
+[user]
+username = tester@example.com
+apikey = 2c....43
+```
+
+You will need to npm install some modules for the client to work.
+
+```
+$ cd scripts/client/nodeclient
+$ npm install 
+```
+
+
+General usage for explicit file upload and entire transfer download is
+as follows:
+
+
+```
+$ cd scripts/client/nodeclient
+$ node upload.js /tmp/testfile.txt --expire 14 --password abc
+$ node download.js --password abc 'https://example.com/filesender/?s=download&token=06....11' 
+```
+
+An entire directory can also be uploaded with the `-R` command line flag:
+
+```
+$ node upload.js -R /tmp/testdir --password allthefiles
+
+```
+
+
+
+The following is a non exhaustive list of issues which might be addressed at some stage.
+
+* Perhaps package this up into a more user friendly installation. The
+  javascript for the web site would either be local to that package or
+  referenced from the upload.js and download.js files.
+
+* TeraSender upload has not been implemented and tested. This would be the preferred
+  upload method for best performance.
+
+* Enable and test upload resume.
+
+* More error checking
+
+* Cleaner file upload progress on the command line
+
+* Perhaps the client should read ~/.filesender/filesender.ini and a
+  recommendation made to soft link that to filesender.py.ini.
+
+

--- a/scripts/client/nodeclient/download.js
+++ b/scripts/client/nodeclient/download.js
@@ -1,0 +1,162 @@
+
+var filesenerapi = require('./filesenderapi');
+
+const http = require('https');
+const fs = require('fs'); 
+const ini = require('ini');
+const path = require('node:path');
+
+var argv = require('minimist')(process.argv.slice(2));
+var expireInDays = 7;
+if( argv.expire && argv.expire >= 1 ) {
+    if( argv.expire > config.max_transfer_days_valid ) {
+        console.log("Error, you need to set the expire days to less than ", config.max_transfer_days_valid );
+        return 1;
+    }
+    expireInDays = argv.expire;
+}
+
+// FIXME we should support generating a password if they do not supply anything.
+if( !argv.password ) {
+    console.log("please use the --password option to supply a password");
+    return;
+}
+var password = argv.password;
+
+global.alert = function(msg) { console.log(msg); }
+if( !filesender.terasender ) {
+    filesender.terasender = {};
+}
+filesender.terasender.stop = function() { console.log("EEEEE terasender.stop");}
+
+
+async function downloadFiles( basepath, token, files )
+{
+    console.log("downloadFiles...!");
+    files.forEach((dl) => {
+
+        var crypto_app = window.filesender.crypto_app();
+
+        window.filesender.ui.prompt = function() { return password; }
+        // var progress = function() { };
+        var progress = null;
+        window.filesender.crypto_encrypted_archive_download = false;
+
+        var filesize = dl.size;
+        var mime = dl.mime;
+        var cleanName = dl.name;
+        cleanName = cleanName.replace(/^[.\/]+/, '');
+
+        // ensure directory
+        var filepath = basepath + "/" + path.dirname(cleanName);
+        if (!fs.existsSync(filepath)){
+            fs.mkdirSync(filepath, { recursive: true });
+        }
+        // make path full again
+        var filepath = basepath + "/" + cleanName;
+
+        
+
+        fs.writeFileSync(filepath, Buffer.from(''),
+                         {
+                             encoding: "utf8",
+                             flag: "w",
+                             mode: 0o660
+                         });                                                 
+        
+        var blobSinkLegacy = {
+            blobArray: [],
+            // keep a tally of bytes processed to make sure we get everything.
+            bytesProcessed: 0,
+            expected_size: filesize,
+            //                                             callbackError: callbackError,
+            name: function() { return "legacy"; },
+            error: function(error) {
+                console.log("");
+                console.log(window.filesender.config.language.file_encryption_wrong_password);
+                console.log("An error has occurred, most likely your password was incorrect.");
+                process.exit(1);
+            },
+            visit: function(chunkid,decryptedData) {
+                //                                                 window.filesender.log("SINK blobSinkLegacy visiting chunkid " + chunkid + "  data.len " + decryptedData.length );
+                this.blobArray.push(decryptedData);
+                this.bytesProcessed += decryptedData.length;
+                var buffer = Buffer.from(decryptedData);
+                fs.writeFileSync(filepath, buffer,
+                                 {
+                                     encoding: "utf8",
+                                     flag: "a+",
+                                     mode: 0o660
+                                 });                                                 
+                
+            },
+            done: function() {
+                // window.filesender.log("SINK blobSinkLegacy.done()");
+                // window.filesender.log("SINK blobSinkLegacy.done()      expected size " + filesize );
+                // window.filesender.log("SINK blobSinkLegacy.done() decryped data size " + this.bytesProcessed );
+                // window.filesender.log("SINK blobSinkLegacy.done()     blobarray size " + this.blobArray.length );
+
+                if( this.expected_size != this.bytesProcessed ) {
+                    window.filesender.log("blobSinkLegacy.done() size mismatch");
+                    //                                                     this.callbackError('decrypted data size and expected data size do not match');
+                    return;
+                }
+                console.log("Your files have been downloaded to ", basepath );
+            }
+        };
+        
+        var blobSink = blobSinkLegacy;
+        var blobSinkStreamed = blobSinkLegacy;
+        var link = config.site_url
+            + 'download.php?token=' + token
+            + '&files_ids=' + dl.id;
+
+        // make sure aead is decoded.
+        if( dl.fileaead ) {
+            try {
+                v = JSON.parse( dl.fileaead );
+            } catch( e ) {
+                dl.fileaead = atob(dl.fileaead);
+            }
+        }
+        
+        crypto_app.decryptDownloadToBlobSink( blobSink, password,
+                                              dl.transferid, link,
+                                              dl.mime, dl.name, dl.size, dl.encrypted_size,
+                                              dl.key_version, dl.key_salt,
+                                              dl.password_version, dl.password_encoding,
+                                              dl.password_hash_iterations,
+                                              dl.client_entropy,
+                                              window.filesender.crypto_app().decodeCryptoFileIV(dl.fileiv,dl.key_version),
+                                              dl.fileaead,
+                                              progress );
+
+
+        
+        
+    });
+}
+
+argv._.forEach((transferLink) => {
+    console.log("Downloading from transfer ", transferLink);
+
+    var rx = /token=([^&]+)/g;
+    var token = rx.exec(transferLink)[1];
+
+    if( token.length != 36 ) {
+        console.log("Sorry, you have supplied a bad token in your download link. Expected token length is 36 and you have given ", token.length );
+        return 1;
+    }
+
+    var basepath = "./" + token;
+    if (!fs.existsSync(basepath)){
+        fs.mkdirSync(basepath, { recursive: true });
+    }    
+    
+    var options = { args: {'token': token}};
+    window.filesender.client.get('/transfer/fileidsextended',
+                                 function (files) {
+                                     downloadFiles( basepath, token, files );
+                                 }, options);    
+    
+});

--- a/scripts/client/nodeclient/filesenderapi.js
+++ b/scripts/client/nodeclient/filesenderapi.js
@@ -1,0 +1,109 @@
+
+    
+const { subtle } = require('crypto').webcrypto;
+const { Blob } = require('buffer');
+const { LocalStorage } = require("node-localstorage");
+const { randombytes } = require('node-get-random-values');
+var FileReader = require('filereader');
+global.FileReader = FileReader;
+
+const http = require('https');
+const fs = require('fs');
+const ini = require('ini');
+
+var requireFromUrl = require('require-from-url/sync');
+const XRegExp = require('xregexp');
+global.XRegExp = XRegExp;
+
+var XMLHttpRequest = require('xhr2');
+global.XMLHttpRequest = XMLHttpRequest;
+
+if (!('config' in global))
+    global.config = {};
+
+
+//get the users home directory
+const home = process.env.HOME || process.env.USERPROFILE;
+const user_config_file = fs.readFileSync(home + '/.filesender/filesender.py.ini', 'utf8');
+const user_config = ini.parse(user_config_file);
+const base_url = user_config['system']['base_url'].replace(/[/]rest.php$/,"");
+const default_transfer_days_valid = user_config['system']['default_transfer_days_valid'];
+const username = user_config['user']['username'];
+const apikey = user_config['user']['apikey'];
+
+const { JSDOM } = require( "jsdom" );
+const { window } = new JSDOM( "", {url: base_url + "/?s=upload"} );
+global.$ = global.jQuery = require( "jquery" )( window );
+global.window = window;
+console.log("loading configuration from " + base_url + "/filesender-config.js.php" );
+var config = requireFromUrl(base_url + "/filesender-config.js.php");
+global.config = window.filesender.config;
+
+
+var enc = new TextEncoder();
+
+
+require('../../../www/js/client.js');
+require('../../../www/js/filesender.js');
+require('../../../www/js/transfer.js');
+require('../../../www/js/crypter/crypto_common.js');
+require('../../../www/js/crypter/crypto_app.js');
+require('../../../www/js/crypter/crypto_blob_reader.js');
+
+
+//add some required functions
+global.window.filesender.ui = {};
+global.window.filesender.ui.error = function(error,callback) {
+    console.log('[error] ' + error.message);
+    console.log(error);
+}
+global.window.filesender.ui.rawError = function(text) {
+    console.log('[raw error] ' + text);
+}
+global.window.filesender.ui.log = function(message) {
+    console.log('[log] ' + message);
+}
+global.window.filesender.ui.validators = {};
+global.window.filesender.ui.validators.email = /^[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_\`\{|\}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[a-z]{2,})$/i
+
+//global.window.location = {}
+global.window.location.href = base_url + "/?s=upload";
+
+global.localStorage = new LocalStorage('/tmp/localstorage',1000000);
+global.window.localStorage = global.localStorage;
+
+global.filesender = window.filesender;
+global.subtle = subtle;
+global.crypto.subtle = subtle;
+
+crypto.getRandomValues(new Uint8Array(32));
+
+
+
+//create a new transfer
+var transfer = new global.window.filesender.transfer()
+global.window.filesender.client.from = username;
+global.window.filesender.client.remote_user = username;
+transfer.from = username;
+global.transfer = transfer;
+global.username = username;
+
+//Turn on reader support for API transfers
+global.window.filesender.supports.reader = true;
+global.window.filesender.client.api_key = apikey;
+
+
+transfer.encryption_key_version = filesender.config.encryption_key_version_new_files;
+
+
+module.exports = function() { 
+    this.transfer = transfer;
+}
+
+window.filesender.client.setupSSLOptions = function( settings ) {
+    if( !user_config['system']['strictssl'] ) {
+        if( settings.context._resourceLoader ) {
+            settings.context._resourceLoader._strictSSL = false;
+        }
+    }
+}

--- a/scripts/client/nodeclient/package.json
+++ b/scripts/client/nodeclient/package.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "filereader": "^0.10.3",
+    "ini": "^4.1.2",
+    "jquery": "^3.7.1",
+    "jsdom": "^24.0.0",
+    "node-blob": "^0.0.2",
+    "node-get-random-values": "^1.1.0",
+    "node-localstorage": "^3.0.5",
+    "require-from-url": "^3.1.3",
+    "xhr2": "^0.2.1",
+    "minimist": "^1.2.8",
+    "node-fetch": "^3.3.2",
+    "recursive-readdir": "^2.2.3",
+    "xregexp": "^5.1.1"
+  }
+}

--- a/scripts/client/nodeclient/upload.js
+++ b/scripts/client/nodeclient/upload.js
@@ -1,0 +1,120 @@
+
+var filesenerapi = require('./filesenderapi');
+
+const http = require('https');
+const fs = require('fs');
+const ini = require('ini');
+var recursive = require("recursive-readdir");
+
+var argv = require('minimist')(process.argv.slice(2));
+var expireInDays = 7;
+if( argv.expire && argv.expire >= 1 ) {
+    if( argv.expire > config.max_transfer_days_valid ) {
+        console.log("Error, you need to set the expire days to less than ", config.max_transfer_days_valid );
+        return 1;
+    }
+    expireInDays = argv.expire;
+}
+
+// FIXME we should support generating a password if they do not supply anything.
+if( !argv.password ) {
+    console.log("please use the --password option to supply a password");
+    return;
+}
+var password = argv.password;
+    
+
+transfer.encryption = true;
+transfer.encryption_password = password;
+transfer.disable_terasender = true;
+
+var addFile = function( filename )
+{
+    console.log("Adding file: ", filename );
+
+    var displayPath = filename.replace(/^[\.\/]*/, '');
+    var data = fs.readFileSync(filename);
+    
+    var blob = new Blob([data]);
+    var errorHandler;
+    transfer.addRecipient(username, undefined);
+    transfer.addFile(displayPath, blob, errorHandler);
+}
+
+
+
+var filelist = [].concat(argv._);
+var expandedlist = [];
+
+/**
+ * If -R is enabled then expand any directory name given into the full
+ * recursive list of files in that directory
+ *
+ * @return expandedlist contains the output from the input filelist.
+ */
+async function expandFileList( filename, filelist )
+{
+    if( !filename ) {
+        return;
+    }
+
+    var isDir = fs.lstatSync(filename).isDirectory();
+    if( !isDir ) {
+        expandedlist.push( filename );
+        expandFileList( filelist.pop(), filelist );
+    } else {
+        if( argv.recursive || argv.R ) {
+            await recursive(filename).then(
+                async function(files) {
+                    files.forEach( (x) => { expandedlist.push( x ); } );
+                    await expandFileList( filelist.pop(), filelist );
+                },
+                function(error) {
+                    console.error("something bad happened", error);
+                    process.exit(1);
+                }
+            );
+        } else {
+            console.log("WARNING: please use -R/--recursive if you wish to upload an entire directory");
+            process.exit(1);
+        }
+    }
+    
+}
+
+
+
+
+
+    
+async function setupFiles( filelist ) {
+
+    filelist.forEach( async function(filename) {
+        addFile( filename );
+    });
+}
+
+
+
+async function upload() {
+
+    await expandFileList( filelist.pop(), filelist );
+    
+    setupFiles(expandedlist);
+    let expiry = (new Date(Date.now() + expireInDays * 24 * 60 * 60 * 1000));
+    transfer.expires = Math.floor(expiry.getTime()/1000);    
+    transfer.options.get_a_link = true;
+
+    transfer.oncomplete = function(transfer, time) {
+        console.log("Your download link: '" + global.transfer.download_link + "'" );
+    }
+
+    transfer.start();
+    
+}
+
+
+//console.log("key version new files:" +  window.filesender.config.encryption_key_version_new_files );
+
+upload();
+

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -137,6 +137,7 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
 ?>
     valid_filename_regex: '<?php echo $vfregex ?>',
     base_path: '<?php echo GUI::path() ?>',
+    site_url: '<?php echo Config::get('site_url') ?>',
     support_email: '<?php echo Config::get('support_email') ?>',
     autocomplete: {
         enabled:  <?php echo value_to_TF(Config::get('autocomplete')) ?>,

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -144,7 +144,6 @@ window.filesender.client = {
                     //Delete all `null` & `undefined` values (== operator vs ===)
                     Object.keys(data).forEach((key) => data[key] == null && delete data[key]);
                     data = JSON.stringify(data);
-                    to_sign += '&' + data;
                     hm.update('&');
                     hm.update(data);
                 } else {
@@ -158,18 +157,12 @@ window.filesender.client = {
                         value = window.filesender.crypto_common().convertArrayBufferViewtoString(data);
                         hm.update(data);
                     }
-                    to_sign += '&'+value;
                 }
             } else {
                 data = undefined;
             }
 
 
-            if( options.force_amp_at_end && !to_sign.endsWith("&")) {
-                to_sign += "&";
-                hm.update("&");
-            }
-            
             let signature = hm.digest().toString('hex');
             urlargs.push('signature' + '=' + signature);
             
@@ -358,10 +351,6 @@ window.filesender.client = {
     },
     
     get: function(resource, callback, options) {
-        // nodejs command line client only
-        if (this.api_key) {
-//            options.force_amp_at_end = true;
-        }
         return this.call('get', resource, undefined, callback, options);
     },
     

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -85,6 +85,9 @@ window.filesender.client = {
         if(filesender.terasender && filesender.terasender.security_token != source)
             filesender.terasender.security_token = source;
     },
+
+    setupSSLOptions: function( settings ) {
+    },
     
     // Send a request to the webservice
     call: function(method, resource, data, callback, options) {
@@ -106,13 +109,85 @@ window.filesender.client = {
         var urlargs = [];
         for(var k in args) urlargs.push(k + '=' + args[k]);
         
-        if(urlargs.length) resource += (resource.match(/\?/) ? '&' : '?') + urlargs.join('&');
         
-        if(data) {
-            var raw = options && ('rawdata' in options) && options.rawdata;
+        // API Key based authentication (i.e. CLI)
+        if (this.api_key) {
+            //... if there is an API key then REST CLI
+            var timestamp = Math.floor(Date.now() / 1000);
+
+            urlargs.push('remote_user' + '=' + this.from);
+            urlargs.push('timestamp' + '=' + timestamp);
+
+            var local_resource = resource.split(/\?|\&/);
+            resource = local_resource.shift();
+
+            local_resource.forEach(v => urlargs.push(v));
+
+            urlargs.sort();
+            var to_sign = method.toLowerCase()
+                        +'&'
+                        +this.base_path.replace('https://','',1).replace('http://','',1)
+                        +resource
+                        +'?'
+                        +urlargs.join('&');
+
+            const crypto = require('crypto');
+            var hm = crypto.createHmac("sha1", this.api_key).update(to_sign);
             
-            if(!raw) data = JSON.stringify(data);
-        }else data = undefined;
+            if(data) {
+                var raw = options && ('rawdata' in options) && options.rawdata;
+
+                if(!raw) {
+                    //clean up the data
+                    data.aup_checked = 1;
+
+                    //Delete all `null` & `undefined` values (== operator vs ===)
+                    Object.keys(data).forEach((key) => data[key] == null && delete data[key]);
+                    data = JSON.stringify(data);
+                    to_sign += '&' + data;
+                    hm.update('&');
+                    hm.update(data);
+                } else {
+                    hm.update('&');
+                    value = '';
+                    if( typeof data != 'object' ) {
+                        value = data.buffer;
+                        hm.update(value);
+                    }
+                    else {
+                        value = window.filesender.crypto_common().convertArrayBufferViewtoString(data);
+                        hm.update(data);
+                    }
+                    to_sign += '&'+value;
+                }
+            } else {
+                data = undefined;
+            }
+
+
+            if( options.force_amp_at_end && !to_sign.endsWith("&")) {
+                to_sign += "&";
+                hm.update("&");
+            }
+            
+            let signature = hm.digest().toString('hex');
+            urlargs.push('signature' + '=' + signature);
+            
+
+        } else {
+
+            if(data) {
+                var raw = options && ('rawdata' in options) && options.rawdata;
+                
+                if(!raw) {
+                    data = JSON.stringify(data);
+                }
+            }else data = undefined;
+            
+        }        
+
+        
+        if(urlargs.length) resource += (resource.match(/\?/) ? '&' : '?') + urlargs.join('&');
         
         var errorhandler = function(error) {
             filesender.ui.error(error);
@@ -135,6 +210,7 @@ window.filesender.client = {
         var settings = {
             cache: false,
             contentType: 'application/json;charset=utf-8',
+            'accept-encoding': 'identity',
             context: window,
             data: data,
             processData: false,
@@ -275,11 +351,17 @@ window.filesender.client = {
             this.pending_requests.push(settings);
             return;
         }
+
         
+        this.setupSSLOptions( settings );
         return jQuery.ajax(settings);
     },
     
     get: function(resource, callback, options) {
+        // nodejs command line client only
+        if (this.api_key) {
+//            options.force_amp_at_end = true;
+        }
         return this.call('get', resource, undefined, callback, options);
     },
     
@@ -407,13 +489,18 @@ window.filesender.client = {
      * @param callable error
      */
     putChunk: function(file, blob, offset, progress, done, error, encrypted, encryption_details ) {
+        var sz = blob.size;
+        if( typeof blob == "string" ) {
+            sz = blob.length;
+        }
         var opts = {
             contentType: 'application/octet-stream',
+            'accept-encoding': 'identity',
             rawdata: true,
             headers: {
                 'X-Filesender-File-Size': file.size,
                 'X-Filesender-Chunk-Offset': offset,
-                'X-Filesender-Chunk-Size': blob.size,
+                'X-Filesender-Chunk-Size': sz,
                 'X-Filesender-Encrypted': '1',
    	        'csrfptoken': filesender.client.getCSRFToken()
             },
@@ -432,25 +519,25 @@ window.filesender.client = {
         var chunkid = Math.floor(offset / window.filesender.config.upload_chunk_size);
         var $this = this;
         if(encrypted){
-            var cryptedBlob = null;
-            blobReader = window.filesender.crypto_blob_reader().createReader(blob, function(blob){
-                // nothing todo here.. 
-            });
-            blobReader.blobSlice = blob;
 
-            blobReader.readArrayBuffer(function(arrayBuffer){
-                window.filesender.crypto_app().encryptBlob(
-                    arrayBuffer,
-                    chunkid,
-                    encryption_details,
-                    function(encrypted_blob) {
-                        var result = $this.put(
-                            file.transfer.authenticatedEndpoint(
-                                '/file/' + file.id + '/chunk/' + offset,
-                                file), encrypted_blob, done, opts);
-                    }
-                );
-            });
+            var origsz = blob.size;
+            var response = new Response(blob);
+            response.arrayBuffer().then(
+                function(arrayBuffer){
+                    arrayBuffer.size = origsz;
+                    window.filesender.crypto_app().encryptBlob(
+                        arrayBuffer,
+                        chunkid,
+                        encryption_details,
+                        function(encrypted_blob) {
+                            var result = $this.put(
+                                file.transfer.authenticatedEndpoint(
+                                    '/file/' + file.id + '/chunk/' + offset,
+                                    file), encrypted_blob, done, opts);
+                        }
+                    );
+                }
+            );
         }else{
             var result = $this.put(file.transfer.authenticatedEndpoint('/file/' + file.id + '/chunk/' + offset, file), blob, done, opts);
         }

--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -1243,9 +1243,10 @@ window.filesender.transfer = function() {
                 if (!transfer.files[i].id)
                     return errorhandler({message: 'file_not_in_response', details: {file: transfer.files[i]}});
             }
-            
-            if('get_a_link' in transfer.options && transfer.options.get_a_link)
+
+            if('get_a_link' in transfer.options && transfer.options.get_a_link) {
                 transfer.download_link = data.recipients[0].download_url;
+            }
             
             transfer.createRestartTracker();
             
@@ -1381,6 +1382,7 @@ window.filesender.transfer = function() {
      * Chunk by chunk upload
      */
     this.uploadChunk = function() {
+
         if (this.status == 'stopped')
             return;
         
@@ -1399,8 +1401,8 @@ window.filesender.transfer = function() {
         filesender.ui.log('Uploading chunk [' + offset + ' .. ' + end + '] from file ' + file.name);
         
         var slicer = file.blob.slice ? 'slice' : (file.blob.mozSlice ? 'mozSlice' : (file.blob.webkitSlice ? 'webkitSlice' : 'slice'));
-        
-        var blob = file.blob[slicer](offset, end);
+
+        var blob = file.blob[slicer](offset, end, "application/octet-stream");
         var file_uploaded_when_chunk_complete = end;
         if (file_uploaded_when_chunk_complete > file.size)
             file_uploaded_when_chunk_complete = file.size;


### PR DESCRIPTION
The main motivation for this client is using nodejs and the WebCrypto API to have as close of a javascript path to transfer files as is used by the web browser. The initial code drop focuses on encrypted upload and download and supports multiple file transfers. A transfer with many files will have all files downloaded to a subdirectory.

Downloads can be performed using the same URL that is loaded in the browser to see a transfer and download files. This is the same link that is displayed as "get a link" and also sent in emails to people. The upload.js program also displays this download link allowing for easy testing.

See scripts/client/nodeclient/README.md for information. 
