### PR TITLE
D3UI3 disable user theme until it is updated.

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -130,7 +130,6 @@ A note about colours;
 ## General UI
 
 * [theme](#theme)
-* [theme_userpref_enabled](#theme_userpref_enabled)
 * [autocomplete](#autocomplete)
 * [autocomplete_max_pool](#autocomplete_max_pool)
 * [autocomplete_min_characters](#autocomplete_min_characters)
@@ -1435,14 +1434,6 @@ Inside of files_downloaded.mail.php for example
 * __available:__ since version 2.8
 * __comment:__ You can not select absolute or relative paths using this parameter. Your theme directory must exist inside the existing template directory.
 
-### theme_userpref_enabled
-
-* __description:__ allow user to change theme.
-* __mandatory:__ no
-* __type:__ boolean
-* __default:__ true
-* __available:__ since version 3.0
-* __comment:__ allow user to select theme in user_page
 
 
 ### autocomplete

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -298,7 +298,7 @@ $default = array(
     'owasp_csrf_protector_enabled' => false,
 
     'theme' => '',
-    'theme_userpref_enabled' => true,
+    'theme_userpref_enabled' => false,
     'openpgp_enabled' => false,
 
     'user_can_only_view_guest_transfers_shared_with_them' => false,

--- a/templates/user_page.php
+++ b/templates/user_page.php
@@ -88,17 +88,6 @@ $user = Auth::user();
                     }
                     ?>
 
-                    <?php if (Config::get('theme_userpref_enabled')) { ?>
-                    <div class='fs-select pt-3'>
-                        <label for='user_theme'>{tr:theme}</label>
-                        <select id="user_theme" name="user_theme">
-                            <option value="device" selected>{tr:device}</option>
-                            <option value="default">{tr:light}</option>
-                            <option value="dark">{tr:dark}</option>
-                        </select>
-                        <small>{tr:theme_info}</small>
-                    </div>
-                    <?php } ?>
 
                     <div class="fs-switch fs-switch--small">
                         <input id="previous-settings" type="checkbox" name="save_transfer_preferences"  <?php echo isChecked($user->save_transfer_preferences); ?> />

--- a/www/js/theme.js
+++ b/www/js/theme.js
@@ -36,9 +36,9 @@ if(!('ui'         in window.filesender)) window.filesender.ui = {};
 const USER_THEME_KEY = 'USER_THEME';
 
 const THEMES = {
-    DEVICE_THEME: 'device',
+    DEVICE_THEME: 'default',
     LIGHT_THEME: 'default',
-    DARK_THEME: 'dark'
+    DARK_THEME: 'default'
 };
 
 /**


### PR DESCRIPTION
Some issues with themes have been reported. Some sites disable them by defualt. Perhaps we should make that the default until the themese have been updated a little bit.

It is best not to present a UI being "unable to log in and unable to upload files". Also a catch22, if you can not login then you can not change your theme.