### PR TITLE
allow image attachments from mail templates

### DIFF
--- a/classes/utils/ApplicationMail.class.php
+++ b/classes/utils/ApplicationMail.class.php
@@ -84,6 +84,21 @@ class ApplicationMail extends Mail
             $this->writePlain($content->plain);
             
             if ($use_html) {
+                
+                // Do we have images in the html that should be attachments? Eg: <img src="cid:<name>;<filepath>">
+                preg_match_all('/<img src="cid:([a-z]+)"/', $content->html, $allmatches, PREG_SET_ORDER);
+
+                foreach ($allmatches as $match) {
+                    $cid = $match[1];
+                    if($imagePath = Config::getTemplateCIDImagePath($cid)) {
+                        $a = new MailAttachment($cid);
+                        $a->path = $imagePath;
+                        $a->cid = '<'.$cid.'>';
+                        $this->attach($a);
+                        
+                    }
+                }
+                
                 $this->writeHTML($content->html);
             }
         }

--- a/classes/utils/ApplicationMail.class.php
+++ b/classes/utils/ApplicationMail.class.php
@@ -86,16 +86,15 @@ class ApplicationMail extends Mail
             if ($use_html) {
                 
                 // Do we have images in the html that should be attachments? Eg: <img src="cid:<name>;<filepath>">
-                preg_match_all('/<img src="cid:([a-z]+)"/', $content->html, $allmatches, PREG_SET_ORDER);
+                preg_match_all('/<img src="cid:([a-z0-9]+)"/', $content->html, $allmatches, PREG_SET_ORDER);
 
                 foreach ($allmatches as $match) {
                     $cid = $match[1];
-                    if($imagePath = Config::getTemplateCIDImagePath($cid)) {
+                    if( $imagePath = Config::getTemplateCIDImagePath($cid)) {
                         $a = new MailAttachment($cid);
                         $a->path = $imagePath;
                         $a->cid = '<'.$cid.'>';
                         $this->attach($a);
-                        
                     }
                 }
                 

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -580,9 +580,15 @@ class Config
      * If there is a CID image mapping in the configuration lookup the $cid
      * and return the path for the image if it is set or null
      *
+     * This method will issue warnings to the logs in case of a cid which does not have
+     * and associated image or the image is not existing. If the return value is not null
+     * the caller can continue to use the image or just do nothing for null return values.
+     * The use of CID images is seen as something to warn the sysadmin about if they are
+     * not found but is not considered a fatal error.
+     *
      * @param string $cid The CID to lookup
      *
-     * @return ?string
+     * @return ?string The path for the image or null.
      */
     public static function getTemplateCIDImagePath($cid)
     {
@@ -590,11 +596,24 @@ class Config
             return null;
 
         $m = self::get('template_email_images');
-        if(!array_key_exists($cid, $m))
+        if(!array_key_exists($cid, $m)) {
+            Logger::warn("Mail processing: A CID was used to select an image but there is no associated image for that cid in your config.php. cid: $cid");
             return null;
+        }
 
         $p = FILESENDER_BASE.'/www/images/' . $m[$cid];
+
+        $prefix = realpath(FILESENDER_BASE.'/www/images/');
+        if(!str_starts_with(realpath($p), $prefix )) {
+            Logger::warn("Mail processing: Your configuration references an image file that is not under the www/images directory for the cid $cid. Prefix $prefix Offending path $p rp " . realpath($p));
+            return null;
+        }
         if(!file_exists($p)) {
+            Logger::warn("Mail processing: An image has been setup for the cid $cid but it does not exist on the system! The path should be $p");
+            return null;
+        }
+        if(!is_readable($p)) {
+            Logger::warn("Mail processing: An image has been setup for the cid $cid but it is not readable! The path is be $p");
             return null;
         }
         return $p;

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -586,10 +586,10 @@ class Config
      */
     public static function getTemplateCIDImagePath($cid)
     {
-        if(!self::exists('template-email-images'))
+        if(!self::exists('template_email_images'))
             return null;
 
-        $m = self::get('template-email-images');
+        $m = self::get('template_email_images');
         if(!array_key_exists($cid, $m))
             return null;
 

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -575,6 +575,30 @@ class Config
         
         return $value;
     }
+
+    /**
+     * If there is a CID image mapping in the configuration lookup the $cid
+     * and return the path for the image if it is set or null
+     *
+     * @param string $cid The CID to lookup
+     *
+     * @return ?string
+     */
+    public static function getTemplateCIDImagePath($cid)
+    {
+        if(!self::exists('template-email-images'))
+            return null;
+
+        $m = self::get('template-email-images');
+        if(!array_key_exists($cid, $m))
+            return null;
+
+        $p = FILESENDER_BASE.'/www/images/' . $m[$cid];
+        if(!file_exists($p)) {
+            return null;
+        }
+        return $p;
+    }
     
     /**
      * Check if parameter exists

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -1384,7 +1384,7 @@ User language detection is done in the following order:
 
 ### template_email_images
 
-* __description:__ A list of CID to image paths for use in email attachments from the mail translation files. Note that these will be relative to the www/images directory by default. To use these images place something like <img src="cid:mylogo"/> into your files_downloaded.mail.php for example. Note that the cid can only contain the lower case characters 'a' through 'z'.
+* __description:__ A list of CID to image paths for use in email attachments from the mail translation files. Note that these will be relative to the www/images directory. The image *MUST* be contained in the www/images directory or it will be logged and ignored. To use these images place something like <img src="cid:mylogo"/> into your files_downloaded.mail.php. Note that the cid can only contain the lower case characters 'a' through 'z' and the digits '0' through '9'. To aid in matching the cid is only sought on img elements and the src attribute *MUST* the the first attribute with only a single space between the img and src. If you wish to have other attributes on the img tag please but those after the src attribute. Attempts to use cid values outside of this scope will be silently ignored. Attempts to reference a CID that is not set in this configuration variable will be shown as an error in your logs and silently ignored. If the path to an image does not exist you will see an error in your logs and that cid will be silently ignored. If an image file is not readable you will see an error in your logs and it will be silently ignored. Attempts to access images outside of www/images will be logged and silently ignored.
 * __mandatory:__ no
 * __type:__ array
 * __default:__ null
@@ -1392,9 +1392,17 @@ User language detection is done in the following order:
 * __Examples:__
 $config['template_email_images'] = [
     'mylogo' => 'mylogo.png',
+    'footer2' => 'my-fancy-footer-2.png',
 ];
 
+Inside of files_downloaded.mail.php for example
 
+<p>
+    You can access your files and view detailed download...
+</p>
+...
+<img src="cid:mylogo"/><img src="cid:footer2"/>
+...
 
 
 ### trackingevents_lifetime

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -124,6 +124,7 @@ A note about colours;
 * [email_send_with_minus_r_option](#email_send_with_minus_r_option)
 * [relay_unknown_feedbacks](#relay_unknown_feedbacks)
 * [translatable_emails_lifetime](#translatable_emails_lifetime)
+* [template_email_images](#template_email_images)
 
 ## General UI
 
@@ -1379,6 +1380,21 @@ User language detection is done in the following order:
 * __type:__ int
 * __default:__ 30
 * __available:__ since before version 2.30
+
+
+### template_email_images
+
+* __description:__ A list of CID to image paths for use in email attachments from the mail translation files. Note that these will be relative to the www/images directory by default. To use these images place something like <img src="cid:mylogo"/> into your files_downloaded.mail.php for example. Note that the cid can only contain the lower case characters 'a' through 'z'.
+* __mandatory:__ no
+* __type:__ array
+* __default:__ null
+* __available:__ since version 2.50
+* __Examples:__
+$config['template_email_images'] = [
+    'mylogo' => 'mylogo.png',
+];
+
+
 
 
 ### trackingevents_lifetime

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -127,6 +127,7 @@ A note about colours;
 * [email_send_with_minus_r_option](#email_send_with_minus_r_option)
 * [relay_unknown_feedbacks](#relay_unknown_feedbacks)
 * [translatable_emails_lifetime](#translatable_emails_lifetime)
+* [template_email_images](#template_email_images)
 
 ## General UI
 
@@ -1382,6 +1383,29 @@ User language detection is done in the following order:
 * __type:__ int
 * __default:__ 30
 * __available:__ since before version 2.30
+
+### template_email_images
+
+* __description:__ A list of CID to image paths for use in email attachments from the mail translation files. Note that these will be relative to the www/images directory. The image *MUST* be contained in the www/images directory or it will be logged and ignored. To use these images place something like <img src="cid:mylogo"/> into your files_downloaded.mail.php. Note that the cid can only contain the lower case characters 'a' through 'z' and the digits '0' through '9'. To aid in matching the cid is only sought on img elements and the src attribute *MUST* the the first attribute with only a single space between the img and src. If you wish to have other attributes on the img tag please but those after the src attribute. Attempts to use cid values outside of this scope will be silently ignored. Attempts to reference a CID that is not set in this configuration variable will be shown as an error in your logs and silently ignored. If the path to an image does not exist you will see an error in your logs and that cid will be silently ignored. If an image file is not readable you will see an error in your logs and it will be silently ignored. Attempts to access images outside of www/images will be logged and silently ignored.
+* __mandatory:__ no
+* __type:__ array
+* __default:__ null
+* __available:__ since version 2.50
+* __Examples:__
+$config['template_email_images'] = [
+    'mylogo' => 'mylogo.png',
+    'footer2' => 'my-fancy-footer-2.png',
+];
+
+Inside of files_downloaded.mail.php for example
+
+<p>
+    You can access your files and view detailed download...
+</p>
+...
+<img src="cid:mylogo"/><img src="cid:footer2"/>
+...
+
 
 
 ### trackingevents_lifetime


### PR DESCRIPTION
This idea was originally proposed in https://github.com/filesender/filesender/pull/1971. 

This update requires the images that can be used in the cid to be listed in a config value and limits which cids can be selected to only using a range of a-z characters. If the cid is not in the config variable then no image will be attached.
