### PR TITLE
d3ui3 doing a notify and reload on language selection

### DIFF
--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -503,6 +503,30 @@ window.filesender.ui = {
         return n;
     },
 
+    notifyAndReload: function(type, message) {
+        if(typeof message != 'string') {
+            if(message.out) {
+                message = message.out();
+            }else if(!message.jquery) {
+                message = message.toString();
+            }
+        }
+
+        var ctn = $('#notifications');
+        if(!ctn.length) ctn = $('<div id="notifications" />').appendTo('body');
+
+        if( type == 'error' ) {
+            type = 'danger';
+        }
+        var n = $('<div class="alert alert-' + type + '" role="alert" />').html(message).appendTo(ctn);
+
+        window.setTimeout(function() {
+            filesender.ui.reload();
+        }, 1500);
+
+        return n;
+    },
+    
     /**
      * Display/remove maintenance popup
      *

--- a/www/js/user_page.js
+++ b/www/js/user_page.js
@@ -85,8 +85,7 @@ $(function() {
         p['clear_frequent_recipients'] = '1';
 
         filesender.client.updateUserPreferences(p, function() {
-            filesender.ui.notify('success', lang.tr('database_updated'));
-            filesender.ui.reload();
+            filesender.ui.notifyAndReload('success', lang.tr('database_updated'));
         });
 
         return false;
@@ -100,8 +99,7 @@ $(function() {
         p['clear_user_transfer_preferences'] = '1';
 
         filesender.client.updateUserPreferences(p, function() {
-            filesender.ui.notify('success', lang.tr('database_updated'));
-            filesender.ui.reload();
+            filesender.ui.notifyAndReload('success', lang.tr('database_updated'));
         });
 
         return false;
@@ -132,8 +130,7 @@ $(function() {
         p['apisecretdelete'] = '1';
 
         filesender.client.updateUserPreferences(p, function() {
-            filesender.ui.notify('success', lang.tr('preferences_updated'));
-            filesender.ui.reload();
+            filesender.ui.notifyAndReload('success', lang.tr('preferences_updated'));
         });
 
         return false;
@@ -148,8 +145,7 @@ $(function() {
             p['apisecretcreate'] = '1';
 
             filesender.client.updateUserPreferences(p, function() {
-                filesender.ui.notify('success', lang.tr('preferences_updated'));
-                filesender.ui.reload();
+                filesender.ui.notifyAndReload('success', lang.tr('preferences_updated'));
             });
         };
 
@@ -200,8 +196,7 @@ $(function() {
 
         
         if (!hasError) {
-            filesender.ui.notify('success', lang.tr('preferences_updated'));
-            location.reload();
+            filesender.ui.notifyAndReload('success', lang.tr('preferences_updated'));
         } else {
             filesender.ui.notify('error', lang.tr('Could not save user preferences.'));
         }
@@ -257,8 +252,7 @@ $(function() {
         var p = {};
         p['openpgp_key_delete'] = '1';        
         filesender.client.updateUserPreferences(p, function() {
-            filesender.ui.notify('success', lang.tr('preferences_updated'));
-            filesender.ui.reload();
+            filesender.ui.notifyAndReload('success', lang.tr('preferences_updated'));
             });
     });
     $('.test_my_openpgp_key').on('click', function(e) {
@@ -314,8 +308,7 @@ $(function() {
                             
                             filesender.client.updateUserPreferences(p, function() {
 
-                                filesender.ui.notify('success', lang.tr('preferences_updated'));
-                                filesender.ui.reload();
+                                filesender.ui.notifyAndReload('success', lang.tr('preferences_updated'));
                             });
                             
                         } else {


### PR DESCRIPTION
It would be cleaner here to be able to do a reload right away and then perform the notify in that reloaded window. That would need some more verification for example that you came from the same page and only allowing some messages to be sent. It is a bit of a security quagmire so just notifying that things went well and then redirecting soon after seems like the simpler short term solution.

This may be also what is effecting the language selection that some people have reported since the notify/reload issue was not used in the lang selection in 2.x.