### PR TITLE
UI3: handle directory_issue in drag and drop

### DIFF
--- a/www/js/dragdrop-dirtree.js
+++ b/www/js/dragdrop-dirtree.js
@@ -63,7 +63,7 @@ filesender.dragdrop = {
                 this.alert = filesender.ui.alert;
                 errorhandler = filesender.ui.error;
                 errorhandler({ message: 'directory_issue',
-                               details: { path: item.name }});
+                               details: { storage_paths: item.name }});
             });
         }
     },

--- a/www/js/dragdrop-dirtree.js
+++ b/www/js/dragdrop-dirtree.js
@@ -56,7 +56,15 @@ filesender.dragdrop = {
                 dirReader.readEntries( handleitems );
             };
                 
-            dirReader.readEntries(handleitems);
+            dirReader.readEntries(handleitems,function(error){
+                this.log = function(message) {
+                    filesender.ui.log(message);
+                };
+                this.alert = filesender.ui.alert;
+                errorhandler = filesender.ui.error;
+                errorhandler({ message: 'directory_issue',
+                               details: { path: item.name }});
+            });
         }
     },
 

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -594,14 +594,14 @@ window.filesender.ui = {
         }
 
         if(error.details) {
-            msgtail += '<div class="details" />';
             $.each(error.details, function(k, v) {
-                if(isNaN(k)) v = lang.tr(k) + ': ' + v;
-                msgtail += '<div class="detail" />';
+                msgtail += '<div class="details">';
+                if (!isNaN(k)) msgtail += lang.tr(k) + ': ';
+                msgtail +=  v + '</div>';
             });
         }
 
-        msgtail += '<div class="report" />';
+        msgtail += '<div class="report">';
         if(filesender.config.support_email) {
             msgtail += lang.tr('you_can_report_exception_by_email') + ' : ';
             $('<a />').attr({
@@ -610,6 +610,7 @@ window.filesender.ui = {
         } else if(error.uid) {
             msgtail += lang.tr('you_can_report_exception') + ' : "' + error.uid + '"';
         }
+        msgtail += '</div>';
 
         msgtail += '<br /><br />' + lang.tr('you_can_send_client_logs') + ' ';
         msgtail += '<button class="send_client_logs btn btn-secondary" id="send_client_logs">' + lang.tr('send_client_logs').out() + '</button>';


### PR DESCRIPTION
Sometimes having long path names in subdirectories causes drag and drop to ignore the long paths and skip the file all together.

This PR pops up an error when this is caught.

Note: tr for `directory_issue` will need to be added for the error to look nicer. (feel free to rename)

Another issue we have noticed, it seems in upload_page.js in the `filesender.ui.nodes.files.input.on('change'` function, the web browser seems to just skip problematic file paths in `this.files` without warning. Not sure how to solve that, maybe a pop up asking users to double check the list?