### PR TITLE
Update for chunk size vary for transfer details page

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -156,6 +156,8 @@ if( !$found ) {
                                                               data-id="<?php echo $file->id ?>"
                                                               data-encrypted="<?php echo isset($transfer->options['encryption'])?$transfer->options['encryption']:'false'; ?>"
                                                               data-mime="<?php echo Template::sanitizeOutput($file->mime_type); ?>"
+                                                              data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
+                                                              data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"                                       
                                                               data-name="<?php echo Template::sanitizeOutput($file->path); ?>"
                                                               data-size="<?php echo $file->size; ?>"
                                                               data-encrypted-size="<?php echo $file->encrypted_size; ?>"

--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -47,6 +47,8 @@ $(function() {
         event.stopPropagation();
 
         var transferid = $(this).attr('data-transferid');
+        var chunk_size         = $(this).attr('data-chunk-size');
+        var crypted_chunk_size = $(this).attr('data-crypted-chunk-size');
         var id = $(this).attr('data-id');
         var encrypted = $(this).attr('data-encrypted');
         var filename = $(this).attr('data-name');
@@ -71,7 +73,7 @@ $(function() {
 
         window.filesender.crypto_app().decryptDownload(
             filesender.config.base_path + 'download.php?files_ids=' + id.join(','),
-            transferid,
+            transferid, chunk_size, crypted_chunk_size,
             mime, filename,
             filesize, encrypted_filesize,
             key_version, salt,


### PR DESCRIPTION
This new page is extremely similar to the download page. This updates that new page to also perform well when the chunk size is varied.