### PR TITLE
d3: set the crypto_encrypted_archive_download in the Zip method too

### DIFF
--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -1388,6 +1388,7 @@ window.filesender.crypto_app = function () {
         decryptDownloadToZip: function(link,transferid,chunk_size,crypted_chunk_size,selectedFiles,progress,onFileOpen,onFileClose,onComplete) {
 
             var $this = this;
+            window.filesender.crypto_encrypted_archive_download = true;
 
             var callbackError = function (error) {
                 window.filesender.log(error);


### PR DESCRIPTION
A follow up to https://github.com/filesender/filesender/pull/2327