### PR TITLE
update gha ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,8 @@ jobs:
           echo "AAAAAAA test"
           sudo chown -R www-data /home/runner/work/filesender        
           ls -ld /home/runner/work/filesender/filesender/includes
-          ls -l /home/runner/work/filesender/filesender/includes/init.php          
+          ls -l /home/runner/work/filesender/filesender/includes/init.php
+          ls -l /home/runner/work/filesender/filesender/scripts/task/../../includes/init.php
           sudo -u www-data id
           sudo -u www-data php scripts/task/cron.php --testing-mode
           echo "cron job complete"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           if [ x"$GITHUB_REPOSITORY" = "xfilesenderuici/filesender" ]; then
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"selenium\", \"db\": \"mysql\", \"travis_sauce_connect\": \"true\"}"
           else
-            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"cron\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"cron\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"mysql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
-            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"dataset\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"dataset\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
           fi
           
           MATRIX_INCLUDE_JSON="${MATRIX_INCLUDE_JSON//\}\{/\}, \{}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
           echo "testing task/cron job"
           echo "BASEDIR $BASEDIR"
           pwd
+          echo "AAAAAAA test"
+          ls -ld /home/runner/work/filesender/filesender/includes
+          ls -l /home/runner/work/filesender/filesender/includes/init.php          
+          sudo -u www-data id
           sudo -u www-data php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       SAUCE_DONT_VERIFY_CERTS: 1
       php_extensions: mbstring, pdo_mysql, pdo_pgsql, pgsql, mysqlnd
       php_cache_key: cache_setup_php_key_v8
-      php_version: '8.1'
+      php_version: '8.3'
       TESTINGUI: 0
 
     strategy:
@@ -141,7 +141,7 @@ jobs:
 
     - name: Install composer.json packages
       run: |
-        composer self-update --1
+        composer self-update
         composer update --no-interaction
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:latest
+        image: postgres:16.8
         env:
           POSTGRES_DB: postgres
           POSTGRES_HOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           pwd
           sudo systemctl stop apparmor
           echo "AAAAAAA test"
-          sudo chown -R www-data /home/runner/work/filesender        
+          sudo chown -R runner /home/runner/work/filesender
           ls -ld /home
           ls -ld /home/runner
           ls -ld /home/runner/work
@@ -211,7 +211,8 @@ jobs:
           php -v
           php -i|grep php.ini
           grep open_basedir /etc/php/8.3/cli/php.ini
-          sudo -u www-data php scripts/task/cron.php --testing-mode
+          id
+          sudo -u runner php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi
         echo "testing $TESTSUITE on database $DB "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,6 @@ jobs:
           pwd
           sudo systemctl stop apparmor
           echo "AAAAAAA test"
-          sudo chmod o+rx /home/runner
           sudo chown -R www-data /home/runner/work/filesender        
           ls -ld /home
           ls -ld /home/runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           --health-retries 5
 
       mariadb:
-        image: mariadb:10.2
+        image: mariadb:latest
         ports:
           - 3306:3306
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
           sudo -u www-data id
           php -v
           php -i|grep php.ini
+          grep open_basedir /etc/php/8.3/cli/php.ini
           sudo -u www-data php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   build:
     if: github.repository == 'filesender/filesender'
     name: ${{ matrix.testsuite }}-${{ matrix.db }}
-    runs-on: Ubuntu-20.04
+    runs-on: Ubuntu-24.04
     needs: metadata
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           pwd
           sudo systemctl stop apparmor
           echo "AAAAAAA test"
+          sudo chmod o+rx /home/runner
           sudo chown -R www-data /home/runner/work/filesender        
           ls -ld /home
           ls -ld /home/runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,8 @@ jobs:
           MYSQL_PASSWORD: password
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
-
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
+        
     steps:
     - name: Checkout code from github
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"selenium\", \"db\": \"mysql\", \"travis_sauce_connect\": \"true\"}"
           else
             #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"cron\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
-            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"mysql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
             #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"dataset\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           echo "testing task/cron job"
           echo "BASEDIR $BASEDIR"
           pwd
+          sudo systemctl stop apparmor
           echo "AAAAAAA test"
           ls -ld /home/runner/work/filesender/filesender/includes
           ls -l /home/runner/work/filesender/filesender/includes/init.php          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,6 @@ jobs:
           MYSQL_PASSWORD: password
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=3
         
     steps:
     - name: Checkout code from github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,6 @@ jobs:
           POSTGRES_USER: postgres
         ports:
           - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
       mariadb:
         image: mariadb:11.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,22 +190,7 @@ jobs:
           echo "testing task/cron job"
           echo "BASEDIR $BASEDIR"
           pwd
-          sudo systemctl stop apparmor
-          echo "AAAAAAA test"
           sudo chown -R runner /home/runner/work/filesender
-          ls -ld /home
-          ls -ld /home/runner
-          ls -ld /home/runner/work
-          ls -ld /home/runner/work/filesender
-          ls -ld /home/runner/work/filesender/filesender
-          ls -ld /home/runner/work/filesender/filesender/includes
-          ls -l /home/runner/work/filesender/filesender/includes/init.php
-          ls -l /home/runner/work/filesender/filesender/scripts/task/../../includes/init.php
-          sudo -u www-data id
-          php -v
-          php -i|grep php.ini
-          grep open_basedir /etc/php/8.3/cli/php.ini
-          id
           sudo -u runner php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           ls -l /home/runner/work/filesender/filesender/includes/init.php
           ls -l /home/runner/work/filesender/filesender/scripts/task/../../includes/init.php
           sudo -u www-data id
+          php -v
           sudo -u www-data php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           pwd
           sudo systemctl stop apparmor
           echo "AAAAAAA test"
+          sudo chown -R www-data /home/runner/work/filesender        
           ls -ld /home/runner/work/filesender/filesender/includes
           ls -l /home/runner/work/filesender/filesender/includes/init.php          
           sudo -u www-data id

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,11 @@ jobs:
           sudo systemctl stop apparmor
           echo "AAAAAAA test"
           sudo chown -R www-data /home/runner/work/filesender        
+          ls -ld /home
+          ls -ld /home/runner
+          ls -ld /home/runner/work
+          ls -ld /home/runner/work/filesender
+          ls -ld /home/runner/work/filesender/filesender
           ls -ld /home/runner/work/filesender/filesender/includes
           ls -l /home/runner/work/filesender/filesender/includes/init.php
           ls -l /home/runner/work/filesender/filesender/scripts/task/../../includes/init.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         POSTGRES_PORT: 5432
 
     - uses: saucelabs/sauce-connect-action@v1.1.2
-      if: ${{ env.TESTSUITE == 'selenium' }}
+      if: ${{ env.TESTSUITE == 'seleniumDISABLED' }}
       with:
         username: ${{ secrets.SAUCE_USERNAME }}
         accessKey: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
           ls -l /home/runner/work/filesender/filesender/scripts/task/../../includes/init.php
           sudo -u www-data id
           php -v
+          php -i|grep php.ini
           sudo -u www-data php scripts/task/cron.php --testing-mode
           echo "cron job complete"
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           if [ x"$GITHUB_REPOSITORY" = "xfilesenderuici/filesender" ]; then
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"selenium\", \"db\": \"mysql\", \"travis_sauce_connect\": \"true\"}"
           else
-            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"cron\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
-            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"cron\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
             MATRIX_INCLUDE_JSON+="{\"testsuite\": \"core\", \"db\": \"mysql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
-            MATRIX_INCLUDE_JSON+="{\"testsuite\": \"dataset\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
+            #MATRIX_INCLUDE_JSON+="{\"testsuite\": \"dataset\", \"db\": \"pgsql\", \"travis_sauce_connect\": \"false\",\"sauce_username\": \"\"}"
           fi
           
           MATRIX_INCLUDE_JSON="${MATRIX_INCLUDE_JSON//\}\{/\}, \{}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
 # this fails for mysql jobs when using the cache (jan 2021)
 #    - name: Cache extensions
-#      uses: actions/cache@v2
+#      uses: actions/cache@v4
 #      with:
 #        path: ${{ steps.cachesetupphp.outputs.dir }}
 #        key: ${{ steps.cachesetupphp.outputs.key }}
@@ -133,7 +133,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -147,7 +147,7 @@ jobs:
 
 
     - name: Cache SimpleSAML
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-simplesaml
       with:
         path: "simplesaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           --health-retries 5
 
       mariadb:
-        image: mariadb:latest
+        image: mariadb:11.4
         ports:
           - 3306:3306
         env:

--- a/ci/scripts/postgresql-setup.sh
+++ b/ci/scripts/postgresql-setup.sh
@@ -16,7 +16,7 @@ chmod 400 ~/.pgpass
 echo "password is "
 cat ~/.pgpass
 
-$PSQL -V
+#$PSQL -V
 echo "database listing is..."
 $PSQL -l
 

--- a/ci/scripts/postgresql-setup.sh
+++ b/ci/scripts/postgresql-setup.sh
@@ -16,6 +16,7 @@ chmod 400 ~/.pgpass
 echo "password is "
 cat ~/.pgpass
 
+$PSQL -V
 echo "database listing is..."
 $PSQL -l
 

--- a/ci/setup-machine.sh
+++ b/ci/setup-machine.sh
@@ -100,8 +100,6 @@ sudo chgrp -R www-data ${FILESENDERROOT}
 sudo chown -R www-data:docker   ${FILESENDERROOT}/log
 sudo chown -R www-data:docker   ${FILESENDERROOT}/files
 sudo chown -R www-data:www-data ${FILESENDERROOT}/tmp
-echo "AAAAAAA test"
-ls -l /home/runner/work/filesender/filesender/includes/init.php
 # recommended by install script for php${php_version}-fpm
 sudo a2enmod proxy_fcgi setenvif
 sudo a2enconf php7.4-fpm

--- a/ci/setup-machine.sh
+++ b/ci/setup-machine.sh
@@ -100,6 +100,8 @@ sudo chgrp -R www-data ${FILESENDERROOT}
 sudo chown -R www-data:docker   ${FILESENDERROOT}/log
 sudo chown -R www-data:docker   ${FILESENDERROOT}/files
 sudo chown -R www-data:www-data ${FILESENDERROOT}/tmp
+echo "AAAAAAA test"
+ls -l /home/runner/work/filesender/filesender/includes/init.php
 # recommended by install script for php${php_version}-fpm
 sudo a2enmod proxy_fcgi setenvif
 sudo a2enconf php7.4-fpm

--- a/ci/setup-machine.sh
+++ b/ci/setup-machine.sh
@@ -102,7 +102,7 @@ sudo chown -R www-data:docker   ${FILESENDERROOT}/files
 sudo chown -R www-data:www-data ${FILESENDERROOT}/tmp
 # recommended by install script for php${php_version}-fpm
 sudo a2enmod proxy_fcgi setenvif
-sudo a2enconf php7.4-fpm
+sudo a2enconf php3.3-fpm
 
 echo "restarting apache2 and php-fpm..."
 sudo service php${php_version}-fpm start

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -31,7 +31,7 @@
  */
 
 
-require_once(dirname(__FILE__).'/../../includes/init.php');
+require_once(realpath(dirname(__FILE__).'/../../includes/init.php'));
 
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -31,7 +31,8 @@
  */
 
 
-require_once(realpath(dirname(__FILE__)) . '/../../includes/init.php');
+require_once '/home/runner/work/filesender/filesender/includes/init.php';
+require_once(dirname(__FILE__) . '/../../includes/init.php');
 
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -31,8 +31,7 @@
  */
 
 
-require_once '/home/runner/work/filesender/filesender/includes/init.php';
-require_once(dirname(__FILE__) . '/../../includes/init.php');
+require_once(dirname(__FILE__).'/../../includes/init.php');
 
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -31,7 +31,7 @@
  */
 
 
-require_once(realpath(dirname(__FILE__).'/../../includes/init.php'));
+require_once(dirname(__FILE__).'/../../includes/init.php');
 
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -31,7 +31,7 @@
  */
 
 
-require_once(dirname(__FILE__).'/../../includes/init.php');
+require_once(realpath(dirname(__FILE__)) . '/../../includes/init.php');
 
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');


### PR DESCRIPTION
IIRC mariadb was locked back at 10.2 because there were some issues with that older version and views. But that was a long time ago so we shouldn't be locked there any more.