### PR TITLE
ui3: allow direct actions for recipients on the transfer details page

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -18,7 +18,7 @@ if ($transfer_id) {
 $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
 ?>
 
-<div class="fs-transfer-detail"
+<div class="fs-transfer-detail transfer_details"
      id="transfer_<?php echo $transfer->id ?>"
      data-id="<?php echo $transfer->id ?>"
      data-status="<?php echo $transfer->status ?>"
@@ -191,9 +191,9 @@ $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
                                 Your transfer has been sent to the following email addresses
                             </span>
 
-                            <div class="fs-badge-list">
+                            <div class="fs-badge-buttons-list recipients">
                                 <?php foreach($transfer->recipients as $recipient) { ?>
-                                    <div class="fs-badge" data-id="<?php echo $recipient->id ?>" data-email="<?php echo Template::sanitizeOutputEmail($recipient->email) ?>" data-errors="<?php echo count($recipient->errors) ? '1' : '' ?>">
+                                    <div class="fs-badge-buttons recipient" data-id="<?php echo $recipient->id ?>" data-email="<?php echo Template::sanitizeOutputEmail($recipient->email) ?>" data-errors="<?php echo count($recipient->errors) ? '1' : '' ?>">
                                         <?php
                                         if(in_array($recipient->email, Auth::user()->email_addresses)) {
                                             echo '<abbr title="'.Template::sanitizeOutputEmail($recipient->email).'">'.Lang::tr('me').'</abbr>';
@@ -201,6 +201,13 @@ $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
                                             echo '<span>'.Template::sanitizeOutput($recipient->identity).'</span>';
                                         }
                                         ?>
+
+                                        <span class="fs-badge-buttons-shell" >
+                                            <span data-action="remind" class="fa    fa-lg fa-repeat" title="{tr:send_reminder}"></span>
+                                            <span data-action="delete" class="fa    fa-lg fa-trash-o" title="{tr:delete}"></span>
+                                            <span data-action="auditlog" class="fa  fa-lg fa-history" title="{tr:open_recipient_auditlog}"></span>
+                                        </span>
+                                        
                                     </div>
                                 <?php } ?>
 

--- a/www/css/new-ui/components/_badge.css
+++ b/www/css/new-ui/components/_badge.css
@@ -37,3 +37,48 @@
   margin-right: var(--fs-spacing-base);
   margin-bottom: var(--fs-spacing-2x);
 }
+
+
+.fs-badge-buttons-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-top: var(--fs-spacing-2x);
+}
+
+.fs-badge-buttons {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--fs-accent);
+  border-radius: var(--fs-spacing-4x);
+  height: var(--fs-spacing-5x);
+  padding: 0 var(--fs-spacing-2x);
+  text-align: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  width: auto;
+  color: var(--fs-accent);
+  background: var(--fs-hightlight-bg);
+  margin-right: var(--fs-spacing-base);
+  margin-bottom: var(--fs-spacing-2x);
+}
+
+.fs-badge-buttons-shell {
+  padding: 0 var(--fs-spacing-2x);
+}
+
+.fs-badge-buttons a {
+  font-size: 1rem !important;
+  color: var(--fs-accent) !important;
+  text-decoration: none !important;
+}
+
+.fs-badge-buttons-listx .fs-button {
+  border-radius: var(--fs-spacing-4x);
+  height: var(--fs-spacing-4x);
+  padding: 0 var(--fs-spacing-2x);
+  margin-right: var(--fs-spacing-base);
+  margin-bottom: var(--fs-spacing-2x);
+}

--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -33,7 +33,7 @@
 $(function() {
 
     // Transfer delete buttons
-    $('.fs-transfer-detail [data-action="delete"]').on('click', function() {
+    $('.fs-transfer-detail .fs-transfer-detail__actions [data-action="delete"]').on('click', function() {
         var id = $(this).closest('.fs-transfer-detail').attr('data-id');
         if(!id || isNaN(id)) return;
 
@@ -278,9 +278,9 @@ $(function() {
     });
 
     // Remind buttons
-    $('[data-recipients-enabled=""] [data-action="remind"]').addClass('disabled');
+    $('[data-recipients-enabled=""] .fs-transfer-detail__actions [data-action="remind"]').addClass('disabled');
 
-    $('[data-recipients-enabled="1"] [data-action="remind"]').on('click', function() {
+    $('[data-recipients-enabled="1"] .fs-transfer-detail__actions [data-action="remind"]').on('click', function() {
         var id = $(this).closest('.fs-transfer-detail').attr('data-id');
         if(!id || isNaN(id)) return;
 
@@ -291,6 +291,43 @@ $(function() {
         });
     });
 
+    $('.transfer_details .recipient [data-action="remind"]').on('click', function() {
+        var rcpt = $(this).closest('.recipient');
+        var id = rcpt.attr('data-id');
+        if(!id || isNaN(id)) return;
+        
+        filesender.ui.confirm(lang.tr('confirm_remind_recipient'), function() {
+            filesender.client.remindRecipient(id, function() {
+                filesender.ui.notify('success', lang.tr('recipient_reminded'));
+            });
+        });
+    });
+    
+    $('.transfer_details .recipient [data-action="delete"]').on('click', function() {
+        var rcpt = $(this).closest('.recipient');
+        var id = rcpt.attr('data-id');
+        var transfer = rcpt.closest('.transfer_details');
+        if(!id || isNaN(id)) return;
+        
+        filesender.ui.confirm(lang.tr('confirm_delete_recipient'), function() {
+            filesender.client.deleteRecipient(id, function() {
+                rcpt.remove();
+                if(!transfer.find('.recipients .recipient').length) {
+                    transfer.prev('.transfer').remove();
+                    transfer.remove();
+                }
+                filesender.ui.notify('success', lang.tr('recipient_deleted'));
+            });
+        });
+    });
+
+    $('.transfer_details .recipient [data-action="auditlog"]').on('click', function(e) {
+        var trid = $(this).closest('.transfer_details').attr('data-id');
+        var rid  = $(this).closest('.recipient').attr('data-id');
+        auditlogs(trid, 'author/recipient/' + rid);
+    });
+    
+    
     // Copy download link
     const copyToClipboard = (value) => {
         navigator.clipboard.writeText(value).then((x) => {


### PR DESCRIPTION
The lack of these buttons in ui3 was reported in https://github.com/filesender/filesender/issues/1923.

This PR also adds back an extremely tiny bit of semantic classes for example the recipients having a class of recipient.
