### PR TITLE
option to send timezone from the client to the server for date handling

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -204,13 +204,19 @@ class Utilities
             }
         }
 
-                
 
         $timezone = null;
         $al = Lang::getUserAcceptedLanguages();
         // use default php.ini value if all else fails
         $al[] = null; 
         $dateFormat = null;
+
+        if( !empty($_COOKIE["x-filesender-timezone"])) {
+            $tz = $_COOKIE["x-filesender-timezone"];
+            if( preg_match(Config::get("valid_timezone_regex"), $tz)) {
+                $timezone = $tz;
+            }
+        }
         
         foreach ($al as $k => $v) {
 

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -213,7 +213,8 @@ class Utilities
 
         if( !empty($_COOKIE["x-filesender-timezone"])) {
             $tz = $_COOKIE["x-filesender-timezone"];
-            if( preg_match(Config::get("valid_timezone_regex"), $tz)) {
+            if( !empty(Config::get("valid_timezone_regex"))
+                && preg_match(Config::get("valid_timezone_regex"), $tz)) {
                 $timezone = $tz;
             }
         }

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1645,7 +1645,7 @@ User language detection is done in the following order:
 * __type:__ string (php regex including the leading and trailing //i characters)
 * __default:__ '@^[_/a-z]+$@i'
 * __available:__ since version 3.0beta7
-* __comment:__ This regex is used to match timezone data passed from the browser. If the regex does not match the timezone is considered invalid and ignored.
+* __comment:__ This regex is used to match timezone data passed from the browser. If the regex does not match the timezone is considered invalid and ignored. Set this to '' to explicitly disable this feature.
 
 
 ### client_send_current_timezone_to_server

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -154,6 +154,8 @@ A note about colours;
 * [date_format_style](#date_format_style)
 * [time_format_style](#time_format_style)
 * [make_download_links_clickable](#make_download_links_clickable)
+* [valid_timezone_regex](#valid_timezone_regex)
+* [client_send_current_timezone_to_server](#client_send_current_timezone_to_server)
 
 
 ## Transfers
@@ -1637,6 +1639,22 @@ User language detection is done in the following order:
 * __comment:__ The transfer link can be clicked on when get a link is used and an upload is compete.
 
 
+### valid_timezone_regex
+* __description:__  A full php regex expression including the leading and trailing //i type characters to match a valid timezone string sent from the browser
+* __mandatory:__ no
+* __type:__ string (php regex including the leading and trailing //i characters)
+* __default:__ '@^[_/a-z]+$@i'
+* __available:__ since version 3.0beta7
+* __comment:__ This regex is used to match timezone data passed from the browser. If the regex does not match the timezone is considered invalid and ignored.
+
+
+### client_send_current_timezone_to_server
+* __description:__  If enabled the client will send the current timezone to the server. This could be a privacy issue so it is off by default.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 3.0beta7
+* __comment:__ If enabled the client will share the current timezone setting to the server so it can format dates as the client expects.
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -371,6 +371,9 @@ $default = array(
 
     'date_format_style' => 'medium',
     'time_format_style' => 'medium',
+
+    'valid_timezone_regex' => '@^[_/a-z]+$@i',
+    'client_send_current_timezone_to_server' => false,
     
     'transfer_options' => array(
         'email_me_copies' => array(

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -210,6 +210,10 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
     download_verification_code_enabled: <?php echo value_to_TF(Config::get('download_verification_code_enabled')) ?>,
 
     make_download_links_clickable: <?php echo value_to_TF(Config::get('make_download_links_clickable')) ?>,
+    client_send_current_timezone_to_server: <?php echo value_to_TF(Config::get('client_send_current_timezone_to_server')) ?>,
+
+
+
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>
@@ -233,4 +237,10 @@ window.filesender.config.isFileSystemWritableFileStreamAvailableForDownload = fu
 window.filesender.config.useFileSystemWritableFileStreamForDownload = function() {
     return window.filesender.config.allow_filesystemwritablefilestream
         && window.filesender.config.isFileSystemWritableFileStreamAvailableForDownload();
+}
+
+
+if( filesender.config && filesender.config.client_send_current_timezone_to_server ) {
+    var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    document.cookie = "x-filesender-timezone=" + tz;
 }

--- a/www/js/filesender.js
+++ b/www/js/filesender.js
@@ -35,3 +35,4 @@ if (window.filesender.supports.workers) {
 window.filesender.log = function( msg ) {
     console.log( msg );
 }
+


### PR DESCRIPTION
I have focused on adding this only in the 3.x series. This is part 1 of 2 for updated timezone handling. This allows the browser to send the timezone to the server if the option is configured on the server. The dates are them formatted for display using that timezone.

This relates to https://github.com/filesender/filesender/issues/354.