### PR TITLE
Allow anonymous access to the filelist of a transfer

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -183,10 +183,6 @@ class RestEndpointTransfer extends RestEndpoint
             if (!Utilities::isValidUID($token)) {
                 throw new RestBadParameterException('token');
             }
-            // Need to be authenticated
-            if (!Auth::isAuthenticated()) {
-                throw new RestAuthenticationRequiredException();
-            }
             
             $recipient = Recipient::fromToken($token);
             if ($recipient->transfer) {


### PR DESCRIPTION
In line with the remarks in #1555 and as a followup of #1569 this removes the need for users to be authenticated to access the filelist.

Use case: An authenticated user, for example a researcher, creates a transfer and allows anonymous download by sharing the download link to his newest paper on his blog.

Why the change:
Any anonymous user that is intended to download a transfer because he is the bearer of the needed token can now obtain details about the filelist, so further download of files via the REST API is possible.

Because an anonymous user can only authenticate themselves by the token, the need to be authenticated to FileSender in addition to presenting the token is odd.

As an alternative, we could make this a configurable, but I'm unsure if anyone would even be able to meet the requirements via the API to download the filelist then.

