### PR TITLE
Bring back configurable site_logo from v2

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -210,9 +210,10 @@ class GUI
     public static function logo()
     {
         $locations = self::filterSources(array(
-            'images/logo.png',
-            'skin/logo.png',
-            Config::get('site_logo')
+	    'images/logo.png',
+	    'images/filesender-logo.svg',
+	    'skin/logo.png',
+	    Config::get('site_logo')
         ));
 
         return array_pop($locations);
@@ -228,7 +229,7 @@ class GUI
             return;
         }
 
-        echo '<img id="logo" src="'.self::path($location).'" alt="'.Config::get('site_name').'" />'."\n";
+        echo '<img id="logo" class="fs-link fs-link--no-hover" src="'.self::path($location).'" alt="'.Config::get('site_name').'" />'."\n";
     }
 
     /**

--- a/templates/menu.php
+++ b/templates/menu.php
@@ -16,8 +16,8 @@ if(Config::get('lang_selector_enabled') && (count(Lang::getAvailableLanguages())
 <header>
 
     <nav>
-        <a class="fs-link fs-link--no-hover" href="{cfg:site_url}">
-            <img src="{cfg:site_url}images/filesender-logo.svg" alt="Filesender Logo">
+        <a class="fs-link fs-link--no-hover" href="<?php echo GUI::path() ?>">
+            <?php GUI::includeLogo() ?>
         </a>
         <ul>
             <?php


### PR DESCRIPTION
Adds back logo behaviour from UI2
Fixes #1552

Possibly the styling in https://github.com/filesender/filesender/blob/bf00c8e4bf123f6964781f30d0e81945a09262ed/classes/utils/GUI.class.php#L232 could be done better, but I'm no CSS king.