### PR TITLE
ui3: update crypto to version 3 (GCM+PBKDF2) by default

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1938,8 +1938,8 @@ If you want to find out the expiry timer for your SAML Identity Provider install
 * __recommend_leaving_at_default:__ true
 * __mandatory:__ no 
 * __type:__ int
-* __default:__ 1
-* __available:__ since version 2.6
+* __default:__ 3
+* __available:__ updated in 3.0 beta7 an above to 3, was 1 since version 2.6
 * __comment:__
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -286,7 +286,8 @@ $default = array(
 
     // see crypto_app.js for constants in the range crypto_key_version_constants
     // Generally higher is newer + better.
-    'encryption_key_version_new_files' => 1,
+    // UI3 has changed from '1' to '3' as the default (AES-GCM + PBKDF2)
+    'encryption_key_version_new_files' => 3,
 
     // for details of possible values see crypto_password_version_constants
     // in the file js/crypter/crypto_app.js


### PR DESCRIPTION
The AES-GCM + PBKDF2 is more secure for a number of reasons and was also audited before acceptance. It may not work in some older browsers but should work in modern Safari, Chrome, Firefox, Edge (Chromium based).