### PR TITLE
updates for database stuff from recent 3.x series changes

### DIFF
--- a/classes/data/Authentication.class.php
+++ b/classes/data/Authentication.class.php
@@ -60,6 +60,11 @@ class Authentication extends DBObject
             'size' => 200,
             'null' => true
         ),
+        'saml_user_identification_idp' => array(
+            'type' => 'string',
+            'size' => 170,
+            'null' => true
+        ),
         'created' => array(
             'type' => 'datetime',
             'null' => true
@@ -97,6 +102,7 @@ class Authentication extends DBObject
     protected $id = null;
     protected $saml_user_identification_uid = null;
     protected $saml_user_identification_uid_hash = 0;
+    protected $saml_user_identification_idp = null;
     protected $created = 0;
     protected $last_activity = 0;
     protected $comment = null;
@@ -129,10 +135,10 @@ class Authentication extends DBObject
     /**
      * Create or return the auth object
      */
-    public static function ensure($saml_auth_uid, $comment = null)
+    public static function ensure($saml_auth_uid, $comment = null, $saml_auth_idp = null)
     {
         $saml_uid = $saml_auth_uid;
-        Logger::info('authentication::create(1) saml_uid ' . $saml_uid);
+        Logger::info('authentication::create(1) saml_uid ' . $saml_uid . ' saml_idp '. $saml_auth_idp);
 
         $statement = DBI::prepare('SELECT * FROM '.self::getDBTable().' WHERE saml_user_identification_uid = :samluid');
         $statement->execute(array(':samluid' => $saml_uid));
@@ -140,6 +146,13 @@ class Authentication extends DBObject
         if ($data) {
             $ret = static::createFactory(null, $data);
             $ret->fillFromDBData($data);
+            if (!is_null($saml_auth_idp)) {
+                // only update if the idp has changed
+                if ($saml_auth_idp!=$ret->saml_user_identification_idp) {
+                    $ret->saml_user_identification_idp = $saml_auth_idp;
+                    $ret->save();
+                }
+            }
             Logger::info('authentication::create(2) FOUND AND RETURNING ' . $data['id']);
             return $ret;
         }
@@ -153,6 +166,10 @@ class Authentication extends DBObject
         $ret->updateHash();
         Logger::info('authentication::create(4) ' . $ret->id);
         Logger::info('authentication::create(5) ' . $ret->saml_user_identification_uid_hash);
+        if (!is_null($saml_auth_idp)) {
+            $ret->saml_user_identification_idp = $saml_auth_idp;
+            Logger::info('authentication::create(6) ' . $ret->saml_user_identification_idp);
+        }
         $ret->save();
         return $ret;
     }
@@ -165,9 +182,9 @@ class Authentication extends DBObject
      *
      * @return self
      */
-    public static function ensureAuthIDFromSAMLUID($saml_auth_uid)
+    public static function ensureAuthIDFromSAMLUID($saml_auth_uid, $saml_auth_idp = null)
     {
-        return self::ensure($saml_auth_uid)->id;
+        return self::ensure($saml_auth_uid,null,$saml_auth_idp)->id;
     }
 
     private function updateHash()
@@ -189,7 +206,7 @@ class Authentication extends DBObject
     public function __get($property)
     {
         if (in_array($property, array(
-            'id', 'saml_user_identification_uid', 'saml_user_identification_uid_hash', 'created','last_activity','passwordhash'
+            'id', 'saml_user_identification_uid', 'saml_user_identification_uid_hash', 'saml_user_identification_idp', 'created','last_activity','passwordhash'
         ))) {
             return $this->$property;
         }
@@ -212,6 +229,8 @@ class Authentication extends DBObject
     {
         if ($property == 'saml_user_identification_uid_hash') {
             $this->saml_user_identification_uid_hash = $value;
+        } elseif ($property == 'saml_user_identification_idp') {
+            $this->saml_user_identification_idp = $value;
         } elseif ($property == 'passwordhash') {
             $this->passwordhash = $value;
         } elseif ($property == 'password') {

--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -122,7 +122,17 @@ class File extends DBObject
         'have_avresults' => array(
             'type' => 'bool',
             'default' => false
-        )
+        ),
+
+        // used by storage::buildPath to cache the storage path used for this file
+        // this may allow migration of settings in the future with access
+        // to existing files.
+        'storage_path' => array(
+            'type' => 'string',
+            'size' => 170,
+            'null' => true
+        ),
+        
     );
 
     protected static $secondaryIndexMap = array(
@@ -146,12 +156,11 @@ class File extends DBObject
             // to work where they do not allow subqueries in view definitions.
             $transferviewdef[$dbtype] = Transfer::getPrimaryViewDefinition($dbtype);
 
-            $filesbywhodef[$dbtype] = 'select t.id as transferid,name,upload_end,f.id as fileid,mime_type,size,'
-                                . ' t.* from '.self::getDBTable().' f, '
-                                    . ' filestranferviewcopy t '
-                                    . ' where f.transfer_id = t.id order by t.id';
-        }
-        
+            $filesbywhodef[$dbtype] = 'select t.id as transferid, name, upload_end, f.id as fileid, mime_type, size,'
+                                    . ' t.* from '.self::getDBTable().' f LEFT JOIN'
+                                    . ' filestranferviewcopy t ON f.transfer_id = t.id'
+                                    . ' order by t.id';
+        }        
         
         return array( strtolower(self::getDBTable()) . 'view' => $a ,
                       'filestranferviewcopy' => $transferviewdef    ,
@@ -178,6 +187,7 @@ class File extends DBObject
     protected $aead = null;
     protected $have_avresults = false;
     protected $storage_class_name = ''; // set in constructor
+    protected $storage_path = null;
    
     /**
      * Related objects cache
@@ -503,7 +513,7 @@ class File extends DBObject
     {
         if (in_array($property, array(
             'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1'
-          , 'storage_class_name', 'iv', 'aead', 'have_avresults'
+          , 'storage_class_name', 'iv', 'aead', 'have_avresults', 'storage_path'
         ))) {
             return $this->$property;
         }
@@ -619,6 +629,8 @@ class File extends DBObject
             $this->aead = $value;
         } elseif ($property == 'have_avresults') {
             $this->have_avresults = $value;
+        } elseif ($property == 'storage_path') {
+            $this->storage_path = $value;
         } else {
             throw new PropertyAccessException($this, $property);
         }

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -142,9 +142,16 @@ class Guest extends DBObject
                         . DBView::columnDefinition_age($dbtype, 'service_aup_accepted_time', 'service_aup_accepted_time_days_ago')
                         . ' , expires < now() as expired '
                         . " , status = 'available' as is_available "
-                        . '  from ' . self::getDBTable();
+                                . '  from ' . self::getDBTable();
+            $idpview[$dbtype] = 'select g.*,u.id as uid,u.authid,a.saml_user_identification_idp from '
+                              . self::getDBTable() . ' g '
+                                    . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON g.userid=u.id '
+                                    . ' LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON u.authid=a.id '
+                                    . ' WHERE ' . self::AVAILABLE;            
         }
-        return array( strtolower(self::getDBTable()) . 'view' => $a );
+        return array( strtolower(self::getDBTable()) . 'view' => $a
+                    , 'guestsidpview' => $idpview
+        );
     }
 
     /**
@@ -161,8 +168,9 @@ class Guest extends DBObject
     const EXPIRED = "expires < :date ORDER BY expires ASC";
     // For these fragments we want to find the guests that have
     // expires is null because they are still considered active
-    const FROM_USER = "userid = :userid AND (expires is null or expires > :date) ORDER BY created DESC";
+    const FROM_USER           = "userid = :userid AND (expires is null or expires > :date) ORDER BY created DESC";
     const FROM_USER_AVAILABLE = "userid = :userid AND (expires is null or expires > :date) AND status = 'available' ORDER BY created DESC";
+    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
     
     /**
      * Properties
@@ -700,6 +708,24 @@ class Guest extends DBObject
         
         return $options;
     }
+
+    /*
+     * Count how many guests we have or a tenant has
+     */
+    public static function getGuestCount( $idp = null )
+    {
+        if (!$idp) {
+            return self::countEstimate();
+        }
+        
+        return self::count(
+            array(
+                'view'  => 'guestsidpview',
+                'where' => self::FROM_IDP_NO_ORDER
+            ),
+            array(':idp' => $idp)
+        );
+    }    
     
     /**
      * Getter
@@ -740,6 +766,10 @@ class Guest extends DBObject
             return $user->saml_user_identification_uid;
         }
         
+        if ($property == 'saml_user_identification_idp') {
+            $user = User::fromId($this->userid);
+            return $user->saml_user_identification_idp;
+        }
         
         if ($property == 'upload_link') {
             return Utilities::http_build_query(

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -91,6 +91,31 @@ class Recipient extends DBObject
             'token' => array()
         )
     );
+
+    public static function getViewMap()
+    {
+        $a = array();
+        foreach (array('mysql','pgsql') as $dbtype) {
+            $a[$dbtype] = 'select *'
+                        . DBView::columnDefinition_age($dbtype, 'created')
+                        . DBView::columnDefinition_age($dbtype, 'last_activity', 'last_activity_days_ago')
+                                . '  from ' . self::getDBTable();
+            $idpview[$dbtype] = 'select r.*,u.id as uid,u.authid,a.saml_user_identification_idp from '
+                              . self::getDBTable() . ' r '
+                                    . ' LEFT JOIN '.call_user_func('Transfer::getDBTable').' t ON r.transfer_id=t.id '
+                                    . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
+                                    . ' LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON u.authid=a.id ';
+            
+        }
+        return array( strtolower(self::getDBTable()) . 'view' => $a
+                    , 'recipientsidpview' => $idpview
+        );
+    }
+
+    /**
+     * Set selectors
+     */
+    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
     
 
     /**
@@ -254,6 +279,25 @@ class Recipient extends DBObject
         foreach (TrackingEvent::fromRecipient($this) as $tracking_event) {
             $tracking_event->delete();
         }
+    }
+
+    /*
+     * Count how many unique recipients we have or a tenant has
+     */
+    public static function getRecipientCount( $idp = null )
+    {
+        if (!$idp) {
+            return self::countEstimate();
+        }
+
+        return self::count(
+            array(
+                'view'  => 'recipientsidpview',
+                'where' => self::FROM_IDP_NO_ORDER
+            ),
+            array(':idp' => $idp)
+        );
+        
     }
     
     /**

--- a/classes/data/StatLog.class.php
+++ b/classes/data/StatLog.class.php
@@ -115,9 +115,25 @@ class StatLog extends DBObject
                                                                'os',
                                                                'os_name' )
                         . '  from ' . self::getDBTable() . ' base';
-            
+            $browserstatsview[$dbtype] ='SELECT '
+                                       .'    MAX(additional_attributes) as "additional_attributes", '
+                                       .'    AVG(CASE WHEN time_taken > 0 THEN size/time_taken ELSE 0 END) as speed, '
+                                       .'    AVG(CASE WHEN time_taken > 0 AND size>1073741824 THEN size/time_taken ELSE NULL END) as gspeed, '
+                                       .'    AVG(size) as avgsize, '
+                                       .'    MIN(size) as minsize, '
+                                       .'    MAX(size) as maxsize, '
+                                       .'    SUM(size) as transfered, '
+                                       .'    COUNT(ID) as count, '
+                                       .'    MIN('.DBLayer::timeStampToEpoch('created').') as firsttransfer, '
+                                       .'    is_encrypted,os_name,browser_name '
+                                       .' FROM statlogsview '
+                                       ." WHERE event='file_uploaded' "
+                                       .' GROUP BY is_encrypted,os_name,browser_name '
+                                       .' ORDER BY count DESC, maxsize DESC ';
         }
-        return array( strtolower(self::getDBTable()) . 'view' => $a );
+        return array( strtolower(self::getDBTable()) . 'view' => $a
+                    , 'browserstatsview' => $browserstatsview
+        );
     }
     
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -172,7 +172,11 @@ class Transfer extends DBObject
             'null'    => false,
             'default' => false,
         ),
-
+        'storage_filesystem_per_idp' => array(
+            'type'    => 'bool',
+            'null'    => false,
+            'default' => false,
+        ),
 
         'download_count' => array(
             'type'    => 'uint',
@@ -223,27 +227,35 @@ class Transfer extends DBObject
             $authviewdef[$dbtype] = 'select t.id as id,t.userid as userid,u.authid as authid,a.saml_user_identification_uid as user_id,'
                                   . 't.made_available,t.expires,t.created '
                                   . ' FROM '
-                                      . self::getDBTable().' t, '
-                                            . call_user_func('User::getDBTable').' u, '
-                                            . call_user_func('Authentication::getDBTable').' a where t.userid = u.id and u.authid = a.id ';
+                                      . self::getDBTable().' t LEFT JOIN '
+                                            . call_user_func('User::getDBTable').' u ON t.userid = u.id LEFT JOIN '
+                                            . call_user_func('Authentication::getDBTable').' a ON u.authid = a.id';
 
             $sizeviewdev[$dbtype] = 'select t.*,sum(f.size) as size from '
-                                  . self::getDBTable().' t, '
-                                        . call_user_func('File::getDBTable').' f '
-                                        . ' where '
-                                        . ' f.transfer_id=t.id '
-                                        . '  group by t.id ';
+                                  . self::getDBTable().' t LEFT JOIN '
+                                        . call_user_func('File::getDBTable').' f ON t.id=f.transfer_id'
+                                        . '  group by t.id,f.size ';
+
+            $sizeidpviewdev[$dbtype] = 'select t.*,sum(f.size) as size,a.saml_user_identification_idp from '
+                                     . self::getDBTable().' t '
+                                           . ' LEFT JOIN '.call_user_func('File::getDBTable').' f ON t.id=f.transfer_id'
+                                           . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
+                                           . ' LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON u.authid=a.id '
+                                           . '  group by t.id, a.saml_user_identification_idp';
             
             $recipientviewdev[$dbtype] = 'select t.*,r.email as recipientemail,r.id as recipientid from '
-                                       . self::getDBTable().' t, '
-                                             . call_user_func('Recipient::getDBTable').' r '
-                                             . ' where '
-                                             . ' r.transfer_id=t.id ';
+                                       . self::getDBTable().' t LEFT JOIN '
+                                             . call_user_func('Recipient::getDBTable').' r ON t.id=r.transfer_id';
+
             $filesview[$dbtype] = 'select t.*,f.name as filename,f.size as filesize from '
-                                . self::getDBTable().' t, '
-                                      . call_user_func('File::getDBTable').' f '
-                                      . ' where '
-                                      . ' f.transfer_id=t.id ';
+                                . self::getDBTable().' t LEFT JOIN '
+                                      . call_user_func('File::getDBTable').' f ON t.id=f.transfer_id';
+
+            $filesidpview[$dbtype] = 'select t.*,f.name as filename,f.size as filesize, a.saml_user_identification_idp from '
+                                   . self::getDBTable().' t LEFT JOIN '
+                                      . call_user_func('File::getDBTable').' f ON t.id=f.transfer_id'
+                                           . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
+                                           . ' LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON u.authid=a.id ';
 
             $auditlogsview[$dbtype] = 'select t.*,0 as fileid,a.created as acreated,a.author_type,a.author_id,a.target_type,a.target_id,a.event,a.id as aid '
                                     . ' from '
@@ -269,18 +281,34 @@ class Transfer extends DBObject
                                        . self::getDBTable() . ' t '
                                              . " left outer join transfersauditlogsdlsubselectcountview zz "
                                              . " on t.id = zz.id  " ;
+            
+            $idpviewsizesumperidp[$dbtype] = 'SELECT SUM(size) AS sizesum, a.saml_user_identification_idp '
+                                           . ' FROM '.File::getDBTable().' f '
+                                           . ' INNER JOIN '.self::getDBTable().' t ON t.id = f.transfer_id '
+                                           . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
+                                           . ' LEFT JOIN '.Authentication::getDBTable().' a ON u.authid=a.id '
+                                           . ' GROUP BY a.saml_user_identification_idp ';
+
+            $idpview[$dbtype] = 'select t.*,a.saml_user_identification_idp as idp, saml_user_identification_idp as saml_user_identification_idp from '
+                              . self::getDBTable() . ' t '
+                                    . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
+                                    . ' LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON u.authid=a.id ';
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a
                     , 'transfersauthview' => $authviewdef
                     , 'transferssizeview' => $sizeviewdev
+                    , 'transferssizeidpview' => $sizeidpviewdev
                     , 'transfersrecipientview' => $recipientviewdev
                     , 'transfersfilesview' => $filesview
+                    , 'transfersfilesidpview' => $filesidpview
                     , 'transfersauditlogsview' => $auditlogsview
                     , 'transfersauditlogsdlsubselectcountview' => $auditlogsviewdlcss
                     , 'transfersauditlogsdlcountview' => $auditlogsviewdlc
+                    , 'transferidpviewsizesumperidp' => $idpviewsizesumperidp
+                    , 'transferidpview' => $idpview
         );
     }
-
+    
     protected static $secondaryIndexMap = array(
         'userid' => array(
             'userid' => array()
@@ -319,6 +347,10 @@ class Transfer extends DBObject
     const CLOSED_NO_ORDER = "status = 'closed' ";
     const FROM_USER_NO_ORDER        = "userid = :userid AND status='available' and ( guest_id is null or guest_transfer_shown_to_user_who_invited_guest ) ";
     const FROM_USER_CLOSED_NO_ORDER = "userid = :userid AND status='closed'    and ( guest_id is null or guest_transfer_shown_to_user_who_invited_guest ) ";
+    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
+    const FROM_IDP_UPLOADING = "status = 'uploading' and saml_user_identification_idp = :idp ORDER BY created DESC";
+    const FROM_IDP_AVAILABLE = "status = 'available' and saml_user_identification_idp = :idp ORDER BY created DESC";
+    const FROM_IDP_EXPIRED   = "expires <= :date  and saml_user_identification_idp = :idp ORDER BY expires ASC";
 
     const ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT = 16;
     
@@ -350,6 +382,7 @@ class Transfer extends DBObject
     protected $guest_transfer_shown_to_user_who_invited_guest = true;
     protected $storage_filesystem_per_day_buckets = false;
     protected $storage_filesystem_per_hour_buckets = false;
+    protected $storage_filesystem_per_idp = false;
     protected $download_count = 0;
     protected $chunk_size = 0;
     protected $crypted_chunk_size = 0;
@@ -383,6 +416,7 @@ class Transfer extends DBObject
     {
         $this->storage_filesystem_per_day_buckets = Config::get('storage_filesystem_per_day_buckets');
         $this->storage_filesystem_per_hour_buckets = Config::get('storage_filesystem_per_hour_buckets');
+        $this->storage_filesystem_per_idp = Config::get('storage_filesystem_per_idp');
         $this->download_count = 0;
         $this->chunk_size = Config::get('upload_chunk_size');
         $this->crypted_chunk_size = Config::get('upload_crypted_chunk_size');
@@ -1092,7 +1126,7 @@ class Transfer extends DBObject
             'expires', 'expiry_extensions', 'options', 'lang', 'key_version', 'userid',
             'password_version', 'password_encoding', 'password_encoding_string', 'password_hash_iterations'
             , 'client_entropy', 'roundtriptoken', 'guest_transfer_shown_to_user_who_invited_guest'
-            , 'storage_filesystem_per_day_buckets', 'storage_filesystem_per_hour_buckets'
+            , 'storage_filesystem_per_day_buckets', 'storage_filesystem_per_hour_buckets', 'storage_filesystem_per_idp'
           , 'download_count', 'chunk_size', 'crypted_chunk_size'
             
         ))) {
@@ -1308,6 +1342,8 @@ class Transfer extends DBObject
             $this->storage_filesystem_per_day_buckets = $value;
         } elseif ($property == 'storage_filesystem_per_hour_buckets') {
             $this->storage_filesystem_per_hour_buckets = $value;
+        } elseif ($property == 'storage_filesystem_per_idp') {
+            $this->storage_filesystem_per_idp = $value;
         } elseif ($property == 'download_count') {
             $this->download_count = $value;
         } else {
@@ -1564,6 +1600,7 @@ class Transfer extends DBObject
 
         $this->storage_filesystem_per_day_buckets = Config::get('storage_filesystem_per_day_buckets');
         $this->storage_filesystem_per_hour_buckets = Config::get('storage_filesystem_per_hour_buckets');
+        $this->storage_filesystem_per_idp = Config::get('storage_filesystem_per_idp');
         
         // Update status and log to audit/stat
         $this->status = TransferStatuses::AVAILABLE;


### PR DESCRIPTION
The database schema has largely remained identical between 2.x and 3.x. This was a deliberate effort to help allow sites to migrate from 2.x to 3.x installations. Some recent changes in 3.x added new columns and views which might be useful to backport so that the database update script will to nothing when switching between matching 2.x and 3.x release versions.

The extended functionality that is based on these new database columns doesn't need to be in the 2.x series. Only the columns themselves need to be in 2.x in order to allow quick switching (no database script) on matching `2.x <---> 3.x` releases again.

This relates to https://github.com/filesender/filesender/issues/2192.