### PR TITLE
3.0rc defaults update

### DIFF
--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -1281,32 +1281,33 @@ User language detection is done in the following order:
 * __description:__ allow explicit language switching via URL (example: ?lang=en)
 * __mandatory:__ no (required when using lang_browser_enabled)
 * __type:__ boolean
-* __default:__ false
+* __default:__ true
 * __available:__ since version 2.0
 * __1.x name:__
-* __comment:__
+* __comment:__ Default changed to true in 3.0
 
 ### lang_userpref_enabled
 
 * __description:__ take user's preferred language from user's stored preferences.  These preferences are stored in the FileSender database.
 * __mandatory:__ no
 * __type:__ boolean
-* __default:__ false
+* __default:__ true
 * __available:__ since version 2.0
 * __1.x name:__
-* __comment:__
+* __comment:__ Default switched to true in 3.0
 
 ### lang_selector_enabled
 
 * __description:__ display language selector in UI .  If your FileSender instance only supports 1 language no selector is displayed and no "translate this email" link is present in emails.
 * __mandatory:__ no
 * __type:__ boolean
-* __default:__ false
+* __default:__ true
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__ requires lang_url_enabled to be true.
 * __comment:__ <span style="background-color:orange">if the lang_selector is disabled a user can still select different translations in the email translation page</span>
 * __comment:__ <span style="background-color:orange">how is determined which language the lang selector defaults to when a user enters a page?  Browser setting?  Order in locale.php? </span>
+* __comment:__ Default changed to true in 3.0
 
 ### lang_save_url_switch_in_userpref
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -48,8 +48,8 @@ $default = array(
     'site_logo' => '', // [optional] This allows a different logo image to be used per site using auth_config_regex_files
     'email_use_html' => true,   // By default, use HTML on mails
     'relay_unknown_feedbacks' => 'sender',   // Report email feedbacks with unknown type but with identified target (recipient or guest) to target owner
-    'upload_display_bits_per_sec' => true, // By default, do not show bits per seconds
-    'upload_display_per_file_stats' => true, //
+    'upload_display_bits_per_sec' => false, // By default, do not show bits per seconds
+    'upload_display_per_file_stats' => false, //
     'upload_force_transfer_resume_forget_if_encrypted' => false, //
     'upload_considered_too_slow_if_no_progress_for_seconds' => 30, // seconds
     'force_ssl' => true,
@@ -245,7 +245,7 @@ $default = array(
         return Config::get('site_url').'?s=logout';
     },
 
-    'admin_can_view_user_transfers_page' => true,
+    'admin_can_view_user_transfers_page' => false,
     'show_storage_statistics_in_admin' => true,
     'statistics_table_rows_per_page' => 10,
 


### PR DESCRIPTION
* Document changed defaults for language switcher 
* Revert default changes where there is no clear benefit: `upload_display_bits_per_sec`, `upload_display_per_file_stats` and `admin_can_view_user_transfers_page` had their defaults changed in an earlier PR, but there seems no added benefit

Fixes #1650 