### PR TITLE
ui: option to warn user if session has expired

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -92,7 +92,8 @@ class AuthSPSaml
             if (!self::isAuthenticated()) {
                 throw new AuthSPAuthenticationNotFoundException();
             }
-            
+
+            $ssp = self::loadSimpleSAML();
             $raw_attributes = self::loadSimpleSAML()->getAttributes();
             
             $attributes = array();
@@ -177,6 +178,29 @@ class AuthSPSaml
                     }
                     
                     $attributes['additional'][is_numeric($key) ? $from : $key] = $value;
+                }
+            }
+
+            //
+            // Let the javascript warn the user of possible end of session time
+            //
+            if( Config::get('auth_warn_expire_time')) {
+                if ($v = $ssp->getAuthData('Expire')) {
+                    if( !headers_sent()) {
+                        // Unset the PHPSESSID cookie, so that the user will get a new session ID on their next request.
+                        $params = session_get_cookie_params();
+                        
+                        setcookie(
+                            'X-FileSender-Session-Expires',
+                            $v,
+                            0,
+                            "/",
+                            Config::get('cookie_domain'),
+                            false, // $params['secure'],
+                            false, // $params['httponly']
+                        );
+                        
+                    }
                 }
             }
             

--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -184,7 +184,7 @@ class AuthSPSaml
             //
             // Let the javascript warn the user of possible end of session time
             //
-            if( Config::get('auth_warn_expire_time')) {
+            if( Config::get('auth_warn_session_expired')) {
                 if ($v = $ssp->getAuthData('Expire')) {
                     if( !headers_sent()) {
                         // Unset the PHPSESSID cookie, so that the user will get a new session ID on their next request.

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -258,7 +258,8 @@ A note about colours;
 	* [auth_sp_saml_uid_attribute](#auth_sp_saml_uid_attribute)
 	* [auth_sp_saml_entitlement_attribute](#auth_sp_saml_entitlement_attribute)
 	* [auth_sp_saml_admin_entitlement](#auth_sp_saml_admin_entitlement)
-        * [using_local_saml_dbauth](#using_local_saml_dbauth)
+    * [using_local_saml_dbauth](#using_local_saml_dbauth)
+    * [auth_warn_expire_time](#auth_warn_expire_time)
 * __Shibboleth__
 	* [auth_sp_shibboleth_uid_attribute](#auth_sp_shibboleth_uid_attribute)
 	* [auth_sp_shibboleth_email_attribute](#auth_sp_shibboleth_email_attribute)
@@ -2776,6 +2777,17 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __default:__ 0
 * __available:__ since version 2.16
 * __comment:__ 
+
+
+### auth_warn_expire_time
+
+* __description:__ When turned on the expire time for SAML sessions is sent to the browser so the user can be warned when the session has expired.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ false
+* __available:__ since version 2.49
+* __comment:__ Note: enabling this setting will use a cookie X-FileSender-Session-Expires to support the functionality. 
+               The warning does not happen during an upload because the session may expire there and the upload can still complete.
 
 
 

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -259,7 +259,7 @@ A note about colours;
 	* [auth_sp_saml_entitlement_attribute](#auth_sp_saml_entitlement_attribute)
 	* [auth_sp_saml_admin_entitlement](#auth_sp_saml_admin_entitlement)
     * [using_local_saml_dbauth](#using_local_saml_dbauth)
-    * [auth_warn_expire_time](#auth_warn_expire_time)
+    * [auth_warn_session_expired](#auth_warn_session_expired)
 * __Shibboleth__
 	* [auth_sp_shibboleth_uid_attribute](#auth_sp_shibboleth_uid_attribute)
 	* [auth_sp_shibboleth_email_attribute](#auth_sp_shibboleth_email_attribute)
@@ -2779,7 +2779,7 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __comment:__ 
 
 
-### auth_warn_expire_time
+### auth_warn_session_expired
 
 * __description:__ When turned on the expire time for SAML sessions is sent to the browser so the user can be warned when the session has expired.
 * __mandatory:__ no

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -69,7 +69,7 @@ $default = array(
     'auth_remote_user_autogenerate_secret' => false,
     'auth_remote_signature_algorithm' => 'sha1',
 
-    'auth_warn_expire_time' => false,
+    'auth_warn_session_expired' => false,
 
     'auth_remote_user_enabled' => false, //disables remote user auth
     

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -69,6 +69,8 @@ $default = array(
     'auth_remote_user_autogenerate_secret' => false,
     'auth_remote_signature_algorithm' => 'sha1',
 
+    'auth_warn_expire_time' => false,
+
     'auth_remote_user_enabled' => false, //disables remote user auth
     
     'aup_default' => false,

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -710,3 +710,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['session_expired_warning'] = 'Your session has expired. Please logon to contiunue.';

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -178,6 +178,7 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
                 , download_complete:       "<?php echo Lang::tr('download_complete')->out(); ?>"
 /**/            , download_chunk_progress: "<?php echo Lang::tr('download_chunk_progress')->out(); ?>"
                 , file_not_found:          "<?php echo Lang::tr('file_not_found')->out(); ?>"
+                , session_expired_warning: "<?php echo Lang::tr('session_expired_warning')->out(); ?>"
 	},
     
     clientlogs: {
@@ -207,6 +208,8 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
     encryption_password_must_have_special_characters: <?php echo value_to_TF(Config::get('encryption_password_must_have_special_characters')) ?>,
 
     download_verification_code_enabled: <?php echo value_to_TF(Config::get('download_verification_code_enabled')) ?>,
+
+    auth_warn_expire_time: <?php echo value_to_TF(Config::get('auth_warn_expire_time')) ?>,
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -209,7 +209,7 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
 
     download_verification_code_enabled: <?php echo value_to_TF(Config::get('download_verification_code_enabled')) ?>,
 
-    auth_warn_expire_time: <?php echo value_to_TF(Config::get('auth_warn_expire_time')) ?>,
+    auth_warn_session_expired: <?php echo value_to_TF(Config::get('auth_warn_session_expired')) ?>,
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -708,7 +708,7 @@ $(function() {
         $(".download_decryption_disabled").show();
     }
 
-    if( window.filesender.config.auth_warn_expire_time ) {
+    if( window.filesender.config.auth_warn_session_expired ) {
 
         var sessionExpires = getCookie('X-FileSender-Session-Expires');
         if( !sessionExpires ) {

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -41,6 +41,8 @@ if(!('filesender' in window)) window.filesender = {};
  * UI methods
  */
 window.filesender.ui = {
+    uploading: false,
+    
     /**
      * Log to console if enabled
      * 
@@ -657,6 +659,14 @@ window.filesender.ui = {
     
 };
 
+function getCookie( name ) {
+    const cookieValue = document.cookie
+          .split("; ")
+          .find((row) => row.startsWith(name + "="))
+    ?.split("=")[1];
+    return cookieValue;
+}
+
 $(function() {
     $('#topmenu_help[href="#"]').on('click', function() {
         $('#dialog-help').dialog({
@@ -697,4 +707,31 @@ $(function() {
         $(".files.box .file[data-encrypted='1'] .download").hide();
         $(".download_decryption_disabled").show();
     }
+
+    if( window.filesender.config.auth_warn_expire_time ) {
+
+        var sessionExpires = getCookie('X-FileSender-Session-Expires');
+        if( !sessionExpires ) {
+            return;
+        }
+        const n = Math.floor(Date.now() / 1000);
+        console.log("session expire check, top cookie:" + sessionExpires + " n " + n + " time to go " + (sessionExpires-n) );
+        const timeout = (sessionExpires-n);
+        console.log("session expire check, timeout function in " + timeout );
+
+        window.filesender.ui.check_expired = window.setTimeout(function() {
+            console.log("session expire check: your session has expired!");
+            document.cookie = "X-FileSender-Session-Expires=0;path=/;";
+
+            if( window.filesender.ui.uploading ) {
+                console.log("session expire check: user is uploading, not showing warning about session expired");
+            } else {
+                window.filesender.ui.alert('info', filesender.config.language.session_expired_warning, function() {
+                    window.filesender.ui.reload();
+                });
+            }
+        }, timeout * 1000  );
+        
+    }
+    
 });

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1088,6 +1088,7 @@ filesender.ui.cancelAutomaticResume = function() {
 
 filesender.ui.startUpload = function() {
 
+    window.filesender.ui.uploading = true;
     this.transfer.encryption = filesender.ui.nodes.encryption.toggle.is(':checked'); 
     this.transfer.encryption_password = filesender.ui.nodes.encryption.password.val();
     this.transfer.disable_terasender = filesender.ui.nodes.disable_terasender.is(':checked');
@@ -1168,6 +1169,7 @@ filesender.ui.startUpload = function() {
     
     this.transfer.oncomplete = function(time) {
 
+        window.filesender.ui.uploading = false;       
         filesender.ui.files.clear_crust_meter_all();
         window.filesender.pbkdf2dialog.ensure_onPBKDF2AllEnded();
 


### PR DESCRIPTION
For SAML sessions, when the new `auth_warn_session_expired` feature is enabled a cookie is used to allow the client to warn the user when their session has expired. This warning is not presented when an upload is in progress because an upload can outlive a session in order to complete.

This relates to https://github.com/filesender/filesender/issues/1881