### PR TITLE
ui3: bring back quick actions for transfer list

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -148,9 +148,9 @@
             <?php clickableHeader('{tr:expires}',TransferQueryOrder::COLUMN_EXPIRES,$trsort,$nosort); ?>
         </th>
 
-<!--        <th>-->
-<!--            {tr:actions}-->
-<!--        </th>-->
+       <th class="actions">
+           {tr:actions}
+       </th>
     </tr>
     </thead>
     <tbody>
@@ -240,6 +240,20 @@
             <td data-label="{tr:expires}">
                 <?php echo Utilities::formatDate($transfer->expires) ?>
             </td>
+
+            <td class="actions">
+                <div id="marg3">
+                    <span data-action="delete" class="fa fa-lg fa-trash-o" title="{tr:delete}"></span>
+                    <?php if($extend) { ?><span data-action="extend" class="fa fa-lg fa-calendar-plus-o"></span><?php } ?>
+                    <span data-action="add_recipient" class="fa fa-lg fa-envelope-o" title="{tr:add_recipient}"></span>
+                </div>
+                <div id="marg3">
+                    <span data-action="remind" class="fa fa-lg fa-repeat" title="{tr:send_reminder}"></span>
+                    <?php if($audit)           { ?><span data-action="auditlog"      class="fa fa-lg fa-history" title="{tr:open_auditlog}"></span><?php } ?>
+                    <?php if($showAdminExtend) { ?><span data-action="extendexpires" class="fa fa-lg fa-clock-o adminaction" title="{tr:extend_expires}"></span><?php } ?>
+                </div>
+            </td>
+            
         </tr>
     <?php } ?>
 

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -38,10 +38,11 @@ $(function() {
 
 
     // Transfer delete buttons
-    $('.actions [data-action="delete"]').on('click', function() {
+    $('.actions [data-action="delete"]').on('click', function(event) {
         var id = $(this).closest('[data-transfer]').attr('data-id');
         if(!id || isNaN(id)) return;
-
+        event.stopPropagation();
+        
         console.log("BBB delete");
         if($(this).closest('table').is('[data-mode="user"][data-status="available"]')) {
         console.log("BBB delete2");
@@ -93,7 +94,8 @@ $(function() {
                 days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
             })
         });
-    }).on('click', function() {
+    }).on('click', function(event) {
+        event.stopPropagation();
         filesender.ui.extendExpires( $(this), 'transfer');
     });
 
@@ -103,7 +105,8 @@ $(function() {
                 days: $(this).closest('[data-transfer]').attr('data-expiry-extension')
             })
         });
-    }).on('click', function() {
+    }).on('click', function(event) {
+        event.stopPropagation();
         filesender.ui.extendExpires( $(this), 'transfer');
     });
 
@@ -112,9 +115,10 @@ $(function() {
     // Add recipient buttons
     $('[data-recipients-enabled=""] [data-action="add_recipient"]').addClass('disabled');
 
-    $('[data-recipients-enabled="1"] [data-action="add_recipient"]').on('click', function() {
+    $('[data-recipients-enabled="1"] [data-action="add_recipient"]').on('click', function(event) {
         var id = $(this).closest('[data-transfer]').attr('data-id');
         if(!id || isNaN(id)) return;
+        event.stopPropagation();
 
         var recipients = [];
         $('.transfer_details[data-id="' + id + '"] .recipients .recipient').each(function() {
@@ -178,7 +182,6 @@ $(function() {
                 });
             }
 
-            return true;
         })
 
         prompt.append('<p>' + lang.tr('email_separator_msg') + '</p>');
@@ -187,9 +190,10 @@ $(function() {
     // Remind buttons
     $('[data-recipients-enabled=""] .actions [data-action="remind"]').addClass('disabled');
 
-    $('[data-recipients-enabled="1"] .actions [data-action="remind"]').on('click', function() {
+    $('[data-recipients-enabled="1"] .actions [data-action="remind"]').on('click', function(event) {
         var id = $(this).closest('[data-transfer]').attr('data-id');
         if(!id || isNaN(id)) return;
+        event.stopPropagation();
 
         filesender.ui.confirm(lang.tr('confirm_remind_transfer'), function() {
             filesender.client.remindTransfer(id, function() {
@@ -200,9 +204,10 @@ $(function() {
 
 
     // Transfer options
-    $('.transfer_options [data-action="remove"]').on('click', function() {
+    $('.transfer_options [data-action="remove"]').on('click', function(event) {
         var id = $(this).closest('[data-transfer]').attr('data-id');
         if(!id || isNaN(id)) return;
+        event.stopPropagation();
 
         filesender.ui.confirm(lang.tr('confirm_remove_daily_stats_transfer'), function() {
             filesender.client.removeTransferOption(id, 'email_daily_statistics', function() {
@@ -213,11 +218,12 @@ $(function() {
 
 
     // File download buttons when the files are encrypted
-    $('.transfer-download').on('click', function () {
+    $('.transfer-download').on('click', function (event) {
 
         if(!filesender.supports.crypto){
             return;
         }
+        event.stopPropagation();
 
         var transferid = $(this).attr('data-transferid');
         var id = $(this).attr('data-id');
@@ -352,11 +358,13 @@ $(function() {
     };
 
     $('[data-transfer] .auditlog a').button().on('click', function(e) {
+        e.stopPropagation();
         auditlogs($(this).closest('tr').attr('data-id'));
     });
 
 
     $('[data-action="auditlog"]').not('.transfer_details .file [data-action="auditlog"]').on('click', function(e) {
+        e.stopPropagation();
         auditlogs($(this).closest('tr').attr('data-id'));
     });
 


### PR DESCRIPTION
This is in response to https://github.com/filesender/filesender/issues/1924

These UI items may need to be hidden in a "non advanced" mode as they were removed by UI experts and requested to be returned by an NREN.
