### PR TITLE
Improve transfer details page for add recipient

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -371,6 +371,17 @@ window.filesender.ui = {
             inputType: 'email',
             className: 'prompt-dialog',
             centerVertical: true,
+            required: true,
+            buttons: {
+                confirm: {
+                    label: lang.tr('OK').out(),
+                    className: 'fs-button fs-button--success'
+                },
+                cancel: {
+                    label: lang.tr('Cancel').out(),
+                    className: 'fs-button fs-button--danger'
+                }
+            },
             callback: function (result) {
                 console.log('This was logged in the callback!  result:' + result);
                 if( result ) {


### PR DESCRIPTION
This makes the buttons the right colour, translates them, and makes an email address required in order to positively process the dialog.