### PR TITLE
Move $idp to use null if not defined or in use.

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -485,12 +485,18 @@ class Auth
     public static function getTenantAdminIDP()
     {
         // Admins can pretend to be tenant admins (like in the statistics page)
-        if (self::isAdmin() && array_key_exists('idp', $_GET))
-            if ($_GET['idp']!='all')
-                return $_GET['idp'];
+        if (self::isAdmin()) {
+            if(array_key_exists('idp', $_GET)) {
+                if ($_GET['idp']!='all') {
+                    return $_GET['idp'];
+                }
+            }
+        }
 
-        if (!self::isTenantAdmin())
-            return false;
+        if (!self::isTenantAdmin()) {
+            return null;
+        }
+        
         return self::user()->saml_user_identification_idp;
     }
 

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -259,10 +259,12 @@ class Recipient extends DBObject
     /*
      * Count how many unique recipients we have or a tenant has
      */
-    public static function getRecipients($idp=false)
+    public static function getRecipients( $idp = null )
     {
-        if ($idp===false)
+        if (!$idp) {
             return self::countEstimate();
+        }
+        
         $sql = 'SELECT COUNT(DISTINCT '.self::getDBTable().'.id) as recipientscount FROM '.self::getDBTable().' LEFT JOIN '.call_user_func('Transfer::getDBTable').' ON '.self::getDBTable().'.transfer_id='.call_user_func('Transfer::getDBTable').'.id LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.call_user_func('Transfer::getDBTable').'.userid='.call_user_func('Authentication::getDBTable').'.id WHERE '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp';
         $statement = DBI::prepare($sql);
         $placeholders =  array(':idp' => $idp);

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -636,7 +636,7 @@ class Transfer extends DBObject
      *
      * @return array
      */
-    public static function getUsage($idp=false)
+    public static function getUsage( $idp = null )
     {
         $quota = Config::get('host_quota');
         
@@ -648,7 +648,7 @@ class Transfer extends DBObject
         }
 
         $idpused = false;
-        if ($idp!==false) {
+        if ($idp) {
             $sql = 'SELECT SUM(size) AS size FROM '.File::getDBTable().' INNER JOIN '.self::getDBTable().' ON ('.self::getDBTable().'.id = '.File::getDBTable().'.transfer_id) LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.self::getDBTable().'.userid='.call_user_func('Authentication::getDBTable').'.id WHERE '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '.self::AVAILABLE_NO_ORDER;
             $statement = DBI::prepare($sql);
             $placeholders =  array(':idp' => $idp);
@@ -672,11 +672,12 @@ class Transfer extends DBObject
      *
      * @return array of Transfer
      */
-    public static function allAvailable($idp=false)
+    public static function allAvailable( $idp = null )
     {
-        if ($idp===false)
+        if (!$idp) {
             return self::all(self::AVAILABLE);
-
+        }
+        
         $sql = 'SELECT '.self::getDBTable().'.* FROM '.self::getDBTable().' LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.self::getDBTable().'.userid='.call_user_func('Authentication::getDBTable').'.id WHERE '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '.self::AVAILABLE;
         $statement = DBI::prepare($sql);
         $placeholders =  array(':idp' => $idp);
@@ -689,10 +690,11 @@ class Transfer extends DBObject
      *
      * @return array of Transfer
      */
-    public static function allUploading($idp=false)
+    public static function allUploading( $idp = null )
     {
-        if ($idp===false)
+        if (!$idp) {
             return self::all(self::UPLOADING);
+        }
 
         $sql = 'SELECT '.self::getDBTable().'.* FROM '.self::getDBTable().' LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.self::getDBTable().'.userid='.call_user_func('Authentication::getDBTable').'.id WHERE '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '.self::UPLOADING;
         $statement = DBI::prepare($sql);
@@ -706,10 +708,11 @@ class Transfer extends DBObject
      *
      * @return array of Transfer
      */
-    public static function allExpired($idp=false)
+    public static function allExpired( $idp = null )
     {
-        if ($idp===false)
+        if (!$idp) {
             return self::all(self::EXPIRED, array(':date' => date('Y-m-d')));
+        }
 
         $sql = 'SELECT '.self::getDBTable().'.* FROM '.self::getDBTable().' LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.self::getDBTable().'.userid='.call_user_func('Authentication::getDBTable').'.id WHERE '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '.self::EXPIRED;
         $statement = DBI::prepare($sql);

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -919,10 +919,12 @@ class User extends DBObject
     /*
      * Count how many users we have or a tenant has
      */
-    public static function users($idp=false)
+    public static function users( $idp = null )
     {
-        if ($idp===false)
+        if ( !$idp ) {
             return self::countEstimate();
+        }
+        
         $statement = DBI::prepare('SELECT COUNT(*) as userscount FROM '.call_user_func('Authentication::getDBTable').' WHERE saml_user_identification_idp = :idp');
         $statement->execute(array(':idp' => $idp));
         $data = $statement->fetch();
@@ -932,9 +934,9 @@ class User extends DBObject
     /*
      * Count how many signed AUPs we have or a tenant has
      */
-    public static function usersSignedAUP($idp=false)
+    public static function usersSignedAUP( $idp = null )
     {
-        if ($idp===false) {
+        if ( !$idp ) {
             $sql='SELECT COUNT(service_aup_accepted_version) as aupcount FROM '.self::getDBTable().' WHERE UserPreferences.service_aup_accepted_version >= :aup';
             $statement = DBI::prepare($sql);
             $statement->execute(array(':aup' => Config::get('service_aup_min_required_version')));
@@ -953,9 +955,9 @@ class User extends DBObject
     /*
      * Count how many API Keys we have or a tenant has
      */
-    public static function usersWithAPIKey($idp=false)
+    public static function usersWithAPIKey( $idp = null )
     {
-        if ($idp===false) {
+        if (!$idp) {
             $sql='SELECT COUNT(auth_secret) as apicount FROM '.self::getDBTable().' WHERE auth_secret IS NOT NULL';
             $statement = DBI::prepare($sql);
             $statement->execute();

--- a/www/js/graph/statistics_data_per_day_graph.php
+++ b/www/js/graph/statistics_data_per_day_graph.php
@@ -76,7 +76,7 @@ $data = array(
 $sql =
     'SELECT '
    .'  Date.date, '
-   .(($idp===false) ?
+   .((!$idp) ?
         '  (SELECT SUM(size) FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as total, '
        .'  (SELECT MAX(size) FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as max, '
        .'  (SELECT AVG(size) FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as avg, '
@@ -97,7 +97,7 @@ $sql =
    .'ORDER BY date';
 
 $placeholders=array();
-if ($idp!==false)
+if ($idp)
     $placeholders[':idp'] = $idp;
 
 //error_log($sql);

--- a/www/js/graph/statistics_encryption_split_graph.php
+++ b/www/js/graph/statistics_encryption_split_graph.php
@@ -11,7 +11,7 @@ $idp = Auth::getTenantAdminIDP();
 
 $sql = '';
 $placeholders = array();
-if ($idp===false) {
+if (!$idp) {
     $sql =
         'SELECT '
        .'  SUM(case WHEN options LIKE \'%\\"encryption\\":false%\' THEN 1 ELSE 0 END) as "Unencrypted", '

--- a/www/js/graph/statistics_transfers_speeds_graph.php
+++ b/www/js/graph/statistics_transfers_speeds_graph.php
@@ -60,7 +60,7 @@ $data = array(
 $sql =
     'SELECT '
    .'  Date.date, '
-   .(($idp===false) ?
+   .((!$idp) ?
         '  (SELECT MAX(size/(UNIX_TIMESTAMP(made_available)-UNIX_TIMESTAMP(created)))/1048576 FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":false%\') as Unencrypted, '
        .'  (SELECT MAX(size/(UNIX_TIMESTAMP(made_available)-UNIX_TIMESTAMP(created)))/1048576 FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":true%\') as Encrypted '
      :
@@ -77,7 +77,7 @@ $sql =
    .'ORDER BY date';
 
 $placeholders = array();
-if ($idp!==false)
+if ($idp)
     $placeholders[':idp'] = $idp;
 
 //error_log($sql);

--- a/www/js/graph/statistics_transfers_vouchers_graph.php
+++ b/www/js/graph/statistics_transfers_vouchers_graph.php
@@ -60,7 +60,7 @@ $data = array(
 $sql =
     'SELECT '
    .'  Date.date, '
-   .(($idp===false) ?
+   .((!$idp) ?
         '  (SELECT COUNT(id) FROM '.call_user_func('Transfer::getDBTable').' WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as transfers, '
        .'  (SELECT COUNT(id) FROM '.call_user_func('Guest::getDBTable').' WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as guests '
      :
@@ -77,7 +77,7 @@ $sql =
    .'ORDER BY date';
 
 $placeholders = array();
-if ($idp!==false)
+if ($idp)
     $placeholders[':idp'] = $idp;
 
 //error_log($sql);

--- a/www/lib/tables/statistics_page.php
+++ b/www/lib/tables/statistics_page.php
@@ -58,13 +58,13 @@ switch ($_GET['t']) {
            .'  SUM('.call_user_func('Transfer::getDBTable').'.download_count) as "Downloads" '
            .'FROM '
            .'  '.call_user_func('Transfer::getDBTable').' JOIN '.call_user_func('File::getDBTable').' ON '.call_user_func('File::getDBTable').'.transfer_id='.call_user_func('Transfer::getDBTable').'.id '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              'LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.call_user_func('Transfer::getDBTable').'.userid='.call_user_func('Authentication::getDBTable').'.id '
            )
            .'WHERE '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '
@@ -76,7 +76,7 @@ switch ($_GET['t']) {
            .'ORDER BY Transfers DESC '
            .'LIMIT '.$start.', '.$pagelimit;
         $placeholders=array();
-        if ($idp!==false)
+        if ($idp)
             $placeholders[':idp'] = $idp;
 
         //error_log($sql);
@@ -104,13 +104,13 @@ switch ($_GET['t']) {
            .'  SUM('.call_user_func('Transfer::getDBTable').'.download_count) as "Downloads" '
            .'FROM '
            .'  '.call_user_func('Transfer::getDBTable').' JOIN '.call_user_func('File::getDBTable').' ON '.call_user_func('File::getDBTable').'.transfer_id='.call_user_func('Transfer::getDBTable').'.id '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              'LEFT JOIN '.call_user_func('Authentication::getDBTable').' ON '.call_user_func('Transfer::getDBTable').'.userid='.call_user_func('Authentication::getDBTable').'.id '
            )
            .'WHERE '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '
@@ -121,7 +121,7 @@ switch ($_GET['t']) {
            .'ORDER BY Transfers DESC '
            .'LIMIT '.$start.', '.$pagelimit;
         $placeholders=array();
-        if ($idp!==false)
+        if ($idp)
             $placeholders[':idp'] = $idp;
 
         //error_log($sql);
@@ -147,7 +147,7 @@ switch ($_GET['t']) {
            .'FROM '
            .'  filesbywhoview LEFT JOIN '.call_user_func('Authentication::getDBTable').' on filesbywhoview.userid='.call_user_func('Authentication::getDBTable').'.id '
            .'WHERE '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp AND '
@@ -158,7 +158,7 @@ switch ($_GET['t']) {
            .'ORDER BY Total DESC '
            .'LIMIT '.$start.', '.$pagelimit;
         $placeholders=array();
-        if ($idp!==false)
+        if ($idp)
             $placeholders[':idp'] = $idp;
 
         //error_log($sql);
@@ -186,7 +186,7 @@ switch ($_GET['t']) {
            .'  '.call_user_func('Authentication::getDBTable').' LEFT JOIN '.call_user_func('User::getDBTable').' on '.call_user_func('Authentication::getDBTable').'.id='.call_user_func('User::getDBTable').'.authid '
            .'WHERE '
            .'  '.call_user_func('User::getDBTable').'.auth_secret IS NOT NULL '
-           .(($idp===false) ?
+           .((!$idp) ?
              ''
              :
              'AND '.call_user_func('Authentication::getDBTable').'.saml_user_identification_idp = :idp '
@@ -194,7 +194,7 @@ switch ($_GET['t']) {
            .'ORDER BY Date DESC '
            .'LIMIT '.$start.', '.$pagelimit;
         $placeholders=array();
-        if ($idp!==false)
+        if ($idp)
             $placeholders[':idp'] = $idp;
 
         //error_log($sql);


### PR DESCRIPTION
As the database might have null for the idp the code should probably handle the null case anyway. This way we either now (or know and have permission to use) the idp or we have to fall back if it is null.

This relates to https://github.com/filesender/filesender/pull/2099
