### PR TITLE
Add download functionality to filesender.py

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -200,7 +200,10 @@ class RestEndpointTransfer extends RestEndpoint
             if (!Utilities::isValidUID($token)) {
                 throw new RestBadParameterException('token');
             }
-
+            // Need to be authenticated
+            if (!Auth::isAuthenticated()) {
+                throw new RestAuthenticationRequiredException();
+            }
             
             $recipient = Recipient::fromToken($token);
             if ($recipient->transfer) {

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -200,10 +200,7 @@ class RestEndpointTransfer extends RestEndpoint
             if (!Utilities::isValidUID($token)) {
                 throw new RestBadParameterException('token');
             }
-            // Need to be authenticated
-            if (!Auth::isAuthenticated()) {
-                throw new RestAuthenticationRequiredException();
-            }
+
             
             $recipient = Recipient::fromToken($token);
             if ($recipient->transfer) {

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -541,7 +541,7 @@ def downloadFile(token,file_info:dict,download_key:bytes|None, attempt:int=0):
 def _downloadFile(token,file_info:dict, download_url:str, local_file_path:str):
   """save file to disk at local path"""
 
-  with requests.get(download_url,params={"token":token,"files_ids":file_info['id']},stream=True) as download:
+  with requests.get(download_url,params={"token":token,"files_ids":file_info['id']},stream=True,verify=(not insecure)) as download:
         download.raise_for_status()
         with open(local_file_path, mode='wb') as f:
             for chunk in download.iter_content(chunk_size=20_000):
@@ -559,7 +559,7 @@ def _downloadEncryptedFile(token,file_info:dict, download_url:str, local_file_pa
       end_offset = min(1 * (chunk_no * upload_chunk_size + (1*upload_crypted_chunk_size)-1),
                        (1*file_info['size']) + 32 - 1)
       download = requests.get(download_url,params={"token":token,"files_ids":file_info['id']},
-                              headers={ "Range": f"bytes={i}-{end_offset}"})
+                              headers={ "Range": f"bytes={i}-{end_offset}"},verify=(not insecure))
       download.raise_for_status()
       f.write(decrypt_chunk(download.content,chunk_no,file_info,download_key))
       chunk_no += 1

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -187,7 +187,7 @@ if not all([apikey, base_url, (username or from_address),arg_files,recipients]) 
   if not arg_files:
     missing_fields.append("[FILE]")
 
-  print(f"Missing required paramter, please provide the following: \n {','.join(missing_fields)}\n or -d --download with a valid download link")
+  print(f"Missing required parameter, please provide the following: \n {','.join(missing_fields)}\n or -d --download with a valid download link")
   sys.exit(1)
 
 #configs
@@ -317,12 +317,12 @@ if encrypted and not download_link:
 
   if encryption_details["password_numbers_required"]:
     if not any(map(lambda x: x.isdigit(),encryption_details["password"])):
-      print("Password does not meet number requirment")
+      print("Password does not meet number requirement")
       exit(1)
 
   if encryption_details["password_special_required"]:
     if all(map(lambda x: x.isalnum(),encryption_details["password"])):
-      print("Password does not meet special character requiremnet")
+      print("Password does not meet special character requirement")
       exit(1)
 
 
@@ -519,7 +519,7 @@ def downloadFile(token,file_info:dict,download_key:bytes|None, attempt:int=0):
   """Download a given file to disk."""
   try:
     if attempt > 10:
-      print("Unable to donwload file.")
+      print("Unable to download file.")
       sys.exit(1)
     download_url = base_url.replace("rest.php","download.php")
     path = file_info['name'].split("/")

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -214,7 +214,7 @@ if base_url != '[base_url]':
       info_response = requests.get(base_url+'/info', verify=False)
       config_response = requests.get(base_url[1:-9]+'/filesender-config.js.php',verify=False)
 
-  upload_chunk_size = info_response.json()['upload_chunk_size']
+  upload_chunk_size = int(info_response.json()['upload_chunk_size'])
 
   try:
       regex_match = re.search(r"terasender_worker_count\D*(\d+)",config_response.text)
@@ -670,7 +670,7 @@ def download_transfer(download_link):
     encryption_details['salt'] = file_list[0]['key-salt'].encode('ascii')
     encryption_details['password_hash_iterations'] = file_list[0]['password-hash-iterations']
     info_response = requests.get(base_url+"/info")
-    globals()['upload_chunk_size'] = info_response.json()['upload_chunk_size']
+    globals()['upload_chunk_size'] = int(info_response.json()['upload_chunk_size'])
     globals()['upload_crypted_chunk_size'] = upload_chunk_size + 32
     globals()["encryption_details"] = encryption_details
     download_key = generate_key()

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -642,7 +642,9 @@ def deconstruct_download_link(download_link:str) -> tuple[str, str]:
   components = download_link.split("?")
   assert len(components) == 2
   query_params = {comp.split('=')[0]: comp.split("=")[-1] for comp in components[1].split("&")}
-
+  if "token" not in query_params:
+    print("Error: Unable to find download token in url, please wrap the download string in ' or \" quotes ")
+    sys.exit(1)
   return (components[0], query_params["token"])
 
 def download_transfer(download_link):


### PR DESCRIPTION
Hey team, we had some users request the ability to easily download files in filesender.py. 

It doesn't require a configuration to be downloaded so it's a bit easier to use.
Currently this supports serial downloading of normal transfers and encrypted transfers if the server is using aes-gcm. 

### Changes:
- Enable anonymous access to the extended file transfer endpoint to match https://github.com/filesender/filesender/pull/2165. to enabled sub directories correctly and encrypted transfer downloads.
- Change in required argument parsing in the script to enable either the previous upload parameters or a new -d download parameter. 
- Adds a -d argument to filesender.py that takes in a download link for any file sender server and saves the contents of the transfer locally.

### Usage:
`python filesender.py -d 'https://filesenderserver/?s=download&token=4127c216-1d48-4d7b-9f41-8e7f19c0674f' -pv`
It will save the transfer in a directory under the token name by default, however you can also specify a folder with the -o argument. 
if the transfer was encrypted you can also pass in the -e argument with the password.

### Testing:
I've tested uploading and downloading large encrypted files, regular files and a large number of files. 
All worked without issue and all file hashes matched.


There is some room for performance improvement as there is no parallel workers like in the upload logic but overall it works fairly well in my testing.

Please let me know if you have any issues with this work.