### PR TITLE
Use a view with group by on idp for disk usage

### DIFF
--- a/classes/data/DBObject.class.php
+++ b/classes/data/DBObject.class.php
@@ -370,6 +370,25 @@ class DBObject
         $data = $statement->fetch();
         return $data['count'];
     }
+
+    /**
+     * Get a single tuple result for a query
+     *
+     * @param string $criteria sql criteria and/or pagination options
+     * @param array $placeholders
+     *
+     * @return the one tuple
+     */
+    public static function pick($columns = '*', $criteria = null, $placeholders = array())
+    {
+        $statement = self::buildStatement($columns,$criteria, $placeholders);
+        
+        // run it
+        $statement->execute($placeholders);
+
+        $data = $statement->fetch();
+        return $data;
+    }
     
     /**
      * convert the result of an sql query on this table to a set objects


### PR DESCRIPTION
The auths.id can not be used directly, it needs to be accessed through user.authid.

This relates to https://github.com/filesender/filesender/pull/2099