### PR TITLE
fix: set 2 to CURLOPT_SSL_VERIFYHOST

### DIFF
--- a/scripts/client/FilesenderRestClient.class.php
+++ b/scripts/client/FilesenderRestClient.class.php
@@ -178,7 +178,7 @@ class FilesenderRestClient {
             'Content-Type: '.$content_type
         ));
         curl_setopt($h, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($h, CURLOPT_SSL_VERIFYHOST, true);
+        curl_setopt($h, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($h, CURLOPT_SSL_VERIFYPEER, true);
         
         switch($method) {


### PR DESCRIPTION
Because 1 (true) caused an error in curl 7.28.1 and later