### PR TITLE
Fix mime types

### DIFF
--- a/classes/rest/RestRequest.class.php
+++ b/classes/rest/RestRequest.class.php
@@ -97,8 +97,6 @@ class RestInput
      */
     private $data = array();
 
-    public $mime_type = '';
-    
     /**
      * Recursive crawler that converts raw data into browsable data
      *


### PR DESCRIPTION
This extra var was effectively ignoring mime_type from web browser eg:

```
Array
(
    [0] => RestInput Object
        (
            [data:RestInput:private] => Array
                (
                    [name] => s-l1600.jpg
                    [size] => 141657
                    [mime_type] => image\/jpeg
                    [cid] => file_1715649373497_11_141657_679143
                    [aead] =>
                )

            [mime_type] =>
        )

)
```

the mimetype on the bottom is always blank. and code in classes/rest/endpoints/RestEndpointTransfer.class.php `$filedata->mime_type` is always empty thus ignoring the image/jpeg above.