### PR TITLE
cleaner interface for deleting duplicate files when clicking on existing file

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -711,3 +711,4 @@ $lang['you_can_report_exception'] = 'When reporting this error please give the f
 $lang['you_can_report_exception_by_email'] = 'You can report this error by email';
 $lang['you_can_send_client_logs'] = 'In order to help your support team to find out what happened you can send the last log entries from your user interface by clicking this button :';
 $lang['you_generated_this_auth_secret_at'] = 'You generated this auth secret at: {datetime}';
+$lang['files_removed_from_upload'] = 'Files have been removed from the upload';


### PR DESCRIPTION
This is an update to UI2 to allow the user to click on the file that is not a duplicate and remove the duplicate(s) in the upload dialog instead. This is because if you delete a file then another file is no longer a duplicate and can be uploaded. 

I will make an update to the UI3 code as well.

This was raised for UI3 at https://github.com/filesender/filesender/issues/2020.