### PR TITLE
get nice idp name using config option auth_sp_idp_filters

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -100,11 +100,11 @@ class AuthSPSaml
 
             // Get IDP from SSP
             $idp = trim($ssp->getAuthData('saml:sp:IdP'));
-            $idp_nice = parse_url($idp, PHP_URL_HOST);
-            if ($idp_nice == '') {
-                $idp_nice = $idp;
+            $idp_filters = Config::get('auth_sp_idp_filters');
+            foreach($idp_filters as $idp_filter) {
+                $idp = preg_replace($idp_filter[0], $idp_filter[1], $idp);
             }
-            $attributes['idp'] = $idp_nice;
+            $attributes['idp'] = $idp;
             
             // Wanted attributes
             foreach (array('uid', 'name', 'email') as $attr) {

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -265,8 +265,9 @@ A note about colours;
 	* [auth_sp_saml_uid_attribute](#auth_sp_saml_uid_attribute)
 	* [auth_sp_saml_entitlement_attribute](#auth_sp_saml_entitlement_attribute)
 	* [auth_sp_saml_admin_entitlement](#auth_sp_saml_admin_entitlement)
-    * [using_local_saml_dbauth](#using_local_saml_dbauth)
-    * [auth_warn_session_expired](#auth_warn_session_expired)
+	* [using_local_saml_dbauth](#using_local_saml_dbauth)
+	* [auth_warn_session_expired](#auth_warn_session_expired)
+	* [auth_sp_idp_filters](#auth_sp_idp_filters)
 * __Shibboleth__
 	* [auth_sp_shibboleth_uid_attribute](#auth_sp_shibboleth_uid_attribute)
 	* [auth_sp_shibboleth_email_attribute](#auth_sp_shibboleth_email_attribute)
@@ -2883,8 +2884,14 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __comment:__ Note: enabling this setting will use a cookie X-FileSender-Session-Expires to support the functionality. 
                The warning does not happen during an upload because the session may expire there and the upload can still complete.
 
+### auth_sp_idp_filters
 
-
+* __description:__ Replacement filters to run on IDP entityIDs to make them read nicer
+* __mandatory:__ no
+* __type:__ array
+* __default:__ 
+* __available:__ since version 3.1
+* __comment:__ Note: setting this will overwrite the default values. If you want them include them in your custom config.
 
 
 ## Authentication: Shibboleth

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -66,6 +66,10 @@ $default = array(
     'auth_sp_shibboleth_name_attribute' => 'cn', // Get name attribute from authentification service
     'auth_sp_shibboleth_uid_attribute' => 'eduPersonTargetedID', // Get uid attribute from authentification service
     'auth_sp_force_session_start_first' => false,  // maybe move session_start() forward.
+    'auth_sp_idp_filters' => array(
+        array('/^https*:\/\//', ''), // get rid of https://
+        array('/\/$/', '') // remove a trailing slash (/)
+    ),
 
     'auth_remote_user_autogenerate_secret' => false,
     'auth_remote_signature_algorithm' => 'sha1',


### PR DESCRIPTION
This is important as IDPs that use Microsoft AD used to show up as `sts.windows.net` and the what we need is the full path.
Creating filters makes this easier. Default filters are set to do very simple things. On ours we would add extra custom filter like:
```
['/\/idp\/shibboleth/',''],
['/sts.windows.net/','Microsoft'],
```
to make things nicer.