### PR TITLE
fix: run testsuite on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   build:
     if: github.repository == 'filesender/filesender'
     name: ${{ matrix.testsuite }}-${{ matrix.db }}
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: metadata
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -149,7 +149,7 @@ jobs:
 
 
     - name: Cache SimpleSAML
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache-simplesaml
       with:
         path: "simplesaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
     steps:
     - name: Checkout code from github
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
 
     - name: Make dummy artifact file


### PR DESCRIPTION
This should use the new `ubuntu-latest` runner instead of the removed `Ubuntu-20.04`