### PR TITLE
Config: SAML additional attriubtes to config (#2350)

### DIFF
--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -85,6 +85,58 @@ class Config
             }
         }
     }
+
+    
+    private static function handleConfigRegexFilesForValue( $configKey, $matchValue, $regex, $extra_config_name )
+    {
+        if( !isset($matchValue)) {
+            return;
+        }
+
+        if (preg_match('`'.$regex.'`', $matchValue)) {
+            $extra_config_file = FILESENDER_BASE.'/config/config-' . $extra_config_name . '.php';
+            if (file_exists($extra_config_file)) {
+                $config = array();
+                include_once($extra_config_file);
+                self::merge(self::$parameters, $config);
+            }
+        }
+    }
+    
+    private static function handleConfigRegexFiles( $configKey, $matchAdditionalAttributes = false )
+    {
+        $configRegexList = self::get($configKey);
+        
+        if( !empty($configRegexList) && is_array($configRegexList) && Auth::isAuthenticated(false)) {
+            $auth_attrs = Auth::attributes();
+            foreach ($configRegexList as $attr=>$regex_and_configs) {
+                if (!is_array($regex_and_configs)) {
+                    continue;
+                }
+                foreach ($regex_and_configs as $regex => $extra_config_name) {
+
+                    if( $matchAdditionalAttributes ) {
+
+                        if (!array_search($attr, Config::get('auth_sp_additional_attributes'))) {
+                            Logger::error("CONFIG ERROR: Please add attriubte $attr to auth_sp_additional_attributes or remove it from your auth_config*regex_files config");
+                        }
+                        
+                        // additional attributes handles an array of values
+                        $a = $auth_attrs['additional'][$attr];
+                        foreach( $a as $matchValue ) {                            
+                            self::handleConfigRegexFilesForValue( $configKey, $matchValue, $regex, $extra_config_name );
+                            
+                        }
+                    } else {
+                        // work on single main value.
+                        $matchValue = $auth_attrs[$attr];
+                        self::handleConfigRegexFilesForValue( $configKey, $matchValue, $regex, $extra_config_name );
+                    }
+                }
+            }
+        }
+    }
+    
     
     /**
      * Main loader, loads defaults, main config and virtualhost config if it exists
@@ -166,26 +218,9 @@ class Config
 
         // Load config regex overrides if used and present
         // if not authenticated then do not throw, just do not load these files
-        $auth_config_regex_files = self::get('auth_config_regex_files');
-        if( !empty($auth_config_regex_files) && is_array($auth_config_regex_files) && Auth::isAuthenticated(false)) {
-                $auth_attrs = Auth::attributes();
-                foreach ($auth_config_regex_files as $attr=>$regex_and_configs) {
-                        if (!is_array($regex_and_configs)) {
-                                continue;
-                        }
-                        foreach ($regex_and_configs as $regex => $extra_config_name) {
-                                if (preg_match('`'.$regex.'`', $auth_attrs[$attr])) {
-                                        $extra_config_file = FILESENDER_BASE.'/config/config-' . $extra_config_name . '.php';
-                                        if (file_exists($extra_config_file)) {
-                                                $config = array();
-                                                include_once($extra_config_file);
-                                                self::merge(self::$parameters, $config);
-                                        }
-                                }
-                        }
-                }
-        }
-
+        self::handleConfigRegexFiles( 'auth_config_additional_regex_files', true );
+        self::handleConfigRegexFiles( 'auth_config_regex_files', false );
+        
         // ensure mandatory config settings file exists
         $mandatory_config_file = FILESENDER_BASE.'/includes/ConfigMandatorySettings.php';
         if (!file_exists($mandatory_config_file)) {

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -316,6 +316,7 @@ A note about colours;
 * [host_quota](#host_quota)
 * [config_overrides](#config_overrides) (experimental feature, not tested)
 * [auth_config_regex_files](#auth_config_regex_files)
+* [auth_config_value_regex_files](#auth_config_value_regex_files)
 
 ## Data Protection
 
@@ -3071,7 +3072,10 @@ $config['log_facilities'] =
 * __available:__ since version 2.0
 * __1.x name:__
 * __comment:__
-* __example:__ <span style="background-color:orange">need an example here!</span>
+* __example:__ 
+ 	<pre><code>
+    $config['auth_sp_additional_attributes'] = ['quota','eduPersonAffiliation'];
+	</code></pre>
 
 ### auth_sp_save_user_additional_attributes
 
@@ -3400,6 +3404,40 @@ Changes are saved in config_overrides.json in the config directory.  The config.
 	In this examples, if the uid ends with "@mydomain.com", the config file config-mydomainfile.php in the config subdir will be loaded.
 	If the uid ends with "@myotherdomain.com" or "@yetanotherdomain.com", the config file config-myotherdomainfile.php in the config subdir will be loaded.
 	
+### auth_config_additional_regex_files
+* __description:__ This is like auth_config_regex_files but it works on the value(s) in attributes['addtional']. Such attributes can be gathered by setting auth_sp_additional_attributes. Note that you have to explicitly gather these attributes using the auth_sp_additional_attributes config key in order to match against them. 
+* __mandatory:__ no
+* __type:__ array of key-value pairs
+* __default:__ 0, null, empty string: no overrides loaded.
+* __available:__ since version 2.58
+* __1.x name:__
+* __comment:__ example:
+ 	<pre><code>
+    $config['auth_sp_additional_attributes'] = ['quota','eduPersonAffiliation'];
+    
+	$config['auth_config_additional_regex_files'] = [
+		'quota' => [
+			'500mb$' => 'quotafor500mbfile',
+			'10gb$'  => 'quotafor10gbfile',
+		],
+		'eduPersonAffiliation' => [
+			'student$' => 'quotaforstdentfile',
+			'employee$ => 'quotaforemployeefile',
+		],
+    ];
+	</code></pre>
+    
+    If the selected key is an array then each value in that array will
+    be attempted to match in turn. The items are considered in the
+    order presented by the authentication system. So in the below you
+    can match various items in an array 'eduPersonAffiliation' to
+    config files. If a user has a list eduPersonAffiliation =
+    array('student','employee') then both keys will match and employee
+    will be last.
+
+    
+
+
 ###
 
 ---


### PR DESCRIPTION
* Config: SAML additional attriubtes to config

A new auth_config_additional_regex_files config key that matches against the whole array (one at a time) for the picked attributes.

Perhaps we should also add at some stage a "sort" type key to allow the provided array to be sorted so that the order that multiple matching config files is applied is determined explicitly. For example, student and employee we might like the student to sort first so that the employee config can be more permissive or have a larger quota.

* catch bad config cases and tell admin in strong terms

* switch order