### PR TITLE
Cloud: apply no limits to available storage

### DIFF
--- a/classes/storage/StorageCloudAzure.class.php
+++ b/classes/storage/StorageCloudAzure.class.php
@@ -84,6 +84,12 @@ class StorageCloudAzure extends StorageFilesystem
         return str_pad($offset, 24, '0', STR_PAD_LEFT);
     }
 
+    public static function canStore(Transfer $transfer)
+    {
+        // FIXME: we should really check if the Cloud backend has enough space
+        return true;
+    }
+    
     /**
      *  Reads chunk at offset
      *

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -109,6 +109,12 @@ class StorageCloudS3 extends StorageFilesystem
         return $file->uid;
     }
 
+
+    public static function canStore(Transfer $transfer)
+    {
+        // FIXME: we should really check if the Cloud backend has enough space
+        return true;
+    }
     
     /**
      *  Reads chunk at offset


### PR DESCRIPTION
While it would be better to check how much storage the back end has available, assuming things are ok and relying on other quota code (eg, user upload size) to enforce limits is better than failing here depending on how much spage is available on the local disk.

This was reported here https://github.com/filesender/filesender/issues/2291