### PR TITLE
Fix undef HTTP_ACCEPT_LANGUAGE warning

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -259,6 +259,10 @@ class Lang
      */
     public static function getUserAcceptedLanguages()
     {
+        if(!isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+            return array();
+        }
+
         $stack = array();
         $codes = array();
         


### PR DESCRIPTION
Probably when trying out the [FileSenderCli](https://github.com/WEHI-ResearchComputing/FileSenderCli) these warnings appeared in my web server error log:

```
Undefined array key "HTTP_ACCEPT_LANGUAGE" in /opt/filesender/classes/utils/Lang.class.php on line 265
```
The only call to `Lang::getUserAcceptedLanguages()` is from `formatDate()` in classes/utils/Utilities.class.php that then iterates over the result `foreach ($al as $k => $v)` so I guess returning an empty array in the pathological case makes sense.