### PR TITLE
SAML: update default id attibute to the more modern pairwise-id for ui3

### DIFF
--- a/ci/filesender-config.php
+++ b/ci/filesender-config.php
@@ -301,8 +301,7 @@ $config['auth_sp_type'] = 'saml';
 // // Get name attribute from authentication service
  $config['auth_sp_saml_name_attribute']         =       'cn';
 // 
-// // Get uid attribute from authentication service.  Usually eduPersonTargetedId or eduPersonPrincipalName
-$config['auth_sp_saml_uid_attribute']           =       'eduPersonPrincipalName';
+$config['auth_sp_saml_uid_attribute']           =       'pairwise-id';
 // 
 // // Get path  attribute from authentication service
 $config['auth_sp_saml_authentication_source']   =       'default-sp';

--- a/config/config-sample-meijer.php
+++ b/config/config-sample-meijer.php
@@ -293,8 +293,8 @@ $config['storage_filesystem_path'] = '/data/branches/filesender-2.0/files';
 // // Get name attribute from authentication service
 // $config['auth_sp_saml_name_attribute'] = 'cn';
 // 
-// // Get uid attribute from authentication service.  Usually eduPersonTargetedId or eduPersonPrincipalName
-$config['auth_sp_saml_uid_attribute'] = 'eduPersonPrincipalName';
+$config['auth_sp_saml_uid_attribute'] = 'pairwise-id';
+
 // 
 // // Get path  attribute from authentication service
 $config['auth_sp_saml_authentication_source'] = 'default-sp';

--- a/config/config_sample.php
+++ b/config/config_sample.php
@@ -110,8 +110,7 @@ $config['auth_sp_saml_simplesamlphp_location'] ='/opt/filesender/simplesaml/';  
 // // Get name attribute from authentication service
 // $config['auth_sp_saml_name_attribute'] = 'cn';
 // 
-// // Get uid attribute from authentication service.  Usually eduPersonTargetedID or eduPersonPrincipalName
-// $config['auth_sp_saml_uid_attribute'] = 'eduPersonTargetedId';
+// $config['auth_sp_saml_uid_attribute'] = 'pairwise-id';
 //
 // // Attribute to use for entitlement. Usually eduPersonEntitlement or isMemberOf
 // $config['auth_sp_saml_entitlement_attribute'] = 'eduPersonEntitlement';

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -2682,13 +2682,13 @@ This is only for old, existing transfers which have no roundtriptoken set.
 
 ### auth_sp_saml_uid_attribute
 
-* __description:__ attribute for user's unique user identifier to get from authentication service provider.  Usually you would use either *eduPersonTargetedID* or *eduPersonPrincipalName* (watch the spelling!).  ePTID is an anonymous identifier making it hard to link FileSender logging to a specific user which may or may not be what you want.  ePTID will protect your users against rogue IdPs.  eduPersonPrincipalName will usually give you an identifier like <username>@<domain>.
+* __description:__ attribute for user's unique user identifier to get from authentication service provider.  Usually you would use either *pairwise-id* or *subject-id* (watch the spelling!). 
 * __mandatory:__ no explicit configuration is needed when the default is used.  However, this value MUST be received from the Identity Provider, otherwise a user can not log on.
 * __type:__ string
-* __default:__ eduPersonTargetedId
+* __default:__ pairwise-id
 * __available:__ since version 1.0
 * __1.x name:__ saml_uid_attribute
-* __comment:__
+* __comment:__ Note that the default has changed from the deprecated eduPersonTargetedId to pairwise-id in version 2.48.
 
 ### auth_sp_saml_entitlement_attribute
 
@@ -2750,7 +2750,7 @@ This is only for old, existing transfers which have no roundtriptoken set.
 
 ### auth_sp_shibboleth_uid_attribute
 
-* __description:__ attribute for user's unique user identifier to get from authentication service provider.  Usually you would use either *eduPersonTargetedID* or *eduPersonPrincipalName* (watch the spelling!).  ePTID is an anonymous identifier making it hard to link FileSender logging to a specific user which may or may not be what you want.  ePTID will protect your users against rogue IdPs.  eduPersonPrincipalName will usually give you an identifier like <username>@<domain>.
+* __description:__ attribute for user's unique user identifier to get from authentication service provider.  Usually you would use pairwise-id.
 * __mandatory:__ no explicit configuration is needed when the default is used.  However, this value MUST be received from the Identity Provider, otherwise a user can not log on.
 * __type:__ string
 * __default:__

--- a/docs/v2.0/admin/reference/index.md
+++ b/docs/v2.0/admin/reference/index.md
@@ -63,14 +63,25 @@ FileSender has no user database and has no concept of user accounts.
 
 ## IdP attributes
 
-By default FileSender looks at the SAML attributes `mail`, `cn`, and `eduPersonTargetedId`.
-The SAML attributes eduPersonTargetedId and mail are *required* to login.
+There are two attributes from SAML that are *required* to login: an
+identifier for the user and an email address. An optional name is also
+taken from the SAML attributes.
 
-The auth_sp_additional_attributes config.php setting can be used to allow access to other SAML attributes as well.
-
-The AuthSPSaml.class.php file processes the attributes. It looks for uid, name, and email. The uid and email must be present. The name will be taken from the email if it is not present.
-These uid, name, and email are found using the filesender config.php settings auth_sp_saml_email_attribute https://docs.filesender.org/filesender/v2.0/admin/configuration/#auth_sp_saml_email_attribute and the like. 
+The exact SAML attributes that are used to obtain these values is
+defined by the FileSender config.php settings such as
+auth_sp_saml_uid_attribute, auth_sp_saml_email_attribute and the like.
+For example see
+https://docs.filesender.org/filesender/v2.0/admin/configuration/#auth_sp_saml_email_attribute
 The filesender config.php settings let you change what SAML attribute to inspect (or a list of them) to obtain these values.
+
+By default FileSender looks at the SAML attributes `pairwise-id`,
+`mail`, and `cn`. These are taken as the identifier, email address,
+and optional name values by FileSender.
+
+The auth_sp_additional_attributes config.php setting can be used to
+allow access to other SAML attributes as well.
+
+
 
 
 


### PR DESCRIPTION
This updates the default SAML user ID attribute from the deprecated `eduPersonTargetedId` to the newer `pairwise-id`.

Interested readers may consider https://docs.oasis-open.org/security/saml-subject-id-attr/v1.0/cs01/saml-subject-id-attr-v1.0-cs01.html for more information.

This was kindly suggested in a comment at https://github.com/filesender/filesender/issues/1781#issuecomment-1991258902

This supersedes https://github.com/filesender/filesender/pull/1822