### PR TITLE
First of the post development merge updates

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -99,7 +99,10 @@ class AuthSPSaml
             $attributes = array();
 
             // Get IDP from SSP
-            $idp = trim($ssp->getAuthData('saml:sp:IdP'));
+            $idp = $ssp->getAuthData('saml:sp:IdP');
+            if( $idp ) {
+                $idp = trim($idp);
+            }
             $attributes['idp'] = $idp;
 
             // Wanted attributes

--- a/classes/autoload.php
+++ b/classes/autoload.php
@@ -44,6 +44,7 @@ class Autoloader
      */
     private static $mappers = array(
         'PropertyAccessException' => 'exceptions/DBObjectExceptions',
+        'ObjectLookupInViewFailedException' => 'exceptions/DBObjectExceptions',
         '*Exception' => 'exceptions/@package(Exception)',
         
         // CONSTANTS

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -265,7 +265,7 @@ class Transfer extends DBObject
             $idpview[$dbtype] = 'select t.*, idp.entityid as idp_entityid, idp.name as idp_name,idp.organization_name as idp_organization_name '
                               . ' from '
                               . self::getDBTable() . ' t '
-                                    . ' INNER JOIN '.call_user_func('IdP::getDBTable').' idp ON idp.id=t.idpid ';
+                                    . ' LEFT JOIN '.call_user_func('IdP::getDBTable').' idp ON idp.id=t.idpid ';
         }
         return array( strtolower(self::getDBTable()) . 'view' => $a
                     , 'transfersauthview' => $authviewdef


### PR DESCRIPTION
If the idp is null we shouldn't pass it to trim

We need to be able to lookup that exception

If we want to pass that view to fetchFromViewForId() it must be a left join to ensure transfer.id lookup will work even if there is no idp information for that particular transfer.