### PR TITLE
fix these to allow removing unsafe-inline from CSP

### DIFF
--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -362,8 +362,8 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
             <div class="col">
                 <h2>{tr:verify_your_email_address_to_download}</h2>
                 <table columns="2" border="1">
-                    <col style="width:25%">
-                    <col style="width:75%">
+                    <col class="width25">
+                    <col class="width75">
                     <tr>
                         <td>
                             <a href="#" class="verificationcodesendtoemail">

--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -139,7 +139,7 @@ use ( $new_guests_can_only_send_to_creator,
                                         <textarea id="message" name="message" rows="4" placeholder="{tr:optional_message}"></textarea>
                                     </div>
 
-                                    <label class="invalid" id="message_can_not_contain_urls" style="display:none;">{tr:message_can_not_contain_urls}</label>
+                                    <label class="invalid hidden-at-page-load" id="message_can_not_contain_urls">{tr:message_can_not_contain_urls}</label>
 
                                     <h2>{tr:transfer_settings}</h2>
 

--- a/www/css/new-ui/_general.css
+++ b/www/css/new-ui/_general.css
@@ -103,6 +103,18 @@ a {
   color: var(--fs-accent);
 }
 
+.hidden-at-page-load {
+  display: none;
+}
+
+.width25 {
+    width:25%;
+}
+
+.width75 {
+    width:75%;
+}
+
 /* XS */
 @media (max-width: 575px) {
 


### PR DESCRIPTION
This is in response to https://github.com/filesender/filesender/issues/1976

Being able to remove unsafe-inline from CSP is very useful!
