### PR TITLE
Fix S3 guests losing transfer settings

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -250,7 +250,7 @@ class RestEndpointGuest extends RestEndpoint
         }
         
         if( strtolower(Config::get('storage_type')) == 'clouds3' ) {
-            $options = StorageCloudS3::augmentTransferOptions( $options );
+            $transfer_options = StorageCloudS3::augmentTransferOptions( $transfer_options );
         }
 
         if(Auth::isRemote()) {


### PR DESCRIPTION
Same as #1963, however now against `development` branch

When upgrading an install from 2.40 to 2.48 recently, we ran across an issue where transfer settings for guests would be lost.

This PR should fix this.