### PR TITLE
help sort by downloads by better recording the count

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -173,6 +173,13 @@ class Transfer extends DBObject
             'default' => false,
         ),
 
+
+        'download_count' => array(
+            'type'    => 'uint',
+            'size'    => 'big',
+            'default' => 0,
+            'null'    => false,
+        ),
         
     );
 
@@ -270,6 +277,9 @@ class Transfer extends DBObject
         ),
         'expires' => array(
             'expires' => array()
+        ),
+        'downlaods' => array(
+            'download_count' => array()
         )
     );
 
@@ -327,6 +337,7 @@ class Transfer extends DBObject
     protected $guest_transfer_shown_to_user_who_invited_guest = true;
     protected $storage_filesystem_per_day_buckets = false;
     protected $storage_filesystem_per_hour_buckets = false;
+    protected $download_count = 0;
 
     
     /**
@@ -356,6 +367,7 @@ class Transfer extends DBObject
     {
         $this->storage_filesystem_per_day_buckets = Config::get('storage_filesystem_per_day_buckets');
         $this->storage_filesystem_per_hour_buckets = Config::get('storage_filesystem_per_hour_buckets');
+        $this->download_count = 0;
         
         if (!is_null($id)) {
             // Load from database if id given
@@ -1064,6 +1076,7 @@ class Transfer extends DBObject
             'password_version', 'password_encoding', 'password_encoding_string', 'password_hash_iterations'
             , 'client_entropy', 'roundtriptoken', 'guest_transfer_shown_to_user_who_invited_guest'
             , 'storage_filesystem_per_day_buckets', 'storage_filesystem_per_hour_buckets'
+            , 'download_count'
             
         ))) {
             return $this->$property;
@@ -1278,6 +1291,8 @@ class Transfer extends DBObject
             $this->storage_filesystem_per_day_buckets = $value;
         } elseif ($property == 'storage_filesystem_per_hour_buckets') {
             $this->storage_filesystem_per_hour_buckets = $value;
+        } elseif ($property == 'download_count') {
+            $this->download_count = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -537,6 +537,14 @@ class Logger
         AuditLog::create($logEvent, $target, $author);
         StatLog::create($logEvent, $target);
         AggregateStatistic::create($logEvent, $target,$author);
+
+        if( $logEvent == LogEventTypes::DOWNLOAD_ENDED || $logEvent == LogEventTypes::ARCHIVE_DOWNLOAD_ENDED ) {
+            if ($target instanceof File) {
+                $transfer = $target->transfer;
+                $transfer->download_count++;
+                $transfer->save();
+            }
+        }
         
         self::info('Event#'.$logEvent.' on '.(string)$target.($author ? ' by '.(string)$author : ''));
     }

--- a/classes/utils/TransferQueryOrder.class.php
+++ b/classes/utils/TransferQueryOrder.class.php
@@ -145,17 +145,13 @@ class TransferQueryOrder
                 break;
             case self::SORT_DOWNLOAD_DESC:
                 $this->usedSort    = $order;
-                $this->viewname    = 'transfersauditlogsdlcountview';
-                $this->orderclause = ' count DESC, created DESC ';
+                $this->orderclause = ' download_count DESC, created DESC ';
                 $this->columnname  = self::COLUMN_DOWNLOAD;
-//                $this->whereclause = " ( event = 'download_ended' or event = 'archive_download_ended' ) ";
                 break;
             case self::SORT_DOWNLOAD_ASC:
                 $this->usedSort    = $order;
-                $this->viewname    = 'transfersauditlogsdlcountview';
-                $this->orderclause = ' count ASC, created DESC ';
+                $this->orderclause = ' download_count ASC, created DESC ';
                 $this->columnname  = self::COLUMN_DOWNLOAD;
-//                $this->whereclause = " ( event = 'download_ended' or event = 'archive_download_ended' ) ";
                 break;
                 
             default:

--- a/scripts/upgrade/explicit/upgrade-2.48-to-2.49-post-download-count.php
+++ b/scripts/upgrade/explicit/upgrade-2.48-to-2.49-post-download-count.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2014, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+require_once dirname(__FILE__).'/../../../includes/init.php';
+
+Logger::setProcess(ProcessTypes::UPGRADE);
+
+set_error_handler(function($no, $str, $file = '', $line = '') {
+    if($no == '2048') return;
+    Logger::error('['.$no.'] '.$str.' in '.$file.' at line '.$line);
+});
+$dbtype = Config::get('db_type');
+
+echo "current db_database is " . Config::get('db_database') . "\n";
+
+$tbl_transfers = call_user_func('Transfer::getDBTable');
+
+$sql = "update ". $tbl_transfers . " t set download_count = (select coalesce(count,0) as count from transfersauditlogsdlcountview tv where tv.id = t.id);";
+$s = DBI::prepare($sql);
+$s->execute(array());
+
+echo "done.\n";


### PR DESCRIPTION
Each time a file is downloaded the download_count in transfers is incremented. This allow very quick sorting by downloads in the transfers table. 

Note that this requires the values to be brought forward with the explicit database script at scripts/upgrade/explicit/upgrade-2.48-to-2.49-post-download-count.php if you want the counts to be set correctly after an upgrade.

This relates to https://github.com/filesender/filesender/issues/1888.