### PR TITLE
ui3d3: bootbox button colours match theme

### DIFF
--- a/www/css/new-ui/components/_buttons.css
+++ b/www/css/new-ui/components/_buttons.css
@@ -100,17 +100,17 @@
 
 .fs-button--success {
   color: var(--fs-light);
-  background: var(--fs-success);
+  background: var(--fs-btn);
 }
 
 .fs-button--success:hover {
-  background: var(--fs-success-hover) !important;
   color: var(--fs-light) !important;
+  background: var(--fs-btn-hover);
 }
 
 .fs-button--success:active {
-  background: var(--fs-success-active) !important;
   color: var(--fs-light) !important;
+  background: var(--fs-btn-active) !important;
 }
 
 .fs-button--success:disabled,

--- a/www/css/themes/dark.css
+++ b/www/css/themes/dark.css
@@ -38,6 +38,7 @@
 
     --fs-hover: #bb86fc;
 
+    --fs-btn: #3700b3;
     --fs-btn-hover: #3700b3;
     --fs-btn-active: #C08FFB;
 

--- a/www/css/themes/default.css
+++ b/www/css/themes/default.css
@@ -38,6 +38,7 @@
 
     --fs-hover: #DCE3F2;
 
+    --fs-btn:  var(--fs-blue);
     --fs-btn-hover: #3E6DC1;
     --fs-btn-active: #81A0D6;
 


### PR DESCRIPTION
This relates to https://github.com/filesender/filesender/issues/1851

If green doesn't mean go in the main theme then it shouldn't be that in the dialogs.