### PR TITLE
UI3: update the metadata around extensions on the transfer details

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -352,7 +352,7 @@ if( !$found ) {
                     </button>
 
                     <?php if($extend) { ?>
-                        <button type="button" data-action="extend" class="fs-button" data-id="<?php echo $transfer->id ?>" data-expiry-extension="<?php echo $transfer->expiry_date_extension ?>" >
+                        <button type="button" data-action="extend" class="fs-button objectholder" data-id="<?php echo $transfer->id ?>" data-expiry-extension="<?php echo $transfer->expiry_date_extension ?>" >
                             <i class="fa fa-calendar-plus-o"></i>
                             <span>{tr:extend_expires}</span>
                         </button>                        

--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -254,8 +254,10 @@ $(function() {
 
     $('.fs-transfer-detail__actions  button[data-action="extend"]').on('click', function() {
         filesender.ui.extendExpires( $(this), 'transfer');
-    });    
+    });
 
+    $('[data-expiry-extension="0"] [data-action="extend"]').addClass('disabled').attr({title: lang.tr('transfer_expiry_extension_count_exceeded')});
+    
     // Add recipient buttons
     $('[data-recipients-enabled=""] [data-action="add_recipient"]').addClass('disabled');
 
@@ -270,7 +272,6 @@ $(function() {
 
         var prompt = filesender.ui.promptEmail(lang.tr('enter_to_email'), function(input) {
             $('p.error', this).remove();
-
             var raw_emails = input.split(/[,;]/);
 
             var emails = [];

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -881,7 +881,10 @@ window.filesender.ui = {
         if(!id || isNaN(id)) return;
 
         var duration = parseInt(t.attr('data-expiry-extension'));
-
+        if( !duration ) {
+            console.log("extendExpires() is not offering to extend the expire time 0 days" );
+            return;
+        }
         var extend = function(remind) {
             filesender.client.extendObject(className,id, remind, function(t) {
                 $('.objectholder[data-id="' + id + '"]').attr('data-expiry-extension', t.expiry_date_extension);


### PR DESCRIPTION
On the transfer details page if we keep the metadata correct when an extension is performed then we can have valid data without having to resort to reloading the page. This brings the transfer details page extension functionality inline with the existing transfers table functionality.

This relates to https://github.com/filesender/filesender/issues/2179