### PR TITLE
d3: allow admin to view other guests

### DIFF
--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -22,14 +22,12 @@ $user = Auth::user();
 if( !Auth::isAuthenticated() || !$guest ) {
     $found = false;
 }
-if( $found ) {
-    if( Auth::isAdmin()) {
-        // admin is superuser.
-    } else {
-        if( $guest->userid != $user->id ) {
-            $found = false;
-        }
-    }   
+if( Auth::isAdmin()) {
+    // admin is superuser.
+} else {
+    if( $guest->userid != $user->id ) {
+        $found = false;
+    }
 }
 
 

--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -8,7 +8,7 @@ if(!isset($guest_id)) $guest_id = 0;
 $guest_id = Utilities::arrayKeyOrDefault($_GET, 'guest_id',  0, FILTER_VALIDATE_INT  );
 
 $guest = null;
-$found = 0;
+$found = false;
 if ($guest_id) {
     try {
         $guest = Guest::fromId($guest_id);
@@ -19,9 +19,19 @@ if ($guest_id) {
 }
 
 $user = Auth::user();
-if( !Auth::isAuthenticated() || !$guest || $guest->userid != $user->id ) {
+if( !Auth::isAuthenticated() || !$guest ) {
     $found = false;
 }
+if( $found ) {
+    if( Auth::isAdmin()) {
+        // admin is superuser.
+    } else {
+        if( $guest->userid != $user->id ) {
+            $found = false;
+        }
+    }   
+}
+
 
 ?>
 


### PR DESCRIPTION
This does the same thing as https://github.com/filesender/filesender/pull/2051 

This code is more verbose and checks are split out a bit more. I was in two minds in the past PR about if the isAdmin() lead to an empty // admin block or I used `!isAdmin()`. At any rate the guest owner check is in a different if block here.

The checks for guest id not found are still run even for admin. If the guest is no longer in the database trying to display it will likely end with errors on the page.
