### PR TITLE
shrink this down to 170 to cover legacy indexing sizes

### DIFF
--- a/classes/data/Authentication.class.php
+++ b/classes/data/Authentication.class.php
@@ -62,7 +62,7 @@ class Authentication extends DBObject
         ),
         'saml_user_identification_idp' => array(
             'type' => 'string',
-            'size' => 200,
+            'size' => 170,
             'null' => true
         ),
         'created' => array(


### PR DESCRIPTION
I recall there being some issue with varchar over 170 chars either in the index or one of the mysql storage backends. I don't recall the details but the 170 limit should be ok to differentiate the IdPs.