### PR TITLE
Load additional config from $auth_attrs['additional'][$attr]

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -174,7 +174,8 @@ class Config
                                 continue;
                         }
                         foreach ($regex_and_configs as $regex => $extra_config_name) {
-                                if (isset($auth_attrs[$attr]) && preg_match('`'.$regex.'`', $auth_attrs[$attr])) {
+                                if ((isset($auth_attrs[$attr]) && preg_match('`'.$regex.'`', $auth_attrs[$attr])) ||
+                                    (isset($auth_attrs['additional'][$attr][0]) && preg_match('`'.$regex.'`', $auth_attrs['additional'][$attr][0]))) {
                                         $extra_config_file = FILESENDER_BASE.'/config/config-' . $extra_config_name . '.php';
                                         if (file_exists($extra_config_file)) {
                                                 $config = array();


### PR DESCRIPTION
This patch allows admins to load different configs from `$config['auth_sp_additional_attributes']` using `$config['auth_config_regex_files']`.

The additional attributes show up as auth_attrs['additional'][$attr] as an array of one item.