### PR TITLE
Limit CI runs on development branches as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
 
   build:
+    if: github.repository == 'filesender/filesender'
     name: ${{ matrix.testsuite }}-${{ matrix.db }}
     runs-on: Ubuntu-20.04
     needs: metadata

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on: [ pull_request_target ]
 
 jobs:
   add_comment_pr:
+    if: github.repository == 'filesender/filesender'
     runs-on: ubuntu-latest
     name: Add link to selenium testing repo as a comment on PRs
     steps:


### PR DESCRIPTION
After #1914 limiting runs on master, it may make sense to activate this on the default branch as well