### PR TITLE
Make CLI client config `default_transfer_days_valid` dynamic (again)

### DIFF
--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -218,11 +218,12 @@ class RestEndpointUser extends RestEndpoint
             $username = $user->saml_user_identification_uid;
             $authsecret = $user->auth_secret;
             $site_url = Config::get('site_url');
+            $days_valid = Config::get('default_transfer_days_valid');
             
             $doc = <<<END
-[system]            
+[system]
 base_url = $site_url/rest.php
-default_transfer_days_valid = 10
+default_transfer_days_valid = $days_valid
 
 [user]
 username = $username


### PR DESCRIPTION
Set `default_transfer_days_valid` from the configuration when writing the CLI client configuration file, instead of hard-coding it to `10`.

We've been here before 5 years ago when #677 (and #682) made this parameter dynamic when it was still being written into the Python CLI client itself.  
Now do the same when writing this into a configuration file for the Python CLI client (and not into the Python code directly).

> N.B.: Untested as of yet, due to my inability to have the CLI client configuration file generated and downloaded, as mentioned as an side in #1856.