### PR TITLE
UI3: Allow these two buttons on the my profile page to be seen

### DIFF
--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -210,7 +210,7 @@ $user = Auth::user();
                             <div class="fs-settings__saved-info">
                                 <h3>{tr:saved_information}</h3>
 
-                                <ul class="fs-list fs-list--inline fs-list--mobile-reverse">
+                                <ul class="fs-listx">
                                     <li>
                                         <button type="button" id="clear_user_transfer_preferences" class="fs-button fs-button--danger">
                                             <i class="fa fa-close"></i>
@@ -224,7 +224,7 @@ $user = Auth::user();
                                     </li>
                                 </ul>
 
-                                <ul class="fs-list fs-list--inline fs-list--mobile-reverse">
+                                <ul class="fs-listx">
                                     <li>
                                         <button type="button" id="clear_frequent_recipients" class="fs-button fs-button--danger">
                                             <i class="fa fa-close"></i>

--- a/www/css/new-ui/components/_list.css
+++ b/www/css/new-ui/components/_list.css
@@ -1,3 +1,32 @@
+
+.fs-listx {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    align-items: center;    
+    flex-direction: row;
+}
+.fs-listx li:nth-child(1) {
+    align-items: center;    
+}
+.fs-listx li:nth-child(2) {
+    flex: 2;
+    flex-grow: 2;
+}
+
+.fs-listx li + li {
+    margin-left: var(--fs-spacing-2x);
+}
+
+.fs-listx + .fs-listx {
+    margin-top: var(--fs-spacing-3x);
+}
+
+
+
+
+
 .fs-list {
     display: flex;
     list-style: none;


### PR DESCRIPTION
There are many UI elements that have issues. This is one case where the text was truncated from view by the button. These are not the sorts of things one would expect to see in the 202x era of web design.

This is not a perfect soluion to the problem. The new listx style sort of relies on there being a button on the left and a description type element on the right. I would have much preferred to use a toolkit that better supports web forms or not have built things in a flex just to add some buttons.

This was reported here https://github.com/filesender/filesender/issues/2181