### PR TITLE
use idpid rather than entityid + CSS fix + fix some broken SQLs

### DIFF
--- a/classes/auth/Auth.class.php
+++ b/classes/auth/Auth.class.php
@@ -497,10 +497,10 @@ class Auth
         }
 
         if (!self::isTenantAdmin()) {
-            return null;
+            return 0;
         }
         
-        return self::user()->saml_user_identification_idp;
+        return self::user()->idpid;
     }
 
     /**

--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -143,7 +143,7 @@ class Guest extends DBObject
                         . ' , expires < now() as expired '
                         . " , status = 'available' as is_available "
                                 . '  from ' . self::getDBTable();
-            $idpview[$dbtype] = 'select g.*,u.id as uid,u.authid,a.saml_user_identification_idp from '
+            $idpview[$dbtype] = 'select g.*,u.id as uid,u.authid,a.idpid from '
                               . self::getDBTable() . ' g '
                                     . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON g.userid=u.id '
                                     . ' LEFT JOIN authidpview a ON u.authid=a.id '
@@ -171,7 +171,7 @@ class Guest extends DBObject
     // expires is null because they are still considered active
     const FROM_USER           = "userid = :userid AND (expires is null or expires > :date) ORDER BY created DESC";
     const FROM_USER_AVAILABLE = "userid = :userid AND (expires is null or expires > :date) AND status = 'available' ORDER BY created DESC";
-    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
+    const FROM_IDP_NO_ORDER   = "idpid = :idp ";
     
     /**
      * Properties
@@ -767,9 +767,9 @@ class Guest extends DBObject
             return $user->saml_user_identification_uid;
         }
         
-        if ($property == 'saml_user_identification_idp') {
+        if ($property == 'idpid') {
             $user = User::fromId($this->userid);
-            return $user->saml_user_identification_idp;
+            return $user->idpid;
         }
         
         if ($property == 'upload_link') {

--- a/classes/data/Recipient.class.php
+++ b/classes/data/Recipient.class.php
@@ -100,7 +100,7 @@ class Recipient extends DBObject
                         . DBView::columnDefinition_age($dbtype, 'created')
                         . DBView::columnDefinition_age($dbtype, 'last_activity', 'last_activity_days_ago')
                                 . '  from ' . self::getDBTable();
-            $idpview[$dbtype] = 'select r.*,u.id as uid,u.authid,a.saml_user_identification_idp from '
+             $idpview[$dbtype] = 'select r.*,u.id as uid, u.authid, a.idpid from '
                               . self::getDBTable() . ' r '
                                     . ' LEFT JOIN '.call_user_func('Transfer::getDBTable').' t ON r.transfer_id=t.id '
                                     . ' LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id '
@@ -115,7 +115,7 @@ class Recipient extends DBObject
     /**
      * Set selectors
      */
-    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
+    const FROM_IDP_NO_ORDER   = "idpid = :idp ";
     
 
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -289,7 +289,7 @@ class Transfer extends DBObject
                                              . " left outer join transfersauditlogsdlsubselectcountview zz "
                                              . " on t.id = zz.id  " ;
             
-            $idpviewsizesumperidp[$dbtype] = 'SELECT SUM(size) AS sizesum,  idp.entityid as saml_user_identification_idp,idp.name as idp_name,idp.organization_name as idp_organization_name '
+            $idpviewsizesumperidp[$dbtype] = 'SELECT SUM(size) AS sizesum, t.idpid, idp.entityid as saml_user_identification_idp,idp.name as idp_name,idp.organization_name as idp_organization_name '
                                            . ' FROM '.File::getDBTable().' f '
                                            . ' INNER JOIN '.self::getDBTable().' t ON t.id = f.transfer_id '
                                            . ' INNER JOIN '.call_user_func('IdP::getDBTable').' idp ON idp.id=t.idpid '
@@ -301,9 +301,6 @@ class Transfer extends DBObject
                               . self::getDBTable() . ' t '
                                     . ' INNER JOIN '.call_user_func('IdP::getDBTable').' idp ON idp.id=t.idpid ';
 
-
-            
-            
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a
                     , 'transfersauthview' => $authviewdef
@@ -358,10 +355,10 @@ class Transfer extends DBObject
     const CLOSED_NO_ORDER = "status = 'closed' ";
     const FROM_USER_NO_ORDER        = "userid = :userid AND status='available' and ( guest_id is null or guest_transfer_shown_to_user_who_invited_guest ) ";
     const FROM_USER_CLOSED_NO_ORDER = "userid = :userid AND status='closed'    and ( guest_id is null or guest_transfer_shown_to_user_who_invited_guest ) ";
-    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
-    const FROM_IDP_UPLOADING = "status = 'uploading' and saml_user_identification_idp = :idp ORDER BY created DESC";
-    const FROM_IDP_AVAILABLE = "status = 'available' and saml_user_identification_idp = :idp ORDER BY created DESC";
-    const FROM_IDP_EXPIRED   = "expires <= :date  and saml_user_identification_idp = :idp ORDER BY expires ASC";
+    const FROM_IDP_NO_ORDER   = "idpid = :idp ";
+    const FROM_IDP_UPLOADING = "status = 'uploading' and idpid = :idp ORDER BY created DESC";
+    const FROM_IDP_AVAILABLE = "status = 'available' and idpid = :idp ORDER BY created DESC";
+    const FROM_IDP_EXPIRED   = "expires <= :date and idpid = :idp ORDER BY expires ASC";
 
     const ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT = 16;
     

--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -158,7 +158,7 @@ class User extends DBObject
                                 . '  from ' . self::getDBTable();
             $userauthviewdef[$dbtype] = 'select up.id as id,authid,a.saml_user_identification_uid as user_id,up.last_activity,up.aup_ticked,up.created from '
                                        .self::getDBTable().' up LEFT JOIN '.call_user_func('Authentication::getDBTable').' a ON up.authid = a.id';
-            $idpview[$dbtype] = 'select u.*, av.saml_user_identification_idp_entityid as saml_user_identification_idp, av.saml_user_identification_idp_entityid as idp from '
+            $idpview[$dbtype] = 'select u.*, av.idpid as idpid, av.saml_user_identification_idp_entityid as idp, av.idp_name as idp_name from '
                                . self::getDBTable().' u '
                                . ' LEFT JOIN authidpview av ON u.authid=av.id ';
         }
@@ -192,11 +192,11 @@ class User extends DBObject
     protected $save_frequent_email_address = true;
     protected $save_transfer_preferences = true;
 
-    const FROM_IDP_NO_ORDER   = "saml_user_identification_idp = :idp ";
+    const FROM_IDP_NO_ORDER   = "idpid = :idp ";
     const AUP             = " service_aup_accepted_version >= :aup ";
-    const FROM_IDP_AUP    = " saml_user_identification_idp = :idp and service_aup_accepted_version >= :aup ";
+    const FROM_IDP_AUP    = " idpid = :idp and service_aup_accepted_version >= :aup ";
     const APIKEY          = " auth_secret IS NOT NULL  ";
-    const FROM_IDP_APIKEY = " saml_user_identification_idp = :idp and auth_secret IS NOT NULL  ";
+    const FROM_IDP_APIKEY = " idpid = :idp and auth_secret IS NOT NULL  ";
 
     
     /** 

--- a/templates/statistics_page.php
+++ b/templates/statistics_page.php
@@ -4,7 +4,7 @@ include_once "pagemenuitem.php";
 $idp = Auth::getTenantAdminIDP();
 
 function html_selectidp( $idp, $row ) {
-    if( $idp == $row['saml_user_identification_idp'] ) {
+    if( $idp == $row['id'] ) {
         return ' selected';
     }
     return '';
@@ -36,14 +36,14 @@ if (Auth::isAdmin()) {
 ?>
     <h3>IDP:
     <select id="idpselect">
-        <option value="all">All</option>
+        <option value="0">All</option>
 <?php
-$sql='SELECT entityid, name FROM idps ORDER BY name';
+$sql='SELECT entityid, name FROM idpsview ORDER BY name';
 $statement = DBI::prepare($sql);
 $statement->execute(array());
 $result = $statement->fetchAll();
 foreach($result as $row) {
-    echo '        <option value="'.$row['entityid'].'"'.html_selectidp( $idp, $row ).'>'.$row['name'].'</option>'."\n";
+    echo '        <option value="'.$row['id'].'"'.html_selectidp( $idp, $row ).'>'.$row['name'].'</option>'."\n";
 }
 ?>
     </select>
@@ -137,7 +137,7 @@ if (!$idp) {
 $sql='SELECT FLOOR(AVG(size)) as s, FLOOR(AVG(count)) as c FROM (select DATE(created) as day,SUM(filesize) as size, COUNT(id) as count FROM transfersfilesview GROUP BY DATE(created)) t';
 $placeholders=array();
 if ($idp) {
-    $sql='SELECT FLOOR(AVG(size)) as s, FLOOR(AVG(count)) as c FROM (select DATE(t.created) as day, SUM(t.filesize) as size, COUNT(t.id) as count FROM transfersfilesview t LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id LEFT JOIN authidpview a ON u.authid=a.id WHERE a.saml_user_identification_idp = :idp GROUP BY DATE(t.created)) tt';
+    $sql='SELECT FLOOR(AVG(size)) as s, FLOOR(AVG(count)) as c FROM (select DATE(t.created) as day, SUM(t.filesize) as size, COUNT(t.id) as count FROM transfersfilesview t LEFT JOIN '.call_user_func('User::getDBTable').' u ON t.userid=u.id LEFT JOIN authidpview a ON u.authid=a.id WHERE a.idpid = :idp GROUP BY DATE(t.created)) tt';
 $placeholders=array();
     $placeholders[':idp'] = $idp;
 }

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -2909,6 +2909,15 @@ table.guests .guest .to .errors .details {
   margin-left: 0.25em;
 }
 
+/* Statistics page */
+.statistics_page #idpbutton {
+  width: 40px;
+}
+
+.statistics_page #idpselect {
+  max-width: calc(100% - 90px);
+}
+
 /* Admin page */
 /* Admin statistics */
 .admin_page .statistics_section .storage_usage_blocks {

--- a/www/js/graph/statistics_data_per_day_graph.php
+++ b/www/js/graph/statistics_data_per_day_graph.php
@@ -73,9 +73,9 @@ $sql =
        .'  (SELECT AVG(size) FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as avg, '
        .'  (SELECT MIN(size) FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as min '
      :
-        '  (SELECT MAX(size) FROM transferssizeidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as max, '
-       .'  (SELECT AVG(size) FROM transferssizeidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as avg, '
-       .'  (SELECT MIN(size) FROM transferssizeidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as min '
+        '  (SELECT MAX(size) FROM transferssizeidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as max, '
+       .'  (SELECT AVG(size) FROM transferssizeidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as avg, '
+       .'  (SELECT MIN(size) FROM transferssizeidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as min '
     )
    .'FROM '
    .'  (SELECT (SELECT Date(NOW() - '.DBLayer::toIntervalDays(30).')) + '.DBLayer::toIntervalDays("a+b").' date '

--- a/www/js/graph/statistics_encryption_split_graph.php
+++ b/www/js/graph/statistics_encryption_split_graph.php
@@ -27,7 +27,7 @@ if (!$idp) {
        .'FROM transferssizeidpview '
        .'WHERE (DATE(created) >= NOW() - '.DBLayer::toIntervalDays(30).') OR '
        .'      (DATE(expires) >= NOW() - '.DBLayer::toIntervalDays(30).' AND DATE(expires) <= NOW()) '
-       .'  AND saml_user_identification_idp = :idp';
+       .'  AND idpid = :idp';
     $placeholders[':idp'] = $idp;
 }
 

--- a/www/js/graph/statistics_transfers_speeds_graph.php
+++ b/www/js/graph/statistics_transfers_speeds_graph.php
@@ -65,8 +65,8 @@ $sql =
         '  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":false%\') as Unencrypted, '
        .'  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":true%\') as Encrypted '
      :
-        '  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":false%\') as Unencrypted, '
-       .'  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":true%\') as Encrypted '
+        '  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":false%\') as Unencrypted, '
+       .'  (SELECT MAX(size/('.DBLayer::timeStampToEpoch('made_available').'-'.DBLayer::timeStampToEpoch('created').'+0.001))/1048576 FROM transferssizeidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date AND options LIKE \'%\\"encryption\\":true%\') as Encrypted '
    )
    .'FROM '
    .'  (SELECT (SELECT Date(NOW() - '.DBLayer::toIntervalDays(30).')) + '.DBLayer::toIntervalDays("a+b").' date '

--- a/www/js/graph/statistics_transfers_vouchers_graph.php
+++ b/www/js/graph/statistics_transfers_vouchers_graph.php
@@ -64,8 +64,8 @@ $sql =
         '  (SELECT COUNT(id) FROM transfersfilesview WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as transfers, '
        .'  (SELECT COUNT(id) FROM '.call_user_func('Guest::getDBTable').' WHERE DATE(created) <= Date.date AND DATE(expires) >= Date.date) as guests '
      :
-        '  (SELECT COUNT(id) FROM transfersfilesidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as transfers, '
-       .'  (SELECT COUNT(id) FROM guestsidpview WHERE saml_user_identification_idp = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as guests '
+        '  (SELECT COUNT(id) FROM transfersfilesidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as transfers, '
+       .'  (SELECT COUNT(id) FROM guestsidpview WHERE idpid = :idp AND DATE(created) <= Date.date AND DATE(expires) >= Date.date) as guests '
     )
    .'FROM '
    .'  (SELECT (SELECT Date(NOW() - '.DBLayer::toIntervalDays(30).')) + '.DBLayer::toIntervalDays("a+b").' date '

--- a/www/lib/tables/statistics_page.php
+++ b/www/lib/tables/statistics_page.php
@@ -6,10 +6,8 @@ if (!Auth::isAdmin() && !Auth::isTenantAdmin()) {
     exit(0);
 }
 
-
 $idp = Auth::getTenantAdminIDP();
 $pagelimit=Config::get('statistics_table_rows_per_page');
-
 
 $topic = Utilities::arrayKeyOrDefaultString( $_GET, 't' );
 $topic = Utilities::filter_regex( $topic, Utilities::FILTER_REGEX_PLAIN_STRING_UNDERSCORE );
@@ -75,7 +73,7 @@ switch ($topic) {
            .((!$idp) ?
              ''
              :
-             'a.saml_user_identification_idp = :idp AND '
+             'a.idpid = :idp AND '
            )
            .'    ((DATE(t.created) >= NOW() - '.DBLayer::toIntervalDays(30).') OR '
            .'     (DATE(t.expires) >= NOW() - '.DBLayer::toIntervalDays(30).' AND DATE(t.expires) <= NOW())) '
@@ -124,7 +122,7 @@ switch ($topic) {
            .((!$idp) ?
              ''
              :
-             'a.saml_user_identification_idp = :idp AND '
+             'a.idpid = :idp AND '
            )
            .'    ((DATE(t.created) >= NOW() - '.DBLayer::toIntervalDays(30).') OR '
            .'     (DATE(t.expires) >= NOW() - '.DBLayer::toIntervalDays(30).' AND DATE(t.expires) <= NOW())) '
@@ -163,13 +161,13 @@ switch ($topic) {
            .((!$idp) ?
              ''
              :
-             'LEFT JOIN '.call_user_func('User::getDBTable').' u ON f.userid=u.id LEFT JOIN a ON u.authid=a.id '
+             'LEFT JOIN '.call_user_func('User::getDBTable').' u ON f.userid=u.id LEFT JOIN authidpview a ON u.authid=a.id '
            )
            .'WHERE '
            .((!$idp) ?
              ''
              :
-             'a.saml_user_identification_idp = :idp AND '
+             'a.idpid = :idp AND '
            )
            .'    ((DATE(f.created) >= NOW() - '.DBLayer::toIntervalDays(30).') OR '
            .'     (DATE(f.expires) >= NOW() - '.DBLayer::toIntervalDays(30).' AND DATE(f.expires) <= NOW())) '
@@ -211,7 +209,7 @@ switch ($topic) {
            .((!$idp) ?
              ''
              :
-             'AND a.saml_user_identification_idp = :idp '
+             'AND a.idpid = :idp '
            )
            .'ORDER BY '.$sort.' '.$sortdirection
            .' LIMIT  '.$pagelimit


### PR DESCRIPTION
- use idpid rather than entityid
- CSS fix for long names
- fix some broken SQLs
- update some views to include idpid for the ones that were missing it

Note: some views can probably be reduced to remove entityid and perhaps other fields to make things tighter