### PR TITLE
Fix filesender.py so that it doesn't get messed up by clidownload.php

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -125,7 +125,8 @@ else:
   
 requiredNamed.add_argument("-r", "--recipients", required=True)
 
-if base_url == "[base_url]":
+# Do not change this seemingly out-of-place concat as it avoid getting this test messed up by clidownload.php
+if base_url == "[" + "base_url" + "]":
   requiredNamed.add_argument("-b", "--base_url", required=True)
 else:
   parser.add_argument("-b", "--base_url")

--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -132,7 +132,7 @@ else:
   parser.add_argument("-b", "--base_url")
 
 # if username is not a valid email address then ensure user supplies a valid email address
-if username is None or not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", username)):
+if username is None or not bool(re.match(r'([^@|\s]+@[^@]+\.[^@|\s]+)', username)):
   requiredNamed.add_argument("-f", "--from_address", help="filesender email from address", required=True)
 
 args = parser.parse_args()


### PR DESCRIPTION
Fixes #2341

Clidownload.php was replacing one too many [base_url] instances in filesender.py, thus messing up --base_url argument mandatory status, this uses concatenation to "hide" the specific instance of [base_url] from the str_replace in clidownload.php