### PR TITLE
Possible to save storage subpath in database for easier migration.

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -122,7 +122,17 @@ class File extends DBObject
         'have_avresults' => array(
             'type' => 'bool',
             'default' => false
-        )
+        ),
+
+        // used by storage::buildPath to cache the storage path used for this file
+        // this may allow migration of settings in the future with access
+        // to existing files.
+        'storage_path' => array(
+            'type' => 'string',
+            'size' => 170,
+            'null' => true
+        ),
+        
     );
 
     protected static $secondaryIndexMap = array(
@@ -178,6 +188,7 @@ class File extends DBObject
     protected $aead = null;
     protected $have_avresults = false;
     protected $storage_class_name = ''; // set in constructor
+    protected $storage_path = null;
    
     /**
      * Related objects cache
@@ -502,7 +513,7 @@ class File extends DBObject
     {
         if (in_array($property, array(
             'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1'
-          , 'storage_class_name', 'iv', 'aead', 'have_avresults'
+          , 'storage_class_name', 'iv', 'aead', 'have_avresults', 'storage_path'
         ))) {
             return $this->$property;
         }
@@ -614,6 +625,8 @@ class File extends DBObject
             $this->aead = $value;
         } elseif ($property == 'have_avresults') {
             $this->have_avresults = $value;
+        } elseif ($property == 'storage_path') {
+            $this->storage_path = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -323,6 +323,8 @@ class StorageFilesystem
      * Build file storage path (without filename)
      *
      * @param File $file
+     * @param string fillPath This is currently only used in the test suite. Using it might break
+     *                        migration of path mangling settings.
      *
      * @return string path
      */
@@ -424,6 +426,15 @@ class StorageFilesystem
             } catch (Exception $e) {
                 Logger::error("Issue with per day buckets and UUID");
                 return $path;
+            }
+        }
+
+        // cache the subpath
+        if( $fullPath ) {
+            if( Config::get('storage_filesystem_explicitly_store_subpath_per_file')) {
+                if( !$file->storage_path ) {
+                    $file->storage_path = $path;
+                }
             }
         }
   

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -68,6 +68,7 @@ A note about colours;
 
 * [storage_type](#storage_type)
 * [storage_filesystem_path](#storage_filesystem_path)
+* [storage_filesystem_explicitly_store_subpath_per_file](#storage_filesystem_explicitly_store_subpath_per_file)
 * [storage_filesystem_df_command](#storage_filesystem_df_command)
 * [storage_filesystem_file_deletion_command](#storage_filesystem_file_deletion_command)
 * [storage_filesystem_tree_deletion_command](#storage_filesystem_tree_deletion_command)
@@ -873,6 +874,17 @@ $config['valid_filename_regex'] = '^['."\u{2010}-\u{2027}\u{2030}-\u{205F}\u{207
 * __available:__ since version 1.0
 * __1.x name:__ site_filestore
 * __comment:__
+
+
+### storage_filesystem_explicitly_store_subpath_per_file
+
+* __description:__ If you are looking to migrate what subpaths are used in the storage for your filesender you might like to enable this feature. It will explicitly store the computed subpath in the database for each file.
+* __mandatory:__ no
+* __type:__ bool
+* __default:__ false
+* __available:__ since version 3.0rc5
+* __comment:__ This will store the computed subpath in the database for each file. As of rc5 only storage of this path is available. In the future it might allow for changing the bucket storage (storage_filesystem_per_day_buckets et al), idp storage (storage_filesystem_per_idp) settings while files previously uploaded will remain available. Being able to store this path is the first step, any migration will require the paths to be explicitly stored in order to work.
+
 
 ### storage_filesystem_df_command
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -181,6 +181,7 @@ $default = array(
     'storage_filesystem_per_day_min_days_to_clean_empty_directories' => -1,
     'storage_filesystem_per_day_max_days_to_clean_empty_directories' => 150,
     'storage_filesystem_per_idp' => false,
+    'storage_filesystem_explicitly_store_subpath_per_file' => false,
     'transfers_table_show_admin_full_path_to_each_file' => false,
     
     'email_from' => 'no-reply@',


### PR DESCRIPTION
New option to allow the path from storage to be stored per file in the database. This is the first step towards allowing various settings like per day buckets and idp in the storage path to be changed and existing files continue to be downloadable.

This PR only optionally stores the path. A future PR will allow that information to be used and this allow storage settings to change and existing files (uploaded with this new
storage_filesystem_explicitly_store_subpath_per_file enabled) to continue to be downloaded in the face of settings changes.

This was inspired by https://github.com/filesender/filesender/pull/2119