### PR TITLE
ui3: allow admin to view transfers from other users

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -31,9 +31,22 @@ if ($transfer_id) {
 
 $extend = (bool)Config::get('allow_transfer_expiry_date_extension');
 
-
+$found = true;
 $user = Auth::user();
-if( !Auth::isAuthenticated() || !$transfer || $transfer->userid != $user->id ) {
+if( !Auth::isAuthenticated() || !$transfer ) {
+    $found = false;
+}
+if( $found ) {
+    if( !Auth::isAdmin()) {
+        // non admin user can only view their own stuff
+        if( $transfer->userid != $user->id ) {
+            $found = false;
+        }
+        
+    }
+}
+
+if( !$found ) {
     echo $transfer_not_found;
     return;
 }


### PR DESCRIPTION
This allows an admin to view transfers from any user. This is useful in the admin pages of FileSender when enabled.

This relates to https://github.com/filesender/filesender/issues/2035