### PR TITLE
fix: Be nicer when deletions fail in cron

### DIFF
--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -114,7 +114,11 @@ if( $verbose ) echo "cron.php delete failed transfers...\n";
 foreach(Transfer::allFailed() as $transfer) {
     Logger::info($transfer.' failed, deleting it');
     if( $force ) {
-        $transfer->deleteForce = true;
+       try {
+            $transfer->deleteForce = true;
+       } catch (Exception $e) {
+               Logger::warn("Deleting transfer failed. error:" . $e->getMessage());
+       }
     }
     $transfer->delete();
 }


### PR DESCRIPTION
There are moments when even forcibly deleting causes failures, and causes cron to abort.
This adds a small handler in these cases. You are not 100% sure the file is deleted, but you have a warning in your logs and cron finishes.