### PR TITLE
php 8.4 deprecation updates

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -194,6 +194,7 @@ class User extends DBObject
     protected $save_frequent_email_address = true;
     protected $save_transfer_preferences = true;
 
+
     const FROM_IDP_NO_ORDER   = "idpid = :idp ";
     const AUP             = " service_aup_accepted_version >= :aup ";
     const FROM_IDP_AUP    = " idpid = :idp and service_aup_accepted_version >= :aup ";
@@ -681,7 +682,7 @@ class User extends DBObject
     public function __get($property)
     {
         if (in_array($property, array(
-            'id','additional_attributes', 'lang', 'aup_ticked', 'aup_last_ticked_date', 'auth_secret',
+            'id','additional_attributes', 'aup_ticked', 'aup_last_ticked_date', 'auth_secret',
             'auth_secret_created',
             'transfer_preferences', 'guest_preferences', 'frequent_recipients', 'created', 'last_activity',
             'email_addresses', 'name', 'quota', 'authid'
@@ -691,6 +692,15 @@ class User extends DBObject
             return $this->$property;
         }
 
+        if( $property == 'lang' ) {
+
+            if( !$this->lang ) {
+                return Lang::getCodeNoUserPref();
+            }
+            
+            return $this->lang;
+        }
+        
         if( $property == 'auth_secret_created_formatted' ) {
             return $this->auth_secret_created ? Utilities::formatDate($this->auth_secret_created,true) : '';
         }

--- a/classes/rest/RestRequest.class.php
+++ b/classes/rest/RestRequest.class.php
@@ -97,6 +97,10 @@ class RestInput
      */
     private $data = array();
 
+    public $mime_type = null;
+    public $iv = null;
+    public $encryption_client_entropy = null;
+    
     /**
      * Recursive crawler that converts raw data into browsable data
      *

--- a/classes/rest/RestRequest.class.php
+++ b/classes/rest/RestRequest.class.php
@@ -90,6 +90,7 @@ class RestRequest
 /**
  * Request body converter
  */
+#[AllowDynamicProperties]
 class RestInput
 {
     /**
@@ -97,9 +98,6 @@ class RestInput
      */
     private $data = array();
 
-    public $mime_type = null;
-    public $iv = null;
-    public $encryption_client_entropy = null;
     
     /**
      * Recursive crawler that converts raw data into browsable data

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -799,6 +799,9 @@ class RestEndpointTransfer extends RestEndpoint
                 }
 
                 // trim off optional rfc2045 *(";" parameter) blocks
+                if(!$filedata->mime_type) {
+                    $filedata->mime_type = '';
+                }
                 $filedata->mime_type = preg_replace('/^([^;]*).*/','$1',$filedata->mime_type);
 
                 $filedata->mime_type = Utilities::valuePassesConfigRegexOrDefault( $filedata->mime_type,

--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -252,6 +252,106 @@ class Lang
     }
 
     /**
+     * Get current default lang code 
+     *
+     * @return string
+     */
+    public static function getCodeNoUserPref()
+    {
+        $stack = array();
+        
+        $available = self::getAvailableLanguages();
+        
+        // Fill stack by order of preference and without duplicates
+        
+        if (count($available) > 1) {
+            // Auth exception should not stop processing of lang code
+            try {
+                // URL/session given language
+                if (Config::get('lang_url_enabled')) {
+                    if (array_key_exists('lang', $_GET) && preg_match('`^[a-z]+(-.+)?$`', $_GET['lang'])) {
+                        $code = self::realCode($_GET['lang']);
+                        if ($code) {
+                            if (!in_array($code, $stack)) {
+                                $stack[] = $code;
+                            }
+                            
+                            if (isset($_SESSION)) {
+                                $_SESSION['lang'] = $code;
+                            }
+                        }
+                    }
+                    
+                    if (isset($_SESSION) && array_key_exists('lang', $_SESSION)) {
+                        if (!in_array($_SESSION['lang'], $stack)) {
+                            $stack[] = $_SESSION['lang'];
+                        }
+                    }
+                }
+                
+            } catch (Exception $e) {
+            }
+            
+            // Browser language
+            if (Config::get('lang_browser_enabled') && array_key_exists('HTTP_ACCEPT_LANGUAGE', $_SERVER)) {
+                $codes = array();
+                foreach (array_map('trim', explode(',', $_SERVER['HTTP_ACCEPT_LANGUAGE'])) as $part) {
+                    $code = $part;
+                    $weight = 1;
+                    if (strpos($part, ';') !== false) {
+                        $part = array_map('trim', explode(';', $part));
+                        $code = array_shift($part);
+                        foreach ($part as $p) {
+                            if (preg_match('`^q=([0-9]+\.[0-9]+)$`', $p, $m)) {
+                                $weight = (float)$m[1];
+                            }
+                        }
+                    }
+                    $codes[$code] = $weight;
+                }
+                
+                uasort($codes, function ($a, $b) {
+                    return ($b > $a) ? 1 : (($b < $a) ? -1 : 0);
+                });
+                
+                foreach ($codes as $code => $weight) {
+                    $code = self::realCode($code);
+                    if ($code && !in_array($code, $stack)) {
+                        $stack[] = $code;
+                    }
+                }
+            }
+        }
+        
+        // Filter provided values
+        $stack = array_filter($stack, function ($code) use ($available) {
+            return array_key_exists($code, $available);
+        });
+        
+        // Config default language
+        $code = Config::get('default_language');
+        if ($code) {
+            $code = self::realCode($code);
+            if ($code && !in_array($code, $stack)) {
+                $stack[] = $code;
+            }
+        }
+        
+        // Absolute default, but avoid adding "en" if already set as default
+        if (!in_array('en', $stack)) {
+            $stack[] = 'en';
+        }
+        
+        // Add to cached stack (most significant first)
+        $main = array_shift($stack);
+        $t = array('main' => $main, 'fallback' => $stack);
+        
+        Logger::debug($t);
+
+        return $t['main'];
+    }
+    
+    /**
      * This is like the PHP setlocale but it respects the language the 
      * user has selected and tries to work with that selection into 
      * something that the php setlocale() can handle.
@@ -310,7 +410,6 @@ class Lang
     public static function getCode()
     {
         $stack = self::getCodeStack();
-        
         return $stack['main'];
     }
     

--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -346,8 +346,6 @@ class Lang
         $main = array_shift($stack);
         $t = array('main' => $main, 'fallback' => $stack);
         
-        Logger::debug($t);
-
         return $t['main'];
     }
     

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -256,7 +256,7 @@ if (!function_exists('clickableHeader')) {
                 $items = array();
                 foreach(array_slice($transfer->files, 0, 3) as $file) {
                     $name = $file->path;
-                    $name_shorten_by = (int) (mb_strlen((string) count($transfer->downloads))+mb_strlen(Lang::tr('see_all'))+3)/2;
+                    $name_shorten_by = intval(ceil(intval (mb_strlen((string) count($transfer->downloads))+mb_strlen(Lang::tr('see_all'))+3)/2));
                     if(mb_strlen($name) > 28-$name_shorten_by) {
                         if(count($transfer->downloads)) $name = mb_substr($name, 0, 23-$name_shorten_by).'...';
                         else $name = mb_substr($name, 0, 23).'...';


### PR DESCRIPTION
Updates for PHP 8.4 as raised here https://github.com/filesender/filesender/issues/2140

User.php can not directly use Lang::getCode as that will call back into $user->lang and start some loops.

The transfers table update doesn't really change much (float rounding) but it does remove many lines from the logs when you have
```
error_reporting = E_ALL
```