### PR TITLE
Clidownload.php fix for python client

### DIFF
--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -63,7 +63,7 @@ if( array_key_exists('config',$_GET) && $_GET['config']=='1' ) {
 $script=file_get_contents('../scripts/client/filesender.py');
 
 
-$script=preg_replace('\[base_url\]',$apipath,$script,1,$one);
+$script=preg_replace('/\[base_url\]/',$apipath,$script,1,$one);
 $script=preg_replace("/\ndefault_transfer_days_valid[ ]*=[ ]*[0-9]+\n/",
                      "\ndefault_transfer_days_valid = $daysvalid\n",
                      $script);

--- a/www/clidownload.php
+++ b/www/clidownload.php
@@ -63,7 +63,7 @@ if( array_key_exists('config',$_GET) && $_GET['config']=='1' ) {
 $script=file_get_contents('../scripts/client/filesender.py');
 
 
-$script=str_replace('[base_url]',$apipath,$script,$one);
+$script=preg_replace('\[base_url\]',$apipath,$script,1,$one);
 $script=preg_replace("/\ndefault_transfer_days_valid[ ]*=[ ]*[0-9]+\n/",
                      "\ndefault_transfer_days_valid = $daysvalid\n",
                      $script);


### PR DESCRIPTION
Hey Team, 

Minor change to address: https://github.com/filesender/filesender/issues/1974 

The CLIDownload will now only replace the default [base_url] string in the python file. 

I tested this on our dev server to confirm the new expected behavior, I kept the $one variable tracking how many changes. there have been but as far as I can tell that isn't used.