### PR TITLE
UX: On OSX/Safari it seems lengthComputable is not set.

### DIFF
--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -864,7 +864,7 @@ window.filesender.crypto_app = function () {
             oReq.addEventListener("progress", function(evt){
                 window.filesender.log("downloadAndDecryptChunk(progress) chunkid " + chunkid
                                       + " loaded " + evt.loaded + " of total " + evt.total );
-                if (evt.lengthComputable) {
+                if (evt.lengthComputable || evt.loaded) {
                     var percentComplete = Math.round(evt.loaded / (1*encryption_details.crypted_chunk_size) *10000) / 100;
                     var percentOfFileComplete = 100*((chunkid * encryption_details.chunk_size + evt.loaded) / encryption_details.filesize );
                     


### PR DESCRIPTION
The evt.lengthComputable is false on osx/safari. This leads to the progressbar not being updated in the UI. The code doesn't actually need to use the total size from the evt message so if there is some indication of what is done we can update the progress anyway.

This should allow a nice download progress message on OSX/Safari.

Tested in an A/B on the current version of macos/safari as of today.