### PR TITLE
auth: do not throw here if not authenticated

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -165,8 +165,9 @@ class Config
         }
 
         // Load config regex overrides if used and present
+        // if not authenticated then do not throw, just do not load these files
         $auth_config_regex_files = self::get('auth_config_regex_files');
-        if( !empty($auth_config_regex_files) && is_array($auth_config_regex_files) && Auth::isAuthenticated()) {
+        if( !empty($auth_config_regex_files) && is_array($auth_config_regex_files) && Auth::isAuthenticated(false)) {
                 $auth_attrs = Auth::attributes();
                 foreach ($auth_config_regex_files as $attr=>$regex_and_configs) {
                         if (!is_array($regex_and_configs)) {


### PR DESCRIPTION
If a REST client (or other browser) fails to authenticate here we just do not load these additional config files. If failed auth is really a problem then other code will have an `Auth::isAuthenticated()` call that throws and will then stop processing there. We can allow failed auth to be served without these additional config files and for that case to not cause a syslog event.

This relates to https://github.com/filesender/filesender/issues/1840