### PR TITLE
Update filesender.py

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -126,7 +126,8 @@ else:
 requiredNamed.add_argument("-r", "--recipients", required=True)
 
 # if username is not a valid email address then ensure user supplies a valid email address
-if not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", username)):
+args = parser.parse_args()
+if args.username and not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", args.username)):
   requiredNamed.add_argument("-f", "--from_address", help="filesender email from address", required=True)
 
 args = parser.parse_args()


### PR DESCRIPTION
Small bugfix when running this script without the username argument:
E.g.:
`python3 filesender.py -h`

```
Traceback (most recent call last):
  File "/home/tijl/filesender.py", line 130, in <module>
    if not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", username)):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/re/__init__.py", line 166, in match
    return _compile(pattern, flags).match(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
```
The variable "username" is addressed before it was instantiated, this might not be the best resolution, but it works. 