### PR TITLE
option to precache values for upload graph

### DIFF
--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -85,6 +85,7 @@ class Autoloader
         'AVResult' => 'data/',
         'DownloadOneTimePassword' => 'data/',
         'RateLimitHistory' => 'data/',
+        'UploadGraph' => 'data/',
         
         'AVProgram*' => 'avprograms/',
         

--- a/classes/data/UploadGraph.class.php
+++ b/classes/data/UploadGraph.class.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2024, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *    Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * *    Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * *    Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+
+    
+/**
+ * Upload graph statistics for display to users
+ */
+class UploadGraph extends DBObject
+{
+    /**
+     * Database map
+     */
+    protected static $dataMap = array(
+        'id' => array(
+            'type' => 'uint',
+            'size' => 'big',
+            'primary' => true,
+            'autoinc' => true
+        ),
+        'date' => array(
+            'type' => 'datetime'
+        ),
+        'speed' => array(
+            'type' => 'numeric',
+            'null' => true,
+        ),
+        'enspeed' => array(
+            'type' => 'numeric',
+            'null' => true,
+        ),
+        'count' => array(
+            'type' => 'numeric',
+            'null' => true,
+        ),
+        'encount' => array(
+            'type' => 'numeric',
+            'null' => true,
+        ),
+    );
+
+    
+
+    protected static $secondaryIndexMap = array(
+        'date' => array(
+            'date' => array()
+        )
+    );
+    
+    
+    /**
+     * Properties
+     */
+    protected $id                  = null;
+    protected $date                = null;
+    protected $speed               = 0;
+    protected $enspeed             = 0;
+    protected $count               = 0;
+    protected $encount             = 0;
+
+    /**
+     * Constructor
+     *
+     * @param integer $id identifier of object to load from database (null if loading not wanted)
+     * @param array $data data to create the object from (if already fetched from database)
+     *
+     * @throws UserNotFoundException
+     */
+    protected function __construct($id = null, $data = null)
+    {
+        if (!is_null($id)) {
+            // Load from database if id given
+            $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE id = :id');
+            $statement->execute(array(':id' => $id));
+            $data = $statement->fetch();
+            $this->id = $id;
+        }
+        
+        if ($data) {
+            // Fill properties from provided data
+            $this->fillFromDBData($data);
+        } else {
+            // New user, set base data
+            $this->id = $id;
+            $this->date = time();
+        }
+    }
+
+    /**
+     * Create a new UploadGraph record
+     *
+     * @return UploadGraph
+     */
+    public static function create( $date, $speed, $enspeed, $count, $encount )
+    {
+        $r = new self();
+        $r->date = $date;
+        $r->speed = $speed;
+        $r->enspeed = $enspeed;
+        $r->count = $count;
+        $r->encount = $encount;
+        return $r;
+    }
+
+    
+    public function __get($property)
+    {
+        if (in_array($property, array(
+            'id', 'date'
+          , 'speed', 'enspeed'
+          , 'count', 'encount'
+        ))) {
+            return $this->$property;
+        }
+        
+        throw new PropertyAccessException($this, $property);
+    }
+    
+
+    public static function update()
+    {
+        DBI::beginTransaction();
+
+        
+
+        $statement = DBI::prepare('delete from ' . self::getDBTable() );
+        $statement->execute(array());
+        
+        $minSz = Config::get('upload_graph_bulk_min_file_size_to_consider');
+
+        $encO = Config::get('encryption_mandatory');
+        $encF = 'additional_attributes LIKE \'%\"encryption\":false%\'';
+        $encT = 'additional_attributes LIKE \'%\"encryption\":true%\'';
+        
+        $sql =
+            ' INSERT INTO ' . self::getDBTable() . ' (date,speed,enspeed,count,encount) ' 
+            . ' SELECT days.date as date, speed.speed as speed, speed.enspeed as enspeed, speed.count as count, speed.encount as encount '
+            . 'FROM (SELECT (SELECT Date(NOW() - INTERVAL \'30\' DAY)) + '
+          . DBLayer::toIntervalDays("a+b") . ' date '
+                   . '        FROM (SELECT 0 a UNION SELECT 1 a UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 '
+                   . '                     UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9 ) d, '
+                   . '             (SELECT 0 b UNION SELECT 10 UNION SELECT 20 UNION SELECT 30 UNION SELECT 40) m '
+                   . '        WHERE (SELECT Date(NOW() - INTERVAL \'30\' DAY)) + '
+                   . DBLayer::toIntervalDays("a+b") . ' <= (select date(now())) '
+                            . '        ORDER BY a + b) as days LEFT '
+                            . ' JOIN (SELECT DATE(created) as date, '
+                             .($encO ? '0 as speed, ' : '   AVG(case WHEN time_taken > 0 AND ' . $encF . ' THEN size/time_taken ELSE null END) as speed, ' )
+                            . '   AVG(case WHEN time_taken > 0 AND ' . $encT . ' THEN size/time_taken ELSE null END) as enspeed, '
+                             .($encO ? '0 as count, ' : '   AVG(case WHEN ' . $encF . ' THEN id ELSE null END) as count, ' )
+                            . '   AVG(case WHEN ' . $encT . ' THEN id ELSE null END) as encount '
+                            . '       from StatLogs '
+                            . '      WHERE event=\'file_uploaded\' '
+                            . '            AND created>NOW() - INTERVAL \'31\' DAY '
+                            . '            AND size > ' . $minSz . ' '
+                            . '      GROUP BY Date) as speed on days.date=speed.date '
+                            . ' ORDER BY days.date';
+
+        $statement = DBI::prepare($sql);
+        $statement->execute(array());
+
+        DBI::commit();
+        
+    }
+    
+    public static function cleanup()
+    {
+    }
+
+    
+}
+
+    

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -209,6 +209,7 @@ A note about colours;
 
 * [upload_graph_bulk_display](#upload_graph_bulk_display)
 * [upload_graph_bulk_min_file_size_to_consider](#upload_graph_bulk_min_file_size_to_consider)
+* [upload_graph_use_cache_table](#upload_graph_use_cache_table)
 
 ## TeraSender (high speed upload module)
 
@@ -2310,6 +2311,15 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __available:__ since version 2.0
 * __comment:__ only useful when you enable upload_graph_bulk_display
 
+
+### upload_graph_use_cache_table
+
+* __description:__ Use a cache table to present the upload speed graphs
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.49
+* __comment:__ If you enable this option you will need to schedule scripts/task/update-upload-graph-table.php to execute periodically to update the cache table. This can be useful on very large installations.
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -211,7 +211,7 @@ $default = array(
 
     'upload_graph_bulk_display' => true, 
     'upload_graph_bulk_min_file_size_to_consider' => 1024*1024*1024, 
-
+    'upload_graph_use_cache_table' => false,
 
     'support_email' => '',
 

--- a/scripts/task/update-upload-graph-table.php
+++ b/scripts/task/update-upload-graph-table.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ * 
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURFnet, UNINETT
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURFnet and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+require_once(dirname(__FILE__).'/../../includes/init.php');
+
+Logger::setProcess(ProcessTypes::CRON);
+Logger::info('Cron started');
+
+UploadGraph::update();


### PR DESCRIPTION
A new option that, when enabled, allows the upload graph to used cached data in the database rather than executing a more complex query each time the upload page is loaded.

Using this option requires you to run `scripts/task/update-upload-graph-table.php` in order to keep the cached data up to date. This can mean one execution every 15 minutes, hour, or whatnot instead of one execution for each load of the upload page.

This relates to https://github.com/filesender/filesender/issues/1887.