### PR TITLE
Only run CI on non-forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
 
   build:
+    if: github.repository == 'filesender/filesender'
     name: ${{ matrix.testsuite }}-${{ matrix.db }}
     runs-on: Ubuntu-20.04
     needs: metadata

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on: [ pull_request_target ]
 
 jobs:
   add_comment_pr:
+    if: github.repository == "filesender/filesender"
     runs-on: ubuntu-latest
     name: Add link to selenium testing repo as a comment on PRs
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on: [ pull_request_target ]
 
 jobs:
   add_comment_pr:
-    if: github.repository == "filesender/filesender"
+    if: github.repository == 'filesender/filesender'
     runs-on: ubuntu-latest
     name: Add link to selenium testing repo as a comment on PRs
     steps:

--- a/.github/workflows/sq.yml
+++ b/.github/workflows/sq.yml
@@ -2,7 +2,7 @@ name: SonarQube CI
 on: push
 jobs:
   sonarQubeTrigger:
-    if: github.repository == "filesender/filesender"
+    if: github.repository == 'filesender/filesender'
     name: SonarQube Trigger
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sq.yml
+++ b/.github/workflows/sq.yml
@@ -2,6 +2,7 @@ name: SonarQube CI
 on: push
 jobs:
   sonarQubeTrigger:
+    if: github.repository == "filesender/filesender"
     name: SonarQube Trigger
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently CI runs on all forks, even if it does not make any sense for it to do so.
It would make sense if we add linting to CI, so we can check if everything is at least valid php/css/etc, but currently we try to do all kinds of checks where secrets are absent for selenium, sq, etc.

Let's be friendly to our kind hosters (and the environment!) and not waste CPU cycles.