### PR TITLE
fix ip when $ip[0] doesn't exist

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -343,7 +343,7 @@ class Utilities
             return '127.0.0.1';
         }
         
-        return $ips[0];
+        return array_shift($ips);
     }
     
     /**


### PR DESCRIPTION
We have 1 user who's first ip in $ips is filtered out, which causes a DBIUsageException exception,
This PR fixes this issue.