### PR TITLE
ui3: leave some space between the progressbar text and bar

### DIFF
--- a/www/css/new-ui/components/_progress-bar.css
+++ b/www/css/new-ui/components/_progress-bar.css
@@ -6,7 +6,7 @@
 }
 
 .fs-progress-bar__value {
-  width: var(--fs-spacing-6x);
+  width: var(--fs-spacing-7x);
 }
 
 .fs-progress-bar__value + .fs-progress-bar__indicator {


### PR DESCRIPTION
Running these together does have an 1980s retro look but having some space between them makes it seem more planned out.