### PR TITLE
d3: update for default value for email_from/email_return_path sender

### DIFF
--- a/classes/utils/ApplicationMail.class.php
+++ b/classes/utils/ApplicationMail.class.php
@@ -190,6 +190,60 @@ class ApplicationMail extends Mail
         
         $this->to['name'] = $name;
     }
+
+    /**
+     * As similar code is run for handling both email_from and email_return_path
+     * this method exists.
+     *
+     * This will;
+     * * do some basic validation
+     * * expand the path 'no-reply@' to include the domain name of the site.
+     * * expand the 'sender' keyword to the sender email.
+     *
+     * @return the expanded $from to use
+     */
+    private function handleEmailFrom( $from, $sender, $config_key )
+    {
+        if ($from != 'sender') {
+            if( str_ends_with($from, "@")) {
+                // 'no-reply@' to have host name from site_url added
+            } else {
+
+                if( $config_key == 'email_return_path' ) {
+                    if( !Utilities::validateEmail(str_replace('<verp>', 'verp', $return_path))) {
+                        throw new ConfigBadParameterException($config_key);
+                    }
+                } else {
+                    if( !Utilities::validateEmail($from)) {
+                        throw new ConfigBadParameterException($config_key);
+                    }
+                }
+            }
+        }
+        
+        if ($from == 'sender') {
+            $from = $sender->email;
+        }
+        
+        if( str_ends_with($from, "@")) {
+
+            $h = Config::get("site_hostname");
+            if( $h == '' ) {
+                $u = parse_url(Config::get("site_url"));
+                if( !$u ) {
+                    throw new ConfigBadParameterException($config_key);
+                }
+                
+                $h = $u["host"];
+                if( $h == '' ) {
+                    throw new ConfigBadParameterException($config_key);
+                }
+            }
+            $from .= $h;
+        }
+
+        return $from;
+    }
     
     /**
      * Sends the mail
@@ -221,7 +275,7 @@ class ApplicationMail extends Mail
         
         // Context identifier
         $context = $this->to['object'] ? strtolower(get_class($this->to['object'])).'-'.$this->to['object']->id : 'no_context';
-        
+
         // Build from field depending on config
         $from = Config::get('email_from');
         if (is_array($from)) {
@@ -235,14 +289,8 @@ class ApplicationMail extends Mail
         }
         
         if ($from) {
-            if ($from != 'sender' && !Utilities::validateEmail($from)) {
-                throw new ConfigBadParameterException('email_from');
-            }
-            
-            if ($from == 'sender') {
-                $from = $sender->email;
-            }
-            
+            $from = $this->handleEmailFrom( $from, $sender, 'email_from' );
+
             // Got one, validate and set header
             if ($from) {
                 if (!Utilities::validateEmail($from)) {
@@ -282,13 +330,7 @@ class ApplicationMail extends Mail
         // Build reply-to field depending on config
         $reply_to = Config::get('email_reply_to');
         if ($reply_to) {
-            if ($reply_to != 'sender' && !Utilities::validateEmail($reply_to)) {
-                throw new ConfigBadParameterException('email_reply_to');
-            }
-            
-            if ($reply_to == 'sender') {
-                $reply_to = $sender->email;
-            }
+            $reply_to = $this->handleEmailFrom( $reply_to, $sender, 'email_reply_to' );
             
             // Got one, validate and set header
             if ($reply_to) {
@@ -307,13 +349,7 @@ class ApplicationMail extends Mail
         // Build return path field depending on config
         $return_path = Config::get('email_return_path');
         if ($return_path) {
-            if ($return_path != 'sender' && !Utilities::validateEmail(str_replace('<verp>', 'verp', $return_path))) {
-                throw new ConfigBadParameterException('email_return_path');
-            }
-            
-            if ($return_path == 'sender') {
-                $return_path = $sender->email;
-            }
+            $return_path = $this->handleEmailFrom( $return_path, $sender, 'email_return_path' );
             
             // Got one, validate and set property to be passed to PHP's mail internal
             if ($return_path) {

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -1290,13 +1290,12 @@ User language detection is done in the following order:
 
 ### email_from
 
-* __description:__ <span style="background-color:orange">sets the email From: header to either an explicit value or fills it with the sender's email address as received from the identity service provider in the "mail" attribute.  Is this the body From:?</span>
+* __description:__ sets the email From: header to either an explicit value, an explicit user name at the domain contained in site_url, or fills it with the sender's email address as received from the identity service provider in the "mail" attribute.
 * __mandatory:__ no
-* __type:__ string or keyword. Permissible value for keyword: "sender"
-* __default:__ -
+* __type:__ string or keyword. Permissible value for keyword: "sender", if the value ends in '@' then the domain name is appended.
+* __default:__ no-reply@
 * __available:__ since version 2.0
-* __1.x name:__
-* __comment:__ To be SPF compliant set this to an address like "filesender-bounces@example.org" and use the bounce-handler script to deal with email bounces.
+* __comment:__ The domain name is taken from site_hostname if that is set. Otherwise the site_url is parsed and the domain name is taken from the result of parsing that url. To be SPF compliant set this to an address like "filesender-bounces@" and use the bounce-handler script to deal with email bounces.
 
 ### email_from_name
 
@@ -1310,13 +1309,12 @@ User language detection is done in the following order:
 
 ### email_reply_to
 
-* __description:__ <span style="background-color:orange">adds a reply-to: header to emails sent by FileSender.  When users reply to such an email usually the reply is then sent to the reply_to address.  A user would typically reply to an email to ask a question about a file transfer which should go directly to the sender as the sender is the only one who knows.</span>
+* __description:__ adds a reply-to: header to emails sent by FileSender. See email_from for more information on the format of this variable.
 * __mandatory:__ no
-* __type:__ string or keyword.  Permissible values for keyword: "sender"
-* __default:__ -
+* __type:__ string or keyword. Permissible value for keyword: "sender", if the value ends in '@' then the domain name is appended.
+* __default:__ no-reply@
 * __available:__ since version 2.0
-* __1.x name:__
-* __comment:__ To be SPF compliant set this to "sender"
+* __comment:__ The default append the hostname from your site_url configuraiton directive to the prefix 'no-reply@'
 
 ### email_reply_to_name
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -35,6 +35,7 @@
 $default = array(
     'testing'   => false,   // TODO
     'debug'   => false,   // TODO
+    'site_hostname' => '', // may be used by email_from
     'default_timezone' => 'Europe/London', // Default timezone to use
     'default_language' => 'en', // Default language to user
     'lang_browser_enabled' => true, // Take language from user's browser's accept-language header if provided
@@ -178,8 +179,9 @@ $default = array(
     'storage_filesystem_per_day_max_days_to_clean_empty_directories' => 150,
     'transfers_table_show_admin_full_path_to_each_file' => false,
     
-    'email_from' => 'sender',
-    'email_return_path' => 'sender',
+    'email_from' => 'no-reply@',
+    'email_return_path' => 'no-reply@',
+    
     'email_subject_prefix' => '{cfg:site_name}:',
     'email_headers' => false,
     'email_send_with_minus_r_option' => true,


### PR DESCRIPTION
The issue and potential default configuration value updates have been discussed in https://github.com/filesender/filesender/issues/1820.

This PR changes the default to "no-reply@" which will be expended to have `site_hostname` or the host name component from `site_url` appended to it to make a no reply address at the server machine name.

One reason site_hostname is handy is if you have the browser setup in a local test environment for a local host name on the LAN but the email system wants to have `.localdomain` added to the name. So you can set site_hostname to `mymachine.localdomain` and that will allow emails to be in the format that the SMTP server is expecting. If this happens on one dev machine it is likely to happen on 1+ machines so the option to optionally set this configuration variable is added here.
