### PR TITLE
Update docs for SSP 2.x use

### DIFF
--- a/config-templates/apache/filesender.conf
+++ b/config-templates/apache/filesender.conf
@@ -1,5 +1,5 @@
-Alias /simplesaml /opt/filesender/simplesaml/www
-<Directory "/opt/filesender/simplesaml/www">
+Alias /simplesaml /opt/filesender/simplesaml/public
+<Directory "/opt/filesender/simplesaml/public">
         Header always append X-Frame-Options SAMEORIGIN
         Header always edit Set-Cookie (.*) "$1; SameSite=Strict; HttpOnly; "
 

--- a/docs/v2.0/install/index.md
+++ b/docs/v2.0/install/index.md
@@ -31,13 +31,11 @@ you can report issues with and update the documentation.
 
 ### Dependencies
 
-* Apache (or nginx) and PHP version 7.3 or later.
+
+* Apache (or nginx) and PHP version 8.2 or later.
 * A PostgreSQL or MariaDB database (10.0 or above, 10.2 or later recommended).
 * A big filesystem (or cloud backed).
-* [SimpleSamlPhp](https://simplesamlphp.org/download/) 1.19.7 or
-  newer. There is some support for the 2.x series of SimpleSamlPhp.
-  You may need to modify some files in your SimpleSamlPhp for this to
-  work, see [issue 1467](https://github.com/filesender/filesender/issues/1467).
+* [SimpleSamlPhp](https://simplesamlphp.org/download/) 2.2 or newer. 
 
 Note that older versions of PHP may work, but they are not supported
 by the PHP project so it is recommended to avoid them in production. Likewise,
@@ -94,8 +92,8 @@ see something like the following:
 # ls -l /opt/filesender
 total 8
 drwxrwxr-x. 21 root root 4096 Jun  6 15:28 filesender
-lrwxrwxrwx.  1 root root   20 Jun  6 15:41 simplesaml -> simplesamlphp-1.19.7
-drwxr-xr-x. 23 root root 4096 Mar  3 01:04 simplesamlphp-1.19.7
+lrwxrwxrwx.  1 root root   20 Jun  6 15:41 simplesaml -> simplesamlphp-2.2.3
+drwxr-xr-x. 23 root root 4096 Mar  3 01:04 simplesamlphp-2.2.3
 
 # ls -l /opt/filesender/filesender/
 total 160
@@ -242,7 +240,7 @@ authentication for development and testing. When you move to a
 production service you probably want to change that to only support
 authentication sources of your choice.
 
-All versions of FileSender currently use the SimpleSAMLphp 1.x series. For example, version 1.19.7 of SimpleSAMLphp.
+All versions of FileSender currently use the SimpleSAMLphp 2.x series. For example, version 2.2.3 of SimpleSAMLphp.
 [Download SimpleSAMLphp](https://simplesamlphp.org/download/). Other
 [(later or older) versions](https://github.com/simplesamlphp/simplesamlphp/releases) will
 probably work. The continuous integration in FileSender has an
@@ -257,17 +255,17 @@ Extract SimpleSAMLphp in a suitable directory and create symlink:
 ```
 mkdir -p ~/src
 cd ~/src
-wget https://github.com/simplesamlphp/simplesamlphp/releases/download/v1.19.7/simplesamlphp-1.19.7.tar.gz
+wget https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.2.3/simplesamlphp-2.2.3-full.tar.gz
 
 php /opt/filesender/filesender/scripts/install/simplesamlphp-extract-sha256-from-release-notes.php https://github.com/simplesamlphp/simplesamlphp/releases/tag/v1.19.7 >| checklist
-echo " simplesamlphp-1.19.7.tar.gz" >> checklist
+echo " simplesamlphp-2.2.3-full.tar.gz" >> checklist
 sha256sum --check checklist
- simplesamlphp-1.19.7.tar.gz: OK
+ simplesamlphp-2.2.3-full.tar.gz: OK
 
 mkdir -p /opt/filesender
 cd /opt/filesender
-tar xvzf ~/src/simplesamlphp-1.19.7.tar.gz
-ln -s simplesamlphp-1.19.7 simplesaml
+tar xvzf ~/src/simplesamlphp-2.2.3-full.tar.gz
+ln -s simplesamlphp-2.2.3 simplesaml
 
 
 ```
@@ -330,30 +328,6 @@ sed -i -e "s@'auth.adminpassword' => '123'@'auth.adminpassword' => '$HASH'@g" co
 
 ```
 
-The below commands will remove some possible functionality such as the
-admin interface and some pages in the core module from being
-available. Note that the authenticate.php page is there to help verify
-authentication and does not seem to be used in the normal flow of
-login and logout. The above admin.protect config settings should also
-remove these pages from regular user access.
-
-```
-cd www
-rm -f resources/jquery-1.8.js
-rm -f resources/jquery-ui-1.8.js
-rm -rf admin
-cd ..
-
-cd modules/core/www
-rm -f frontpage_auth.php
-rm -f frontpage_config.php
-rm -f frontpage_federation.php
-rm -f frontpage_welcome.php
-rm -f authenticate.php
-rm -f show_metadata.php
-rm -f login-admin.php
-
-```
 
 To tailor your [SimpleSAMLphp](https://simplesamlphp.org/) installation
 to match your local site's needs please check the SimpleSAMLphp [installation and
@@ -365,16 +339,6 @@ Manual for details.
 
 * **NOTE**: It's outside the scope of this document to explain how to configure an authentication backend. The software has built-in support for [SAML](https://simplesamlphp.org/docs/stable/ldap:ldap), [LDAP](https://simplesamlphp.org/docs/stable/ldap:ldap), [Radius](https://simplesamlphp.org/docs/stable/radius:radius) and [many more](https://simplesamlphp.org/docs/stable/simplesamlphp-idp#section_2).
 
-The below are some URLs that will be disabled by the above configuration.
-You might like to load them and see that you are happy with the results.
-
-```
-https://.../simplesaml/module.php/sanitycheck/index.php
-https://.../simplesaml/admin/phpinfo.php
-https://.../simplesaml/module.php/core/frontpage_config.php
-https://.../simplesaml/module.php/core/authenticate.php
-https://.../simplesaml/module.php/saml/sp/metadata.php/default-sp?output=xhtml
-```
 
 The default redirect for https://.../simplesaml/ will be to
 https://.../simplesaml/module.php/core/frontpage_welcome.php so you might like to

--- a/docs/v3.0/install/index.md
+++ b/docs/v3.0/install/index.md
@@ -31,13 +31,10 @@ you can report issues with and update the documentation.
 
 ### Dependencies
 
-* Apache (or nginx) and PHP version 7.3 or later.
+* Apache (or nginx) and PHP version 8.2 or later.
 * A PostgreSQL or MariaDB database (10.0 or above, 10.2 or later recommended).
 * A big filesystem (or cloud backed).
-* [SimpleSamlPhp](https://simplesamlphp.org/download/) 1.19.7 or
-  newer. There is some support for the 3.x series of SimpleSamlPhp.
-  You may need to modify some files in your SimpleSamlPhp for this to
-  work, see [issue 1467](https://github.com/filesender/filesender/issues/1467).
+* [SimpleSamlPhp](https://simplesamlphp.org/download/) 2.2 or newer. 
 
 Note that older versions of PHP may work, but they are not supported
 by the PHP project so it is recommended to avoid them in production. Likewise,
@@ -94,8 +91,8 @@ see something like the following:
 # ls -l /opt/filesender
 total 8
 drwxrwxr-x. 21 root root 4096 Jun  6 15:28 filesender
-lrwxrwxrwx.  1 root root   20 Jun  6 15:41 simplesaml -> simplesamlphp-1.19.7
-drwxr-xr-x. 23 root root 4096 Mar  3 01:04 simplesamlphp-1.19.7
+lrwxrwxrwx.  1 root root   20 Jun  6 15:41 simplesaml -> simplesamlphp-2.2.3
+drwxr-xr-x. 23 root root 4096 Mar  3 01:04 simplesamlphp-2.2.3
 
 # ls -l /opt/filesender/filesender/
 total 160
@@ -242,7 +239,7 @@ authentication for development and testing. When you move to a
 production service you probably want to change that to only support
 authentication sources of your choice.
 
-All versions of FileSender currently use the SimpleSAMLphp 1.x series. For example, version 1.19.7 of SimpleSAMLphp.
+All versions of FileSender currently use the SimpleSAMLphp 2.x series. For example, version 2.2.3 of SimpleSAMLphp.
 [Download SimpleSAMLphp](https://simplesamlphp.org/download/). Other
 [(later or older) versions](https://github.com/simplesamlphp/simplesamlphp/releases) will
 probably work. The continuous integration in FileSender has an
@@ -257,17 +254,17 @@ Extract SimpleSAMLphp in a suitable directory and create symlink:
 ```
 mkdir -p ~/src
 cd ~/src
-wget https://github.com/simplesamlphp/simplesamlphp/releases/download/v1.19.7/simplesamlphp-1.19.7.tar.gz
+wget https://github.com/simplesamlphp/simplesamlphp/releases/download/v2.2.3/simplesamlphp-2.2.3-full.tar.gz
 
 php /opt/filesender/filesender/scripts/install/simplesamlphp-extract-sha256-from-release-notes.php https://github.com/simplesamlphp/simplesamlphp/releases/tag/v1.19.7 >| checklist
-echo " simplesamlphp-1.19.7.tar.gz" >> checklist
+echo " simplesamlphp-2.2.3-full.tar.gz" >> checklist
 sha256sum --check checklist
- simplesamlphp-1.19.7.tar.gz: OK
+ simplesamlphp-2.2.3-full.tar.gz: OK
 
 mkdir -p /opt/filesender
 cd /opt/filesender
-tar xvzf ~/src/simplesamlphp-1.19.7.tar.gz
-ln -s simplesamlphp-1.19.7 simplesaml
+tar xvzf ~/src/simplesamlphp-2.2.3-full.tar.gz
+ln -s simplesamlphp-2.2.3 simplesaml
 
 
 ```
@@ -330,30 +327,6 @@ sed -i -e "s@'auth.adminpassword' => '123'@'auth.adminpassword' => '$HASH'@g" co
 
 ```
 
-The below commands will remove some possible functionality such as the
-admin interface and some pages in the core module from being
-available. Note that the authenticate.php page is there to help verify
-authentication and does not seem to be used in the normal flow of
-login and logout. The above admin.protect config settings should also
-remove these pages from regular user access.
-
-```
-cd www
-rm -f resources/jquery-1.8.js
-rm -f resources/jquery-ui-1.8.js
-rm -rf admin
-cd ..
-
-cd modules/core/www
-rm -f frontpage_auth.php
-rm -f frontpage_config.php
-rm -f frontpage_federation.php
-rm -f frontpage_welcome.php
-rm -f authenticate.php
-rm -f show_metadata.php
-rm -f login-admin.php
-
-```
 
 To tailor your [SimpleSAMLphp](https://simplesamlphp.org/) installation
 to match your local site's needs please check the SimpleSAMLphp [installation and
@@ -365,16 +338,6 @@ Manual for details.
 
 * **NOTE**: It's outside the scope of this document to explain how to configure an authentication backend. The software has built-in support for [SAML](https://simplesamlphp.org/docs/stable/ldap:ldap), [LDAP](https://simplesamlphp.org/docs/stable/ldap:ldap), [Radius](https://simplesamlphp.org/docs/stable/radius:radius) and [many more](https://simplesamlphp.org/docs/stable/simplesamlphp-idp#section_2).
 
-The below are some URLs that will be disabled by the above configuration.
-You might like to load them and see that you are happy with the results.
-
-```
-https://.../simplesaml/module.php/sanitycheck/index.php
-https://.../simplesaml/admin/phpinfo.php
-https://.../simplesaml/module.php/core/frontpage_config.php
-https://.../simplesaml/module.php/core/authenticate.php
-https://.../simplesaml/module.php/saml/sp/metadata.php/default-sp?output=xhtml
-```
 
 The default redirect for https://.../simplesaml/ will be to
 https://.../simplesaml/module.php/core/frontpage_welcome.php so you might like to

--- a/scripts/install/simplesamlphp-extract-sha256-from-release-notes.php
+++ b/scripts/install/simplesamlphp-extract-sha256-from-release-notes.php
@@ -8,7 +8,7 @@ if( $earl=='' ) {
 }
 
 $page = file_get_contents($earl);
-preg_match('/SHA256 checksum: ([a-f0-9]+)<.*/', $page, $matches );
+preg_match('/SHA256 checksum full-release: <code>([a-f0-9]+)<.*/', $page, $matches );
 if( count($matches) == 2 ) {
     echo $matches[1];
 } else {


### PR DESCRIPTION
We should be using SSP 2.x these days. The hash extractor script is updated and many parts of the docs. A clean install into a VM would be useful to try to catch any outstanding issues.
