### PR TITLE
d3: allow language selection on upload as option

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -643,6 +643,24 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                     </div>
                                 </div>
 
+                                <?php
+                                if(Config::get('transfer_recipients_lang_selector_enabled')) {
+                                    $opts = array();
+                                    $code = Lang::getBaseCode();
+                                    foreach(Lang::getAvailableLanguages() as $id => $dfn) {
+                                        $selected = ($id == $code) ? 'selected="selected"' : '';
+                                        $opts[] = '<option value="'.$id.'" '.$selected.'>'.Utilities::sanitizeOutput($dfn['name']).'</option>';
+                                    }
+                                    
+                                    echo '<div class="fs-select">';
+                                    echo '  <label for="lang">{tr:recipients_notifications_language}:</label>';
+                                    echo '  <select id="lang" name="lang">'.implode('', $opts).'</select>';
+                                    echo '</div>';
+
+                                    
+                                }
+                                ?>
+                                
                                 <div class="row">
                                     <div class="col-12">
                                         <div class="fs-collapse">

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1231,6 +1231,9 @@ filesender.ui.startUpload = function() {
             this.transfer.lang = filesender.ui.nodes.lang.attr('data-id');
         }
 
+        if(filesender.ui.nodes.lang.length)
+            this.transfer.lang = filesender.ui.nodes.lang.val();
+        
         for(var o in filesender.ui.nodes.options) {
             var i = filesender.ui.nodes.options[o];
             var v = i.is('[type="checkbox"]') ? i.is(':checked') : i.val();


### PR DESCRIPTION
This restores the optional feature of letting a user select the human language for a transfer. This allows the greeting email to be send in a language that is more likely to be accepted by the person reading the email notifying that a new file is available.

Fixes https://github.com/filesender/filesender/issues/1620