### PR TITLE
d3: add a more info link on the download page

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -848,3 +848,4 @@ $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at:
 $lang['your_download_link'] = 'Here\'s your download link';
 $lang['your_invitation_was_sent_to'] = 'Your invitation was sent to';
 $lang['your_transfer_was_sent'] = 'Your transfer was sent to the following email addresses';
+$lang['more_information_about_downloading_files'] = 'More information about downloading files';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -176,6 +176,9 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
                         <strong>{tr:transfer_size}:</strong>
                         <span><?php echo Utilities::sanitizeOutput(Utilities::formatBytes($transfer->size)) ?></span>
                     </div>
+                    <div  class="fs-info">
+                        <a href="https://docs.filesender.org/filesender/v3.0/user/download/">{tr:more_information_about_downloading_files}</a>
+                    </div>
                 </div>
             </div>
             <div class="col col-sm-12 col-md-7 col-lg-8">


### PR DESCRIPTION
The docs page linked to should start out describing the web ui more as that is probably the first thing folks might want to know about. Then the command line stuff. Then the rest clients to transfer encrypted files.