### PR TITLE
ui3: remove the subject and message when get a link is used

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -481,7 +481,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                 <?php } ?>
                                             </div>
 
-                                            <div data-related-to="message">
+                                            <div data-related-to="message" class="emailonly">
                                                 <div class="fs-input-group">
                                                     <label for="subject">
                                                         {tr:subject}
@@ -501,7 +501,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                 </label>
                                             </div>
 
-                                            <div data-related-to="message">
+                                            <div data-related-to="message" class="emailonly">
                                                 <div class="fs-input-group">
                                                     <label for="message">
                                                         {tr:message}

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1596,6 +1596,7 @@ filesender.ui.handle_get_a_link_change = function() {
     var form = $('#upload_form');
     var gal = form.find('input[id="get_a_link"]');
     var choice = gal.is(':checked');
+    
     form.find(
         '.fieldcontainer[data-related-to="message"], .recipients,' +
         ' .fieldcontainer[data-option="add_me_to_recipients"],' +
@@ -1609,7 +1610,15 @@ filesender.ui.handle_get_a_link_change = function() {
     form.find(
         ' .fieldcontainer[data-option="hide_sender_email"]'
     ).toggle(!choice);
-
+    
+    form.find(
+        ' .emailonly'
+    ).toggle(!choice);
+    
+    if( choice ) {
+        form.find('#subject').val('');
+        form.find('#message').val('');
+    }
     filesender.ui.evalUploadEnabled();
 }
 


### PR DESCRIPTION
This has been requested by 3 NRENs now (https://github.com/filesender/filesender/issues/1920). It is a strange situation where I am reluctant to make simple changes to the UI code even with strong feedback. I suppose since this is not a huge change code wise it can be reverted if it violates the overall design in mind for the 3.x UI and in the meantime folks can use it based on the feedback they have from their respective teams. Or we can make this yet another an optional change with a configuration setting to have and maintain.

This was requested in https://github.com/filesender/filesender/issues/1920