### PR TITLE
d3 that found test is handy because we would need it anyway to test the guest

### DIFF
--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -22,14 +22,15 @@ $user = Auth::user();
 if( !Auth::isAuthenticated() || !$guest ) {
     $found = false;
 }
-if( Auth::isAdmin()) {
-    // admin is superuser.
-} else {
-    if( $guest->userid != $user->id ) {
-        $found = false;
+if( $found ) {
+    if( Auth::isAdmin()) {
+        // admin is superuser.
+    } else {
+        if( $guest->userid != $user->id ) {
+            $found = false;
+        }
     }
 }
-
 
 ?>
 


### PR DESCRIPTION
I removed the `if( $found )` test but it is needed to investigate the `$guest` object here.
An update to https://github.com/filesender/filesender/pull/2052