### PR TITLE
default config: enable streamsaver on Firefox by default

### DIFF
--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -324,7 +324,7 @@ $default = array(
 
     'streamsaver_enabled' => true,
     'streamsaver_on_unknown_browser' => false,
-    'streamsaver_on_firefox' => false,
+    'streamsaver_on_firefox' => true,
     'streamsaver_on_chrome' => true,
     'streamsaver_on_edge'   => true,
     'streamsaver_on_safari' => true,


### PR DESCRIPTION
This was reported as working here
https://github.com/filesender/filesender/issues/1337#issuecomment-1502774131

IIRC I had some issues in the very early days with Firefox but it may have been my env/proxy at the time. I am enabling this as the UX for streamsaver is substantially better than the fallback.