### PR TITLE
add basic ensureLocalIdPMetadata for Shibboleth

### DIFF
--- a/classes/auth/AuthSPShibboleth.class.php
+++ b/classes/auth/AuthSPShibboleth.class.php
@@ -170,6 +170,24 @@ class AuthSPShibboleth
         
         return self::$attributes;
     }
+
+    public static function ensureLocalIdPMetadata( $entityId, $idp, $force = false )
+    {
+        if( !$force ) {
+            $secs_ago = Config::get('auth_sp_idp_metadata_to_capture_frequency');
+            if( !$secs_ago ) {
+                return;
+            }
+            if( $secs_ago ) {
+                if( $idp->updated > (time() - $secs_ago )) {
+                    return;
+                }
+            }
+        }
+        
+        Logger::info("Finding IdP metadata for $entityId from Shibboleth");
+        $idp->saveIfChanged();
+    }
     
     /**
      * Generate the logon URL.


### PR DESCRIPTION
For this to be fully functional in the new stats update I need to play around more with some IdPs for Shibboleth and check that per IdP data is properly presented. Many of the fields in the idps table for Shibboleth will be left as null for now.

For SSP the code was reading the remote idp listing from the library. For the code to match in Shibboleth it should also be looking at the metadata for the remote IdPs that the Shibboleth SP knows about and adding that information into the local idps table in FileSender.