### PR TITLE
Fix: add empty file error to cli

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -597,6 +597,10 @@ for fn_abs in fileList:
 
   size = os.path.getsize(fn_abs)
 
+  if size == 0 and not os.path.isdir(fn_abs):
+    print(f"Error: empty file '{fn_abs}' cannot continue")
+    sys.exit(1)
+
   files[fn+':'+str(size)] = {
     'name':fn,
     'size':size,


### PR DESCRIPTION
Hi Team, 

Just a small change to add the empty file protection that exists in the webui into the cli. 
Currently these transfers just slowly fail, early warning makes it a little nicer for users.

I tested this with both empty files, normal files and a mix passed as a directory and had the expected behavior.
Please let me know if you have any questions.