### PR TITLE
Hide buttons for transfer metadata from guests

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -943,7 +943,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                         </div>
                     </div>
                 </div>
-
+                <?php if(!Auth::isGuest()) { ?>
                 <div class="fs-transfer__upload-actions">
                     <a id="detail-link" href=""type="button" class="fs-button fs-button--info" role="button">
                         <i class="fa fa-file-text-o"></i>
@@ -954,6 +954,7 @@ $expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
                         {tr:all_my_transfers}
                     </a>
                 </div>
+                <?php } ?>
             </div>
         </div>
 


### PR DESCRIPTION
After competing a transfer as a guest, the page you are shown holds buttons for "Transfer details" and "My transfers". Both pages are only available when authenticated, which is something a guest typically cannot do.

This hides these buttons for guests.