### PR TITLE
updated chunk vary

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -267,6 +267,7 @@ class File extends DBObject
     private function calculateEncryptedFileSize()
     {
         $upload_chunk_size = Config::get('upload_chunk_size');
+
         
         $echunkdiff = Config::get('upload_crypted_chunk_size') - $upload_chunk_size;
         $chunksMinusOne = ceil($this->size / $upload_chunk_size)-1;
@@ -507,6 +508,10 @@ class File extends DBObject
             return $this->$property;
         }
 
+        if(in_array($property, array('chunk_size', 'crypted_chunk_size'))) {
+            return $this->transfer->$property;
+        }
+        
         if ($property == 'id') {
             if (is_null($this->id)) {
                 $this->save();

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -180,7 +180,20 @@ class Transfer extends DBObject
             'default' => 0,
             'null'    => false,
         ),
-        
+
+        'chunk_size' => array(
+            'type'    => 'uint',
+            'size'    => 'big',
+            'null'    => false,
+            'default' => 0
+        ),
+        'crypted_chunk_size' => array(
+            'type'    => 'uint',
+            'size'    => 'big',
+            'null'    => false,
+            'default' => 0
+        ),
+
     );
 
     /**
@@ -338,7 +351,10 @@ class Transfer extends DBObject
     protected $storage_filesystem_per_day_buckets = false;
     protected $storage_filesystem_per_hour_buckets = false;
     protected $download_count = 0;
+    protected $chunk_size = 0;
+    protected $crypted_chunk_size = 0;
 
+    
     
     /**
      * Related objects cache
@@ -368,6 +384,8 @@ class Transfer extends DBObject
         $this->storage_filesystem_per_day_buckets = Config::get('storage_filesystem_per_day_buckets');
         $this->storage_filesystem_per_hour_buckets = Config::get('storage_filesystem_per_hour_buckets');
         $this->download_count = 0;
+        $this->chunk_size = Config::get('upload_chunk_size');
+        $this->crypted_chunk_size = Config::get('upload_crypted_chunk_size');
         
         if (!is_null($id)) {
             // Load from database if id given
@@ -389,7 +407,6 @@ class Transfer extends DBObject
             CollectionType::initialize();
             $this->collectionsCache = Collection::fromTransfer($this);
         }
-
     }
     
     /**
@@ -1076,7 +1093,7 @@ class Transfer extends DBObject
             'password_version', 'password_encoding', 'password_encoding_string', 'password_hash_iterations'
             , 'client_entropy', 'roundtriptoken', 'guest_transfer_shown_to_user_who_invited_guest'
             , 'storage_filesystem_per_day_buckets', 'storage_filesystem_per_hour_buckets'
-            , 'download_count'
+          , 'download_count', 'chunk_size', 'crypted_chunk_size'
             
         ))) {
             return $this->$property;

--- a/classes/storage/Storage.class.php
+++ b/classes/storage/Storage.class.php
@@ -170,7 +170,6 @@ class Storage
                 $offset = 0;
             }
         }
-        
         // Ask underlying class to read data
         $data = call_user_func(self::getStorageClass($file).'::readChunk', $file, $offset, $length);
         

--- a/classes/storage/StorageCloudAzure.class.php
+++ b/classes/storage/StorageCloudAzure.class.php
@@ -67,16 +67,20 @@ class StorageCloudAzure extends StorageFilesystem
         return $blobClient;
     }
     
+    // seems deprecated
     public static function getOffsetWithinBlob($offset)
     {
         $file_chunk_size = Config::get('upload_chunk_size');
         return ($offset % $file_chunk_size);
     }
     
-    public static function getBlobName($offset)
+    public static function getBlobName(File $file, $offset)
     {
-        $file_chunk_size = Config::get('upload_chunk_size');
-        $offset = $offset - ($offset % $file_chunk_size);
+        $chunk_size = Config::get('upload_chunk_size');
+        $chunk_size = $file->transfer->chunk_size;
+        $crypted_chunk_size = $file->transfer->crypted_chunk_size;
+        
+        $offset = $offset - ($offset % $chunk_size);
         return str_pad($offset, 24, '0', STR_PAD_LEFT);
     }
 
@@ -94,12 +98,15 @@ class StorageCloudAzure extends StorageFilesystem
      */
     public static function readChunk(File $file, $offset, $length)
     {
+        $chunk_size = $file->transfer->chunk_size;
+        $crypted_chunk_size = $file->transfer->crypted_chunk_size;
+        
         if ($file->transfer->options['encryption']) {
-            $offset=$offset/Config::get('upload_chunk_size')*Config::get('upload_crypted_chunk_size');
+            $offset = $offset / $chunk_size * $crypted_chunk_size;
         }
 
         $container_name = $file->uid;
-        $blob_name      = self::getBlobName($offset);
+        $blob_name      = self::getBlobName($file,$offset);
         
         try {
             $az = self::getBlobService();
@@ -140,7 +147,7 @@ class StorageCloudAzure extends StorageFilesystem
     {
         $chunk_size     = strlen($data);
         $container_name = $file->uid;
-        $blob_name      = self::getBlobName($offset);
+        $blob_name      = self::getBlobName($file,$offset);
 
         try {
             $az = self::getBlobService();
@@ -191,7 +198,6 @@ class StorageCloudAzure extends StorageFilesystem
      */
     public static function deleteFile(File $file)
     {
-        $chunk_size     = strlen($data);
         $container_name = $file->uid;
 
         try {

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -67,7 +67,8 @@ class StorageCloudS3 extends StorageFilesystem
         
         return self::$client;
     }
-    
+
+    // seems deprecated
     public static function getOffsetWithinBlob( $offset )
     {
         $file_chunk_size = Config::get('upload_chunk_size');
@@ -87,8 +88,11 @@ class StorageCloudS3 extends StorageFilesystem
     
     public static function getObjectName( File $file, $offset )
     {
-        $file_chunk_size = Config::get('upload_chunk_size');
-        $offset = $offset - ($offset % $file_chunk_size);
+        $chunk_size = Config::get('upload_chunk_size');
+        $chunk_size = $file->transfer->chunk_size;
+        $crypted_chunk_size = $file->transfer->crypted_chunk_size;
+        
+        $offset = $offset - ($offset % $chunk_size);
         $object_name = str_pad($offset, 24, '0', STR_PAD_LEFT);
 
         if( self::usingCustomBucketName( $file ) ) {
@@ -120,8 +124,11 @@ class StorageCloudS3 extends StorageFilesystem
      */
     public static function readChunk(File $file, $offset, $length)
     {
+        $chunk_size = $file->transfer->chunk_size;
+        $crypted_chunk_size = $file->transfer->crypted_chunk_size;
+        
         if ($file->transfer->options['encryption']) {
-            $offset=$offset/Config::get('upload_chunk_size')*Config::get('upload_crypted_chunk_size');
+            $offset = $offset / $chunk_size * $crypted_chunk_size;
         }
 
         $bucket_name = self::getBucketName( $file );

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -440,6 +440,8 @@ class StorageFilesystem
     public static function readChunk(File $file, $offset, $length)
     {
         $chunk_size = (int)Config::get('download_chunk_size');
+        $chunk_size = $file->transfer->chunk_size;
+        $crypted_chunk_size = $file->transfer->crypted_chunk_size;
         
         $file_path = static::buildPath($file).static::buildFilename($file);
         
@@ -448,7 +450,7 @@ class StorageFilesystem
         }
 
         if ($file->transfer->is_encrypted) {
-            $offset=floor($offset/Config::get('upload_chunk_size')*Config::get('upload_crypted_chunk_size'));
+            $offset=floor($offset / $chunk_size * $crypted_chunk_size);
         }
 
         // Open file for reading

--- a/classes/storage/StorageFilesystemChunkedStream.class.php
+++ b/classes/storage/StorageFilesystemChunkedStream.class.php
@@ -68,7 +68,7 @@ class StorageFilesystemChunkedStream
         }
         
         $file_path = StorageFilesystem::buildPath($file).$file->uid;
-        $chunkFile = StorageFilesystemChunked::getChunkFilename($file_path, $offset);
+        $chunkFile = StorageFilesystemChunked::getChunkFilename($file, $file_path, $offset);
 
 
         if (strcmp($this->currentChunkFile, $chunkFile)) {
@@ -80,7 +80,7 @@ class StorageFilesystemChunkedStream
                 return false;
             }
             
-            $rc = fseek($fh, StorageFilesystemChunked::getOffsetWithinChunkedFile($offset));
+            $rc = fseek($fh, StorageFilesystemChunked::getOffsetWithinChunkedFile($file, $offset));
             if ($rc == -1) {
                 $this->gameOver = true;
                 if ($this->fh) {

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -744,6 +744,7 @@ class Config
         }
     }
 
+    
 }
 
 /**

--- a/codeception.yml
+++ b/codeception.yml
@@ -10,3 +10,4 @@ actor_suffix: Tester
 extensions:
     enabled:
         - Codeception\Extension\RunFailed
+bootstrap: bootstrap.php

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -743,6 +743,15 @@ try {
     }
 
     verifyTableCharacterSets();
+
+    // set the chunk size info to current settings for tuples that didn't have any value
+    $chunk_size = Config::get('upload_chunk_size');
+    $crypted_chunk_size = Config::get('upload_crypted_chunk_size');
+    $tbl_transfers = call_user_func('Transfer::getDBTable');
+    $statement = DBI::prepare("UPDATE $tbl_transfers set chunk_size = :chunk_size, crypted_chunk_size=:crypted_chunk_size where chunk_size=0 "  );
+    $placeholders =  array(':chunk_size' => $chunk_size,
+                           ':crypted_chunk_size' => $crypted_chunk_size);
+    $statement->execute($placeholders);
     
     
 } catch(Exception $e) {

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -265,6 +265,8 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
         <div class="file" data-id="<?php   echo Template::Q($file->id) ?>"
              data-encrypted="<?php         echo isset($transfer->options['encryption'])?Utilities::isTrue($transfer->options['encryption']):'false'; ?>"
              data-mime="<?php              echo Template::Q($file->mime_type); ?>"
+             data-chunk-size="<?php         echo Template::Q($file->chunk_size); ?>"
+             data-crypted-chunk-size="<?php echo Template::Q($file->crypted_chunk_size); ?>"
              data-name="<?php              echo Template::Q($file->path); ?>"
              data-size="<?php              echo Template::Q($file->size); ?>"
              data-encrypted-size="<?php    echo Template::Q($file->encrypted_size); ?>"

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -468,6 +468,8 @@ if (!function_exists('clickableHeader')) {
                              data-fileiv="<?php                   echo Template::Q($file->iv); ?>"
                              data-fileaead="<?php                 echo Template::Q($file->aead); ?>"
                              data-transferid="<?php               echo Template::Q($transfer->id); ?>"
+                             data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
+                             data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"
                         >
                             <?php echo Template::Q($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo count($file->downloads) ?> {tr:downloads}
                             
@@ -489,6 +491,8 @@ if (!function_exists('clickableHeader')) {
                                         data-fileiv="<?php            echo Template::Q($file->iv); ?>"
                                         data-fileaead="<?php          echo Template::Q($file->aead); ?>"
                                         data-transferid="<?php        echo Template::Q($transfer->id); ?>"
+                                        data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
+                                        data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"
                                 ></span>
                                         
                                 <?php } else {?>

--- a/unittests/codeception/accept-dialog.sh
+++ b/unittests/codeception/accept-dialog.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+name=`uuidgen`
+
+mkdir -p /tmp/selenium-downloads
+
+echo "$name" >| /tmp/selenium-downloads/active.txt
+
+sleep 1
+xdotool search "Warning: this site can see edits you make" windowactivate
+sleep 1
+xdotool type "$name"
+xdotool key Return

--- a/unittests/codeception/acceptance.suite.yml
+++ b/unittests/codeception/acceptance.suite.yml
@@ -1,9 +1,10 @@
 actor: AcceptanceTester
 modules:
     enabled:
-        - WebDriver:
-            browser: chrome
-            url: 'http://localhost/filesender'
+      - Asserts
+      - WebDriver:
+          browser: chrome
+          url: 'http://localhost/filesender'
             
 step_decorators:
   - \Codeception\Step\Retry

--- a/unittests/codeception/acceptance/ConfigurationABCest.php
+++ b/unittests/codeception/acceptance/ConfigurationABCest.php
@@ -1,0 +1,162 @@
+<?php
+
+
+namespace Tests\Acceptance;
+
+
+include_once(FILESENDER_BASE . "/vendor/autoload.php");
+include_once(FILESENDER_BASE . '/classes/utils/TestSuiteSupport.class.php');
+
+use Tests\Support\AcceptanceTester;
+use \Tests\Support\Page\Acceptance\FileSender;
+
+
+class ConfigurationABCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    
+    private $settingsA = array();
+    private $settingsB = array();
+
+    private function applySettings( $I, $fs, $s )
+    {
+        $fs->clearCustomConfig();
+        foreach( $s as $k => $v ) {
+            $fs->setConfig($k,$v);
+        }
+        $fs->writeCustomConfig();
+    }
+    
+    private function switchToConfigurationA( $I, $fs )
+    {
+        $I->amOnPage('/');
+        $this->applySettings($I, $fs, $this->settingsA);
+        $fs->setupAuth();        
+        $I->amOnPage('/');
+    }
+
+    private function switchToConfigurationB( $I, $fs )
+    {        
+        $I->amOnPage('/');
+        $this->applySettings($I, $fs, $this->settingsB);
+        $fs->setupAuth();        
+        $I->amOnPage('/');
+/*        
+        $fs->clearCustomConfig();
+
+        $v = 32 * 1024 * 1024;
+        $fs->setConfig('upload_chunk_size', $v );
+        $fs->setConfig('upload_crypted_chunk_size', 32 + $v );
+        $fs->setConfig('upload_chunk_size', $v );
+
+        $fs->writeCustomConfig();
+ */
+        
+    }
+    
+    
+    private function runtestsAB( AcceptanceTester $I, FileSender $fs, $settingsA, $settingsB )
+    {
+        $this->I = $I;
+        $this->fs = $fs;
+
+        $this->settingsA = $settingsA;        
+        $this->settingsB = $settingsB;
+
+
+        // upload in configA, download in configB
+        // upload in configB, download in configA
+        ////////////////////////////////
+        ////////////////////////////////
+        ////////////////////////////////        
+        $this->switchToConfigurationA( $I, $fs );
+        $fs->uploadNotEncrypted(array("file2.txt", "file10mb.txt"));
+ 
+        $this->switchToConfigurationB( $I, $fs );
+        $fs->downloadNotEncrypted();
+        $fs->downloadNotEncrypted("file10mb.txt");
+        $I->amOnPage('/');
+        $fs->uploadNotEncrypted(array("file2.txt", "file10mb.txt"));
+
+        $this->switchToConfigurationA( $I, $fs );
+        $I->amOnPage('/');
+        $fs->downloadNotEncrypted();
+        $fs->downloadNotEncrypted("file10mb.txt");
+
+        ////////////////////////////////
+        ////////////////////////////////
+        ////////////////////////////////
+        
+
+        $this->switchToConfigurationA( $I, $fs );
+        $fs->uploadEncrypted();
+        
+        $this->switchToConfigurationB( $I, $fs );
+        $fs->downloadEncrypted();
+        $I->amOnPage('/');
+        $fs->uploadEncrypted();
+
+        $this->switchToConfigurationA( $I, $fs );
+        $fs->downloadEncrypted();
+
+        ////////////////////////////////
+        ////////////////////////////////
+        ////////////////////////////////
+        
+
+        $this->switchToConfigurationA( $I, $fs );
+        $fs->uploadEncrypted(array("file2.txt", "file10mb.txt"));
+ 
+        $this->switchToConfigurationB( $I, $fs );
+        $fs->downloadEncryptedArchive( array("file10mb.txt", "file2.txt", "file20mb.txt" ));
+        $I->amOnPage('/');
+        $fs->uploadEncrypted(array("file2.txt", "file10mb.txt"));
+        
+        $this->switchToConfigurationA( $I, $fs );
+        $fs->downloadEncryptedArchive( array("file10mb.txt", "file2.txt", "file20mb.txt" ));
+
+        
+    }    
+
+    public function testConfigurationAB( AcceptanceTester $I, FileSender $fs )
+    {
+        // explicitly set the chunk size to 5mb and then 32mb
+        // as the A and B setup
+        $smallv =  5 * 1024 * 1024;
+        $v      =  7 * 1024 * 1024;  // this shouldn't line up well with 5
+
+        $this->runtestsAB( $I, $fs,
+                           array(
+                               'storage_type' => 'filesystem',
+                               'upload_chunk_size' => $smallv,
+                               'upload_crypted_chunk_size' => 32 + $smallv,
+                               'download_chunk_size' => $smallv,
+                           ),
+                           array(
+                               'storage_type' => 'filesystem',
+                               'upload_chunk_size' => $v,
+                               'upload_crypted_chunk_size' => 32 + $v,
+                               'download_chunk_size' => $v,
+                           ));
+
+        $this->runtestsAB( $I, $fs,
+                           array(
+                               'storage_type' => 'filesystemChunked',
+                               'upload_chunk_size' => $smallv,
+                               'upload_crypted_chunk_size' => 32 + $smallv,
+                               'download_chunk_size' => $smallv,
+                           ),
+                           array(
+                               'storage_type' => 'filesystemChunked',
+                               'upload_chunk_size' => $v,
+                               'upload_crypted_chunk_size' => 32 + $v,
+                               'download_chunk_size' => $v,
+                           ));
+ 
+        
+    }
+    
+}

--- a/unittests/codeception/bootstrap.php
+++ b/unittests/codeception/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+
+
+
+if( !defined('FILESENDER_BASE')) {
+    if(file_exists('/Develop/filesender/filesender-monkeyiq')) {
+        define('FILESENDER_BASE', '/Develop/filesender/filesender-monkeyiq');
+    }
+}
+

--- a/unittests/codeception/fix-download-permissions.sh
+++ b/unittests/codeception/fix-download-permissions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# the below sudo just does something like this
+# so we can get at the downloads as another user.
+# chmod g+r /home/testdriver/Downloads/*
+
+sudo /home/ben/bin/filesender-fix-testdriver-permissions.sh

--- a/www/download.php
+++ b/www/download.php
@@ -36,7 +36,9 @@
  */
 require_once('../includes/init.php');
 
+
 try {
+    
     // List of files to be downloaded
     if(!array_key_exists('files_ids', $_REQUEST))
         throw new DownloadMissingFilesIDsException();
@@ -160,7 +162,7 @@ try {
             $archive_format = "tar";
         }
     }
-    
+
     if(count($files_ids) > 1 || $archive_format_selected) { 
         // Archive download
         $ret = downloadArchive($transfer, $recipient, $files_ids, $recently_downloaded,$archive_format);
@@ -296,17 +298,18 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     register_shutdown_function($abort_handler);
 
     $read_range = function($range = null) use($file, $recipient, $abort_handler, $transfer) {
+
         $abort_handler();
 
         $offset = $range ? $range['start'] : 0;
 
-        $chunk_size = (int) Config::get('download_chunk_size');
+        $chunk_size = $file->chunk_size;
         if (!$chunk_size)
             $chunk_size = 1024 * 1024;
 
         if($transfer->options['encryption'] == 1){
             $end = $file->encrypted_size;
-            $chunk_size = (int) Config::get('upload_crypted_chunk_size');
+            $chunk_size = $file->crypted_chunk_size;
         }else{
             $end = $file->size;
         }

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -101,7 +101,6 @@ window.filesender.config = {
     crypto_gcm_max_chunk_size: '<?php echo Config::get('crypto_gcm_max_chunk_size') ?>',
     crypto_gcm_max_chunk_count: '<?php echo Config::get('crypto_gcm_max_chunk_count') ?>',
 
-    upload_crypted_chunk_size: '<?php echo Config::get('upload_crypted_chunk_size') ?>',
     crypto_iv_len: '<?php echo Config::get('crypto_iv_len') ?>',
     crypto_crypt_name: '<?php echo Config::get('crypto_crypt_name') ?>',
     crypto_hash_name: '<?php echo Config::get('crypto_hash_name') ?>',

--- a/www/js/crypter/archive_sink.js
+++ b/www/js/crypter/archive_sink.js
@@ -37,7 +37,7 @@ if (typeof window === 'undefined')
 if (!('filesender' in window))
     window.filesender = {};
 
-window.filesender.archive_sink = function ( cryptoapp, link, transferid, archiveName, pass, selectedFiles, arg_callbackError ) {
+window.filesender.archive_sink = function ( cryptoapp, link, transferid, chunk_size, crypted_chunk_size, archiveName, pass, selectedFiles, arg_callbackError ) {
     return {
         complete:       false,
         // keep a tally of bytes processed to make sure we get everything.
@@ -49,6 +49,8 @@ window.filesender.archive_sink = function ( cryptoapp, link, transferid, archive
         cryptoapp:      cryptoapp,
         link:           link,
         transferid:     transferid,
+        chunk_size:     chunk_size,
+        crypted_chunk_size: crypted_chunk_size,
         pass:           pass,
         activeFileID:   null,
         progress:       null,
@@ -139,6 +141,8 @@ window.filesender.archive_sink = function ( cryptoapp, link, transferid, archive
                 }
                 
                 $this.cryptoapp.decryptDownloadToBlobSink( $this, pass, $this.transferid,
+                                                           $this.chunk_size,
+                                                           $this.crypted_chunk_size,
                                                            $this.link+f.fileid,
                                                            f.mime, f.filename, f.filesize, f.encrypted_filesize,
                                                            f.key_version, f.salt,

--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -47,9 +47,11 @@ window.filesender.crypto_app_downloading = false;
 // list of fileid for this encrypted download
 window.filesender.crypto_encrypted_archive_download_fileidlist = '';
 
-window.filesender.crypto_last_password_succeeded = false;
+window.filesender.crypto_last_password_succeeded = false; 
 window.filesender.crypto_last_password = '';
 
+
+window.filesender.crypted_chunk_size = 0;
 
 /*
  * Main entry points
@@ -63,6 +65,7 @@ window.filesender.crypto_app = function () {
         crypto_crypt_name:   window.filesender.config.crypto_crypt_name,
         crypto_hash_name:    window.filesender.config.crypto_hash_name,
         upload_crypted_chunk_size: window.filesender.config.upload_crypted_chunk_size,
+//        upload_crypted_chunk_size: window.filesender.crypted_chunk_size,
         // random passwords should be 32 octects (256 bits) of entropy.
         crypto_client_entropy_octets: 32,
         crypto_random_password_octets: 32,
@@ -534,7 +537,7 @@ window.filesender.crypto_app = function () {
                 // then do not allow it to happen.
                 // Other checks should stop the code before this code can
                 // run, but more checks are always better
-                if( value.byteLength + chunkid*$this.crypto_chunk_size
+                if( value.byteLength + chunkid * encryption_details.chunk_size
                     > window.filesender.config.crypto_gcm_max_file_size )
                 {
                     return callbackError({message: 'maximum_encrypted_file_size_exceeded',
@@ -788,9 +791,9 @@ window.filesender.crypto_app = function () {
             var oReq = new XMLHttpRequest();
             oReq.open("GET", link, true);
             oReq.responseType = "arraybuffer";
-            var chunksz     = 1 * $this.crypto_chunk_size;
+            var chunksz     = 1 * encryption_details.chunk_size;
             var startoffset = 1 * (chunkid * chunksz);
-            var endoffset   = 1 * (chunkid * chunksz + (1*$this.upload_crypted_chunk_size)-1);
+            var endoffset   = 1 * (chunkid * chunksz + (1*encryption_details.crypted_chunk_size)-1);
             var legacyChunkPadding = 0;
             oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Download', filesender.crypto_encrypted_archive_download );
 
@@ -808,15 +811,15 @@ window.filesender.crypto_app = function () {
             // Handle last chunk details, some offsets might need to change slightly
             //
             if( chunkid == encryption_details.chunkcount ) {
-                var padding = (1*$this.upload_crypted_chunk_size) - (1* $this.crypto_chunk_size);
+                var padding = (1*encryption_details.crypted_chunk_size) - (1* encryption_details.chunk_size);
                 var blockPad = 32;
 
                 window.filesender.log("downloadAndDecryptChunk(last chunk offset adjustment) "
                                       + " legacyPadding " + legacyChunkPadding
-                                      + " ccs "  + $this.crypto_chunk_size
-                                      + " uccs " + $this.upload_crypted_chunk_size
+                                      + " ccs "  + encryption_details.chunk_size
+                                      + " uccs " + encryption_details.crypted_chunk_size
                                       + " soffset " + startoffset
-                                      + " soffsetcc " + (1 * (chunkid * $this.upload_crypted_chunk_size))
+                                      + " soffsetcc " + (1 * (chunkid * encryption_details.crypted_chunk_size))
                                      );
                 window.filesender.log("downloadAndDecryptChunk(last chunk offset adjustment) "
                                       + " eoffset " + endoffset
@@ -844,10 +847,6 @@ window.filesender.crypto_app = function () {
                     
                 }
 
-                window.filesender.log("downloadAndDecryptChunk(adjustments done) "
-                                      + " eoffset " + endoffset
-                                      + " padding " + padding );
-
                 oReq.setRequestHeader('X-FileSender-Encrypted-Archive-Contents', window.filesender.crypto_encrypted_archive_download_fileidlist );
                 window.filesender.crypto_encrypted_archive_download_fileidlist = '';
                 
@@ -856,13 +855,18 @@ window.filesender.crypto_app = function () {
             var brange = 'bytes=' + startoffset + '-' + endoffset;
             oReq.setRequestHeader('Range', brange);
 
+            window.filesender.log("downloadAndDecryptChunk(adjustments done) "
+                                  + " eoffset " + endoffset
+                                  + " padding " + padding
+                                 + " range " + brange );
+            
             //Download progress
             oReq.addEventListener("progress", function(evt){
                 window.filesender.log("downloadAndDecryptChunk(progress) chunkid " + chunkid
                                       + " loaded " + evt.loaded + " of total " + evt.total );
                 if (evt.lengthComputable) {
-                    var percentComplete = Math.round(evt.loaded / (1*$this.upload_crypted_chunk_size) *10000) / 100;
-                    var percentOfFileComplete = 100*((chunkid*$this.crypto_chunk_size + evt.loaded) / encryption_details.filesize );
+                    var percentComplete = Math.round(evt.loaded / (1*encryption_details.crypted_chunk_size) *10000) / 100;
+                    var percentOfFileComplete = 100*((chunkid * encryption_details.chunk_size + evt.loaded) / encryption_details.filesize );
                     
                     if (progress) {
 
@@ -903,7 +907,7 @@ window.filesender.crypto_app = function () {
             // When we get the chunk data (or an XHR error)
             //
             oReq.onload = function (oEvent) {
-                window.filesender.log("ddChunk(onload)");
+                window.filesender.log("ddChunk(onload) chunkid:" + chunkid);
                 
                 // check for a redirect containing and error and halt if so
                 if( $this.handleXHRError( oReq, link, 'file_encryption_wrong_password' )) {
@@ -916,7 +920,7 @@ window.filesender.crypto_app = function () {
                 var arrayBuffer = new Uint8Array(oReq.response);
                 setTimeout(function(){
 
-                    var sliced = window.filesender.crypto_blob_reader().sliceForDownloadBuffers(arrayBuffer);
+                    var sliced = window.filesender.crypto_blob_reader(encryption_details.chunk_size,encryption_details.crypted_chunk_size).sliceForDownloadBuffers( arrayBuffer );
                     var encryptedChunk = window.filesender.crypto_common().separateIvFromData(sliced[0]);
                     
                     $this.decryptBlob(
@@ -1000,7 +1004,7 @@ window.filesender.crypto_app = function () {
          * 
          * @param fileiv is the decoded fileiv. Decoding can be done with decodeCryptoFileIV()
          */
-        decryptDownloadToBlobSink: function (blobSink, pass, transferid,
+        decryptDownloadToBlobSink: function (blobSink, pass, transferid, chunk_size, crypted_chunk_size,
                                              link, mime, name, filesize, encrypted_filesize,
                                              key_version, salt,
                                              password_version, password_encoding, password_hash_iterations,
@@ -1011,7 +1015,7 @@ window.filesender.crypto_app = function () {
                                        filesize:           filesize,
                                        encrypted_filesize: encrypted_filesize,
                                        // zero based count.
-                                       chunkcount: Math.ceil( filesize / (1* $this.crypto_chunk_size))-1,
+                                       chunkcount: Math.ceil( filesize / (1* chunk_size))-1,
                                        key_version:       key_version,
                                        salt:              salt,
                                        password_version:  password_version,
@@ -1020,7 +1024,9 @@ window.filesender.crypto_app = function () {
                                        client_entropy:    client_entropy,
                                        fileiv:            fileiv,
                                        fileaead:          fileaead,
-                                       transferid:        transferid
+                                       transferid:        transferid,
+                                       chunk_size:         chunk_size,
+                                       crypted_chunk_size: crypted_chunk_size,
                                      };
             // For GCM this will be the fileiv (96 bits of fixed entropy).
             encryption_details.expected_fixed_chunk_iv = new Uint8Array(16);
@@ -1081,7 +1087,7 @@ window.filesender.crypto_app = function () {
                     return callbackError({message: 'decryption_verification_failed_bad_aead',
                                           details: {}});
                 }
-                if( encryption_details.aead.chunksize != window.filesender.config.upload_chunk_size ) {
+                if( encryption_details.aead.chunksize != encryption_details.chunk_size ) {
                     window.filesender.log("decryptBlobSpecificFinalChunkChecks() bad aead 4");
                     return callbackError({message: 'decryption_verification_failed_bad_aead',
                                           details: {}});
@@ -1226,7 +1232,8 @@ window.filesender.crypto_app = function () {
                 );
  
         },
-        decryptDownload: function (link, transferid, mime, name, filesize, encrypted_filesize,
+        decryptDownload: function (link, transferid, chunk_size, crypted_chunk_size,
+                                   mime, name, filesize, encrypted_filesize,
                                    key_version, salt,
                                    password_version, password_encoding, password_hash_iterations,
                                    client_entropy, fileiv, fileaead,
@@ -1245,6 +1252,10 @@ window.filesender.crypto_app = function () {
                 }
             };
 
+
+            window.filesender.config.upload_chunk_size = crypted_chunk_size;
+            window.filesender.crypted_chunk_size = crypted_chunk_size;
+            
             // Should we use streamsaver for this download?
             var use_streamsaver = $this.useStreamSaver();
             
@@ -1319,7 +1330,7 @@ window.filesender.crypto_app = function () {
                 var pass = $(this).find('input').val();
                 window.filesender.crypto_last_password = pass;
                 
-                $this.decryptDownloadToBlobSink( blobSink, pass, transferid,
+                $this.decryptDownloadToBlobSink( blobSink, pass, transferid, chunk_size, crypted_chunk_size,
                                                  link, mime, name, filesize, encrypted_filesize,
                                                  key_version, salt,
                                                  password_version, password_encoding, password_hash_iterations,
@@ -1373,7 +1384,7 @@ window.filesender.crypto_app = function () {
             }
             window.filesender.crypto_encrypted_archive_download_fileidlist = fileidlist;
         },
-        decryptDownloadToZip: function(link,transferid,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
+        decryptDownloadToZip: function(link,transferid,chunk_size,crypted_chunk_size,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
 
             var $this = this;
 
@@ -1406,7 +1417,7 @@ window.filesender.crypto_app = function () {
                 }
                                                      
                 
-                blobSinkStreamed = window.filesender.archive_sink( $this, link, transferid, archiveName, pass, selectedFiles, callbackError );
+                blobSinkStreamed = window.filesender.archive_sink( $this, link, transferid, chunk_size, crypted_chunk_size, archiveName, pass, selectedFiles, callbackError );
                 blobSink = blobSinkStreamed;
                 blobSink.init()
                     .then( () => {

--- a/www/js/crypter/crypto_blob_reader.js
+++ b/www/js/crypter/crypto_blob_reader.js
@@ -13,15 +13,16 @@ window.filesender.log = function( msg ) {
 }
 
 
-window.filesender.crypto_blob_reader = function () {
+
+window.filesender.crypto_blob_reader = function (chunkSize,cryptedChunkSize) {
     return {
         reader: null,
         file: null,
         file_size: null,
         blobSlice: null,
         blob: null,
-        chunkSize: window.filesender.config.upload_chunk_size, // 5 MB default
-        cryptedChunkSize: window.filesender.config.upload_crypted_chunk_size, // 5mb + checksum + IV
+        chunkSize: chunkSize,
+        cryptedChunkSize: cryptedChunkSize,
         
         completed: 0,
         numberOfChunks: 0,
@@ -171,6 +172,7 @@ window.filesender.crypto_blob_reader = function () {
             return returnBlobArray;
         },
         sliceForDownloadBuffers: function (largeBuffer) {
+            
             if(typeof largeBuffer.slice === 'undefined'){
                 largeBuffer.slice = largeBuffer.subarray;
             }

--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -167,6 +167,8 @@ $(function() {
                         var key_version = $($this).find("[data-id='" + ids[i] + "']").attr('data-key-version');
                         var fileivcoded = $($this).find("[data-id='" + ids[i] + "']").attr('data-fileiv');
                         var transferid = $('.transfer').attr('data-id');
+                        var chunk_size         = $($this).find("[data-id='" + ids[0] + "']").attr('data-chunk-size');
+                        var crypted_chunk_size = $($this).find("[data-id='" + ids[0] + "']").attr('data-crypted-chunk-size');
                         
                         selectedFiles.push({
                             fileid:ids[i]
@@ -193,6 +195,8 @@ $(function() {
                                                      + 'download.php?token=' + token
                                                      + '&files_ids='
                                                      , transferid
+                                                     , chunk_size
+                                                     , crypted_chunk_size
                                                      , selectedFiles
                                                      , progress
                                                      , onFileOpen, onFileClose, onComplete
@@ -204,6 +208,8 @@ $(function() {
                 {
                     // single file download
                     var transferid  = $('.transfer').attr('data-id');
+                    var chunk_size         = $($this).find("[data-id='" + ids[0] + "']").attr('data-chunk-size');
+                    var crypted_chunk_size = $($this).find("[data-id='" + ids[0] + "']").attr('data-crypted-chunk-size');
                     var filename    = $($this).find("[data-id='" + ids[0] + "']").attr('data-name');
                     var filesize    = $($this).find("[data-id='" + ids[0] + "']").attr('data-size');
                     var encrypted_filesize=$($this).find("[data-id='" + ids[0] + "']").attr('data-encrypted-size');
@@ -224,7 +230,7 @@ $(function() {
                     crypto_app.decryptDownload( filesender.config.base_path
                                                 + 'download.php?token=' + token
                                                 + '&files_ids=' + ids.join(','),
-                                                transferid,
+                                                transferid, chunk_size, crypted_chunk_size,
                                                 mime, filename, filesize, encrypted_filesize,
                                                 key_version, salt,
                                                 password_version, password_encoding,

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -126,7 +126,7 @@ var terasender_worker = {
                 
                 // Decrypt the contents of the file
                 var oReq = this.createXhr();
-                
+
                 oReq.open("GET", job.link, true);
                 oReq.responseType = "arraybuffer";
                 var chunksz     = 1 * this.crypto_app.crypto_chunk_size;

--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -350,6 +350,8 @@ $(function() {
         }
         
         var transferid = $(this).attr('data-transferid');
+        var chunk_size         = $(this).attr('data-chunk-size');
+        var crypted_chunk_size = $(this).attr('data-crypted-chunk-size');
         var id = $(this).attr('data-id');
         var encrypted = $(this).attr('data-encrypted');
         var filename = $(this).attr('data-name');
@@ -375,6 +377,8 @@ $(function() {
         window.filesender.crypto_app().decryptDownload(
             filesender.config.base_path + 'download.php?files_ids=' + id.join(','),
             transferid,
+            chunk_size,
+            crypted_chunk_size,
             mime, filename,
             filesize, encrypted_filesize,
             key_version, salt,


### PR DESCRIPTION
With this you should be able to change the config.php upload_chunk_size (with upload_crypted_chunk_size and download_chunk_size to allow a valid configuration) and still be able to download existing uploads with new uploads performed using the current settings.

This PR has been tested manually and with the new
ConfigurationABCest.php acceptance test. The acceptance test targets both the normal filesystem and filesystemChunked storage_type and varies the chunk size in an A,B,A test with uploads in A, downloads in B then uploads in B and downloads in A for two configurations. These automatic tests check for unencrypted, encrypted, and encrypted to zip transfer scenarios. See testConfigurationAB for details.

Some testing has also been performed using a fake S3 backend and chunk size changes. As in the past I find myself with no credentials to a real S3 service so can only test with these environments. For this I have used a zenko/cloudserver server.

The Azure storage was updated inline with the S3 one but has not been extensively tested for migrations.

The database.php script creates new columns in the Transfer table and sets their values to the current upload_chunk_size and upload_crypted_chunk_size values which should allow existing uploads to work properly after the upgrade.

This relates to https://github.com/filesender/filesender/issues/1876
