### PR TITLE
ui3 info icon in transfer list to hint at clickable

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -261,6 +261,7 @@ EOF;
                     makeAction("delete", "fs-button--danger delete", "{tr:delete_invitation}", "fa-trash" );  
                     if($extend) { makeAction("extend", "", "", "fa-calendar-plus-o" ); }  
                     makeAction("add_recipient", "", "{tr:add_recipient}", "fa-envelope-o" );
+                    makeAction("details", "", "{tr:details}", "fa-info" );
                     
                     ?>
                 </div>


### PR DESCRIPTION
some reports indicate that the transfer list is not obvious it can be clicked. This adds a fake icon to allow a hint to click.