### PR TITLE
d3: foramt dates with locale and a config as to how long the admin wishes these to be

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -182,35 +182,42 @@ class Utilities
 
         Lang::setlocale_fromUserLang( LC_TIME );
 
-        $lid = $with_time ? 'datetime_format' : 'date_format';
-        $dateFormat = Lang::trWithConfigOverride($lid);
-        if( $dateFormat == "%d %b %Y" ) {
-            $dateFormat = 'dd MMM yyyy';
+        $dateFormatStyle = IntlDateFormatter::MEDIUM;
+        $timeFormatStyle = IntlDateFormatter::NONE;
+        if( $with_time ) {
+            $timeFormatStyle = IntlDateFormatter::MEDIUM;
         }
-        if( $dateFormat == "%d %b %Y %T" ) {
-            $dateFormat = 'dd MMM yyyy HH:mm:ss';
+        $v = Config::get("date_format_style");
+        switch($v) {
+            case "full":   $dateFormatStyle = IntlDateFormatter::FULL; break;
+            case "long":   $dateFormatStyle = IntlDateFormatter::LONG; break;
+            case "medium": $dateFormatStyle = IntlDateFormatter::MEDIUM; break;
+            case "short":  $dateFormatStyle = IntlDateFormatter::SHORT; break;
         }
-        if ($dateFormat == '{date_format}') {
-            $dateFormat = 'dd MMM yyyy';
+        if( $with_time ) {
+            $v = Config::get("time_format_style");
+            switch($v) {
+                case "full":   $timeFormatStyle = IntlDateFormatter::FULL; break;
+                case "long":   $timeFormatStyle = IntlDateFormatter::LONG; break;
+                case "medium": $timeFormatStyle = IntlDateFormatter::MEDIUM; break;
+                case "short":  $timeFormatStyle = IntlDateFormatter::SHORT; break;
+            }
         }
-        if ($dateFormat == '{datetime_format}') {
-            $dateFormat = 'dd MMM yyyy HH:mm:ss';
-        }
+
+                
 
         $timezone = null;
         $al = Lang::getUserAcceptedLanguages();
         // use default php.ini value if all else fails
         $al[] = null; 
-        if( str_contains($dateFormat,'%')) {
-            $dateFormat = null;
-        }
+        $dateFormat = null;
         
         foreach ($al as $k => $v) {
 
             $fmt = new IntlDateFormatter(
                 $v,
-                IntlDateFormatter::MEDIUM,
-                $with_time ? IntlDateFormatter::MEDIUM : IntlDateFormatter::NONE,
+                $dateFormatStyle,
+                $timeFormatStyle,
                 $timezone,
                 IntlDateFormatter::GREGORIAN,
                 $dateFormat

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -151,6 +151,8 @@ A note about colours;
 * [auth_sp_saml_can_view_statistics_entitlement](#auth_sp_saml_can_view_statistics_entitlement)
 * [auth_sp_saml_can_view_aggregate_statistics_entitlement](#auth_sp_saml_can_view_aggregate_statistics_entitlement)
 * [read_only_mode](#read_only_mode)
+* [date_format_style](#date_format_style)
+* [time_format_style](#time_format_style)
 
 
 
@@ -1606,6 +1608,25 @@ User language detection is done in the following order:
 * __default:__ false
 * __available:__ since version 2.48
 * __comment:__ If you are performing a major upgrade you might like to retain an original FileSender installation in read only mode so users can continue to download existing files and redirect visitors to a new site for new uploads. This may be useful for upgrading between major FileSender releases such as the 2.x series to the 3.x series and also for change in infrastructure such as moving to different disk pools or storage back ends.
+
+
+### date_format_style
+* __description:__  High level selection of the style to format a date with.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ medium
+* __available:__ since version 3.0beta7
+* __comment:__ This can be one of full, long, medium, or short. This will be used to format dates and times with the locale according to IntlDateFormatter. The local is taken from the user profile, and then from the http accepted languages sent from the browser so it should match which language and locale the user is most confortable with. See for example https://www.php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants This replaces the use of the date_format translation string in the 2.x series of FileSender.
+
+
+### time_format_style
+* __description:__  High level selection of the style to format a date with a time component with.
+* __mandatory:__ no
+* __type:__ string
+* __default:__ medium
+* __available:__ since version 3.0beta7
+* __comment:__ This can be one of full, long, medium, or short. This will be used to format dates and times with the locale according to IntlDateFormatter. The local is taken from the user profile, and then from the http accepted languages sent from the browser so it should match which language and locale the user is most confortable with. See for example https://www.php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants This replaces the use of the datetime_format translation string in the 2.x series of FileSender.
+
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -368,6 +368,9 @@ $default = array(
 
     'upload_show_play_pause' => false,
     'read_only_mode' => false,
+
+    'date_format_style' => 'medium',
+    'time_format_style' => 'medium',
     
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
This is an update to the deprecation of strftime and the old translation strings which are specific to that function. The new breaking change is to allow the length of formatted date and time to be specified in the configuration file and the information is then presented in that level of detail using the locale that the user is most comfortable with.