### PR TITLE
ui: update rawerror handling to handle when the get by class returns an empty set

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -392,7 +392,7 @@ window.filesender.ui = {
     rawError: function (text) {
         console.log(text);
         var doc = new DOMParser().parseFromString(text, 'text/html');
-        if (doc.getElementsByClassName('exception')) { //if this is from our template, pull out the exception only.
+        if (doc.getElementsByClassName('exception').length >= 1 ) { //if this is from our template, pull out the exception only.
                 text = doc.getElementsByClassName('exception')[0].textContent || text;
         } else { //strip html as alert cant process that.
                 text = doc.body.textContent || text;


### PR DESCRIPTION
This was raised in https://github.com/filesender/filesender/issues/2172

One may consider an A/B test as follows. If the class is not found an HTMLCollection object is returned. This object will cause the `if` in the original code to assume there is content for that class which is not true as `.length` is zero.

```
var text = "<html><p class='x'></p></html>";
console.log(text);
var doc = new DOMParser().parseFromString(text, 'text/html');
console.log(doc.getElementsByClassName("xx").length);
console.log(doc.getElementsByClassName("xx"));
console.log(doc.getElementsByClassName("x").length);
console.log(doc.getElementsByClassName("x"));
```

This results in 
```
0
[object HTMLCollection]
1
[object HTMLCollection] 
```