### PR TITLE
Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, Array given- RestEndpointTransfer.class.php (#2027)

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -561,9 +561,12 @@ class RestEndpointTransfer extends RestEndpoint
             
             foreach ($allOptions as $name => $dfn) {
                 if (in_array($name, $allowed_options)) {
-                    if (method_exists($data->options, 'exists')) {
-                        if ($data->options->exists($name)) {
-                            $options[$name] = $data->options->$name;
+                    // check if options is object
+                    if (is_object( $data->options) ) {
+                        if (method_exists($data->options, 'exists')) {
+                            if ($data->options->exists($name)) {
+                                $options[$name] = $data->options->$name;
+                            }
                         }
                     } else {
                         if (array_search($name, $data->options) !== false) {


### PR DESCRIPTION
When POST to endpoint _/rest.php/transfer_ with payload as described here: [creare new tranfert request](https://docs.filesender.org/filesender/v2.0/rest/)
we get the following error:

`Fix: PHP Fatal error:  Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, Array given in /usr/local/data/sites/fsender/filesender -2.49/classes/rest/endpoints/RestEndpointTransfer.class.php:564`

Issue ( #2027)