### PR TITLE
Set the HTTP_HOST so that SimpleSAMLphp has the FQDN

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -282,6 +282,10 @@ class AuthSPSaml
             }
         }
 
+        if(!array_key_exists("HTTP_HOST",$_SERVER)) {
+            $_SERVER["HTTP_HOST"] = Config::get("site_hostname");
+        }
+        
         Auth::$authClassLoadingCount++;
         if (is_null(self::$simplesamlphp_auth_simple)) {
             $saml_auto_load_path = self::$config['simplesamlphp_location'] . 'lib/_autoload.php';


### PR DESCRIPTION
The cron jobs are not executed via an HTTP request so they do not have this key set in the _SERVER variable. Without it the default of localhost might be used by SSP because it is expecting to be called from an HTTP request in php.