### PR TITLE
Patch download exceptions to limit the number of session-stored exceptions

### DIFF
--- a/templates/exception_page.php
+++ b/templates/exception_page.php
@@ -9,15 +9,13 @@ if (!preg_match('`^[0-9a-f]{13}$`', $sid)) {
     throw new DetailedException('not_an_exception_identifier', $sid);
 }
 
-if (!array_key_exists('exception_'.$sid, $_SESSION)) {
+if (!array_key_exists('exception', $_SESSION) || !is_array($_SESSION['exception']) || !array_key_exists($sid, $_SESSION['exception'])) {
     throw new DetailedException('unknown_exception_identifier', $sid);
 }
 
-$exception = $_SESSION['exception_'.$sid];
+$exception = $_SESSION['exception'][$sid];
 if (!($exception instanceof Exception)) {
     throw new DetailedException('not_an_exception', $sid);
 }
-
-$exception = $_SESSION['exception_'.$sid];
 
 Template::display('exception', array('exception' => $exception));

--- a/www/download.php
+++ b/www/download.php
@@ -175,8 +175,14 @@ try {
         manageOptions($ret, $transfer, $recipient, $recently_downloaded);
     
 } catch (Exception $e) {
+    if(!array_key_exists('exception', $_SESSION))
+        $_SESSION['exception'] = [];
+
+    $_SESSION['exception'] = array_slice($_SESSION['exception'], -4);
+    
     $sid = uniqid();
-    $_SESSION['exception_'.$sid] = $e;
+    $_SESSION['exception'][$sid] = $e;
+    
     $path = GUI::path() . '?s=exception&sid=' . $sid;
     header('Location: ' . $path);
 }


### PR DESCRIPTION
Depending on server config and limits it was possible for a bad actor or a bugged user to fill its session with 100s of download exceptions as this storage was not purged. This patch limits the number of stored exceptions to 5 in order to try to mitigate this issue.