### PR TITLE
Added the option for upload complete popups.

### DIFF
--- a/classes/constants/TransferOptions.class.php
+++ b/classes/constants/TransferOptions.class.php
@@ -52,7 +52,8 @@ class TransferOptions extends Enum
     const HIDE_SENDER_EMAIL                         = 'hide_sender_email';
     
     const REDIRECT_URL_ON_COMPLETE                  = 'redirect_url_on_complete';
-
+    const POPUP_ON_COMPLETE                         = 'popup_on_complete';
+    
     const ENCRYPTION                                = 'encryption';
     const COLLECTION                                = 'collection';
     const MUST_BE_LOGGED_IN_TO_DOWNLOAD             = 'must_be_logged_in_to_download';

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -280,7 +280,7 @@ $default = array(
                                                                 , 'email_daily_statistics', 'email_report_on_closing'
                                                                 , 'enable_recipient_email_download_complete'
                                                                 , 'add_me_to_recipients', 'redirect_url_on_complete'
-                                                                , 'hide_sender_email'
+                                                                , 'hide_sender_email', 'popup_on_complete'
     ),
 
     'header_x_frame_options' => 'sameorigin',
@@ -432,6 +432,11 @@ $default = array(
             'default' => true
         ),
         'redirect_url_on_complete' => array(
+            'available' => false,
+            'advanced' => true,
+            'default' => ''
+        ),
+        'popup_on_complete' => array(
             'available' => false,
             'advanced' => true,
             'default' => ''

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -439,7 +439,7 @@ $default = array(
         'popup_on_complete' => array(
             'available' => false,
             'advanced' => true,
-            'default' => ''
+            'default' => false
         ),
         'must_be_logged_in_to_download' => array(
             'available' => true,

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1314,6 +1314,9 @@ filesender.ui.startUpload = function() {
 
             return;
         }
+        if(filesender.ui.transfer.options.popup_on_complete) {
+            filesender.ui.alert("info",lang.tr('upload_completed')) 
+        }
 
         var close = function() {
             window.filesender.notification.clear();

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1314,9 +1314,11 @@ filesender.ui.startUpload = function() {
 
             return;
         }
-        if(filesender.ui.transfer.options.popup_on_complete) {
-            filesender.ui.alert("info",lang.tr('upload_completed')) 
+
+        if(filesender.ui.transfer.options.popup_on_complete){
+           filesender.ui.confirmTitle(lang.tr('uploaded'),' ✔ '+lang.tr('upload_completed'))
         }
+
 
         var close = function() {
             window.filesender.notification.clear();

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1316,7 +1316,7 @@ filesender.ui.startUpload = function() {
         }
 
         if(filesender.ui.transfer.options.popup_on_complete){
-           filesender.ui.confirmTitle(lang.tr('uploaded'),' ✔ '+lang.tr('upload_completed'))
+           filesender.ui.confirmTitle(lang.tr('uploaded'),' <i class="fa fa-check" aria-hidden="true"></i> '+lang.tr('upload_completed'))
         }
 
 


### PR DESCRIPTION
Hi Team, 

We've noticed more users raising support requests unsure if their upload was complete and wanting to double check with our team. 
To resolve this we wanted the option for a more aggressive confirmation for the users.

This PR adds a new transfer option called 'popup_on_complete'  following the examples of 'WEB_NOTIFICATION_WHEN_UPLOAD_IS_COMPLETE' and 'redirect_url_on_complete'. 

When enabled it provides a notification using the standard language as follows:
![image](https://github.com/user-attachments/assets/a29601a4-de57-4d1e-af2d-d6e06de35ba0)

The admin simply needs to add the configuration option to their transfer options like they would any other. 