### PR TITLE
read only mode to allow for major migrations

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -149,6 +149,7 @@ A note about colours;
 * [can_view_aggregate_statistics](#can_view_aggregate_statistics)
 * [auth_sp_saml_can_view_statistics_entitlement](#auth_sp_saml_can_view_statistics_entitlement)
 * [auth_sp_saml_can_view_aggregate_statistics_entitlement](#auth_sp_saml_can_view_aggregate_statistics_entitlement)
+* [read_only_mode](#read_only_mode)
 
 
 
@@ -1585,6 +1586,17 @@ User language detection is done in the following order:
 * __default:__ ""
 * __available:__ since version 2.8
 * __comment:__ See also can_view_statistics
+
+
+### read_only_mode
+* __description:__  Do not allow new transfers and guests to be created.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.48
+* __comment:__ If you are performing a major upgrade you might like to retain an original FileSender installation in read only mode so users can continue to download existing files and redirect visitors to a new site for new uploads. This may be useful for upgrading between major FileSender releases such as the 2.x series to the 3.x series and also for change in infrastructure such as moving to different disk pools or storage back ends.
+
+
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -353,6 +353,8 @@ $default = array(
     'download_verification_code_random_bytes_used' => 8,
 
     'download_show_download_links' => false,
+
+    'read_only_mode' => false,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -708,3 +708,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['read_only_mode'] = 'This FileSender is in read only mode. You can continue to download existing files but can not upload new files or create new guests at the moment.';

--- a/templates/guests_page.php
+++ b/templates/guests_page.php
@@ -66,6 +66,8 @@ use ( $new_guests_can_only_send_to_creator,
     }
 };
 
+$read_only_mode = Config::get('read_only_mode');
+
 
 ?>
 
@@ -76,7 +78,13 @@ use ( $new_guests_can_only_send_to_creator,
 // begin html part
 ////////////////////////
 ?>
+<?php if($read_only_mode) { ?>
 <div class="box">
+    {tr:read_only_mode}
+</div>
+<?php } else { ?>
+<div class="box">
+
     <div id="send_voucher" class="box">
         <div class="disclamer">
             {tr:send_new_voucher}
@@ -200,6 +208,7 @@ use ( $new_guests_can_only_send_to_creator,
         </div>
     </div>
 </div>
+<?php } ?>
 
 <div class="box">
     <h1>{tr:guests}</h1>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -69,8 +69,20 @@ if(Auth::isGuest()) {
 
 
 
-
 ?>
+
+
+<?php if( Config::get('read_only_mode')) { ?>
+    <div class="box">
+        {tr:read_only_mode}
+    </div>
+<?php
+    return;
+}
+?>
+
+
+
 
 <div class="box">
     <form id="upload_form" class="<?php echo $formClasses; ?>" enctype="multipart/form-data" accept-charset="utf-8" method="post" autocomplete="off" data-need-recipients="<?php echo $need_recipients ? '1' : '' ?>">


### PR DESCRIPTION
This is to help some sites migrate to the 3.x series. It might be useful in other contexts as well. For example,  migrating to a different server machine or disk storage environment where you might not wish to copy existing files over.

I considered if I should disable deleting a transfer, deleting a guest and other mutable actions. At the moment the PR is just for disable new uploads and disable new guest creation.

This relates to https://github.com/filesender/filesender/issues/1808