### PR TITLE
Replace clipboard messages with language strings

### DIFF
--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -388,10 +388,10 @@ $(function() {
     // Copy download link
     const copyToClipboard = (value) => {
         navigator.clipboard.writeText(value).then((x) => {
-            filesender.ui.notify('info', 'Copied to clipboard!');
+            filesender.ui.notify('info', lang.tr('copied_to_clipboard'));
         }).catch((e) => {
             console.error(e);
-            filesender.ui.notify('error', 'Error copying to clipboard!');
+            filesender.ui.notify('error', lang.tr('copied_to_clipboard_error'));
         });
     }
 

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -2052,10 +2052,10 @@ filesender.ui.updateSizeInfo = function () {
 
 filesender.ui.copyToClipboard = function(value) {
     navigator.clipboard.writeText(value).then((x) => {
-        filesender.ui.notify('info', 'Copied to clipboard!');
+        filesender.ui.notify('info', lang.tr('copied_to_clipboard'));
     }).catch((e) => {
         console.error(e);
-        filesender.ui.notify('error', 'Error copying to clipboard!');
+        filesender.ui.notify('error', lang.tr('copied_to_clipboard_error'));
     });
 };
 

--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -36,10 +36,10 @@ $(function() {
 
     const copyToClipboard = (value) => {
         navigator.clipboard.writeText(value).then((x) => {
-            filesender.ui.notify('info', 'Copied to clipboard!');
+            filesender.ui.notify('info', lang.tr('copied_to_clipboard'));
         }).catch((e) => {
             console.error(e);
-            filesender.ui.notify('error', 'Error copying to clipboard!');
+            filesender.ui.notify('error', lang.tr('copied_to_clipboard_error'));
         });
     }
 


### PR DESCRIPTION
A few static text strings were found while going through the new UX.
This replaces the strings with translation terms.

Terms have been added to the FileSender3 POEditor project.