### PR TITLE
UI3: "Send transfer to" use red border rather than * mandatory

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -429,7 +429,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                         {tr:from}
                                                     </label>
 
-                                                    <input name="to" id="to" type="email"
+                                                    <input name="from" id="from" type="email"
                                                            title="{tr:from}"
                                                            value=""
                                                            placeholder="<?php echo Template::sanitizeOutputEmail($emails[0]) ?>" disabled />
@@ -458,7 +458,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                 <?php if(Auth::isGuest() && AuthGuest::getGuest()->getOption(GuestOptions::CAN_ONLY_SEND_TO_ME)) { ?>
                                                     <div class="fs-input-group fs-input-group--hide" data-transfer-type="transfer-email">
                                                         <label for="to">
-                                                            {tr:send_transfer_to} *
+                                                            {tr:send_transfer_to}
                                                         </label>
 
                                                         <?php echo Template::sanitizeOutputEmail(AuthGuest::getGuest()->user_email) ?>
@@ -466,7 +466,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                 <?php } else { ?>
                                                     <div class="fs-input-group fs-input-group--hide" data-transfer-type="transfer-email">
                                                         <label for="to">
-                                                            {tr:send_transfer_to} *
+                                                            {tr:send_transfer_to}
                                                         </label>
 
                                                         <div>
@@ -508,7 +508,6 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                                                     </label>
                                                     <textarea id="message" name="message" rows="3" placeholder="{tr:optional_message}"></textarea>
                                                 </div>
-                                                * = {tr:mandatory}
 
                                                 <label class="invalid" id="message_can_not_contain_urls">{tr:message_can_not_contain_urls}</label>
                                                 <label class="invalid" id="password_can_not_be_part_of_message_warning">

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1087,6 +1087,11 @@ filesender.ui.evalUploadEnabled = function() {
 
     if (filesender.ui.stage == 3) {
         filesender.ui.nodes.stages.confirm.prop('disabled', !configStageOk);
+        if (configStageOk) {
+            filesender.ui.nodes.recipients.input.removeClass('invalid');
+        } else {
+            filesender.ui.nodes.recipients.input.addClass('invalid');
+        }
     }
 
     return ok;


### PR DESCRIPTION
I don't like https://github.com/filesender/filesender/pull/2175 so made it use red border

Also fixed a typeO on the "from" input line that was labeled as "to"