### PR TITLE
db: add index on TranslatableEmails.token

### DIFF
--- a/classes/data/TranslatableEmail.class.php
+++ b/classes/data/TranslatableEmail.class.php
@@ -87,6 +87,12 @@ class TranslatableEmail extends DBObject
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a );
     }
+
+    protected static $secondaryIndexMap = array(
+        'token' => array(
+            'token' => array()
+        )
+    );
     
     /**
      * Properties


### PR DESCRIPTION
This was raised in https://github.com/filesender/filesender/issues/1916. Normally one would not have as many tuples as in that issue but even with fewer tuples and index here will increase efficiency, especially for selecting single tuples from the table.
