### PR TITLE
fix: make sending of autoreminders to transfer owners configurable

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1813,7 +1813,7 @@ class Transfer extends DBObject
         if (!count($rms)) {
             return;
         }
-        
+
         foreach (self::all(self::AVAILABLE) as $transfer) {
             $recipients_downloaded_ids = array_map(function ($l) {
                 return $l->author_id;
@@ -1847,7 +1847,10 @@ class Transfer extends DBObject
                 $recipient->remind();
             }
 
-            $send_owner_autoreminder = true;
+            $send_owner_autoreminder = Config::get('owner_automatic_reminder');
+            if (!$send_owner_autoreminder) {
+                $send_owner_autoreminder = true;
+            }
 
             // no not leak this transfer in a reminder if the system wants
             // private guests

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1848,9 +1848,6 @@ class Transfer extends DBObject
             }
 
             $send_owner_autoreminder = Config::get('owner_automatic_reminder');
-            if (!$send_owner_autoreminder) {
-                $send_owner_autoreminder = true;
-            }
 
             // no not leak this transfer in a reminder if the system wants
             // private guests

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -214,6 +214,7 @@ A note about colours;
 * [recipient_reminder_limit](#recipient_reminder_limit)
 * [log_authenticated_user_download_by_ensure_user_as_recipient](#log_authenticated_user_download_by_ensure_user_as_recipient)
 * [transfer_automatic_reminder](#transfer_automatic_reminder)
+* [owner_automatic_reminder](#owner_automatic_reminder)
 * [transfers_table_show_admin_full_path_to_each_file](#transfers_table_show_admin_full_path_to_each_file)
 
 ## Graphs
@@ -2366,8 +2367,6 @@ This is only for old, existing transfers which have no roundtriptoken set.
      log in and thus the exact user is not known for the download log.
      
 
-
-
 ### transfer_automatic_reminder
 
 * __description:__ The number of reminders that a user can send to a recipient
@@ -2389,6 +2388,16 @@ This is only for old, existing transfers which have no roundtriptoken set.
    $config['transfer_automatic_reminder'] = 7;
    $config['transfer_automatic_reminder'] = array(7,10);
 
+
+### owner_automatic_reminder
+
+* __description:__ When sending a transfer reminder, also send one to the transfer owner
+* __mandatory:__ no
+* __type:__ bool
+* __default__: true
+* __available__: 3.0rc9
+* __comment__: When the transfer_automatic_reminder is true, this controls if an additional reminder is sent to 
+  the owner of the transfer.
 
 
 ### transfers_table_show_admin_full_path_to_each_file

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -217,6 +217,7 @@ $default = array(
     'guest_reminder_limit' => 50,
     'guest_reminder_limit_per_day' => 0,
     'recipient_reminder_limit' => 50,
+    'owner_automatic_reminder' => true,
 
     'autocomplete' => false,
     'autocomplete_min_characters' => 3,


### PR DESCRIPTION
The flag `send_owner_autoreminder` was set to true by default, only to be turned off when private guests feature was turned on.

This causes every transfer owner to be sent a receipt of every automatic reminder, which causes a flood of mail when many transfers/guests are active for a user, triggering spam protection mechanisms. 

This PR makes this configurable, defaulting to `True` for backward compatibility.