### PR TITLE
optional: make guest csrf optional to allow sys admins to select

### DIFF
--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -109,7 +109,12 @@ class Security
         }
 
         if (Auth::isGuest()) {
+
             $checkToken = true;
+            
+            if( Utilities::isFalse(Config::get('validate_csrf_token_for_guests'))) {
+                $checkToken = false;
+            }
         }
         
         if( $checkToken ) {

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -59,7 +59,7 @@ A note about colours;
 * [cookie_domain](#cookie_domain)
 * [rate_limits](#rate_limits) (rate limits for some actions)
 * [valid_filename_regex](#valid_filename_regex)
-
+* [validate_csrf_token_for_guests](#validate_csrf_token_for_guests)
 
 ## Backend storage
 
@@ -804,6 +804,15 @@ $config['rate_limits'] = array(
   //  adds '+' in ASCII
   //  adds special character areas, for example MIDDLE DOT U+30FB
 $config['valid_filename_regex'] = '^['."\u{2010}-\u{2027}\u{2030}-\u{205F}\u{2070}-\u{FFEF}\u{10000}-\u{10FFFF}".' \\/\\p{L}\\p{N}_\\.,;:!@#$%^&*+)(\\]\\[_-]+';
+
+
+### validate_csrf_token_for_guests
+* __description:__ If CSRF token checks are performed for guest users.
+* __mandatory:__ no
+* __type:__ boolean
+* __default:__ true
+* __available:__ since version 2.50
+* __comment:__ 
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -357,6 +357,8 @@ $default = array(
     'download_show_download_links' => false,
 
     'read_only_mode' => false,
+
+    'validate_csrf_token_for_guests' => true,
     
     'transfer_options' => array(
         'email_me_copies' => array(


### PR DESCRIPTION
Some sites are wanting to disable this check for guests. The default is to perform the checks so security and configuration does not change unless you set this new option to `false`.

This is in response to a few requests in  https://github.com/filesender/filesender/issues/1514