### PR TITLE
Lift getBoolArg into the Args util class

### DIFF
--- a/classes/utils/Args.class.php
+++ b/classes/utils/Args.class.php
@@ -197,4 +197,19 @@ class Args
     {
         return max($min, min($max, $current));
     }
+
+
+    /**
+     * A simple method to get --verbose and --dry-run type single arguments
+     * without needing to do full arg passing
+     *
+     * @param name Full binary arg, for example '--verbose'
+     * @return false by default, true of arg is set
+     */
+    public static function getBoolArg( $name )
+    {
+        global $argv;
+        return in_array($name,$argv);
+    }
+    
 }

--- a/scripts/StorageFilesystemForward/forward-MMCFTP.php
+++ b/scripts/StorageFilesystemForward/forward-MMCFTP.php
@@ -49,14 +49,6 @@ function customErrorHandler($errno, $errstr, $errfile, $errline) {
 set_error_handler("customErrorHandler");
 
 
-//
-// False by default, if present it is set
-//
-function getBoolArg( $name )
-{
-    global $argv;
-    return in_array($name,$argv);
-}
 
 //
 // Target transfer id
@@ -71,7 +63,7 @@ if (!$target) {
 //
 // Mainly a developer feature. Do not send emails to allow rapid testing
 //
-$testingMode = getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
+$testingMode = Args::getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
 //$testingMode = true;
 if( $testingMode ) {
     Mail::TESTING_SET_DO_NOT_SEND_EMAIL();

--- a/scripts/StorageFilesystemForward/forward-REST.php
+++ b/scripts/StorageFilesystemForward/forward-REST.php
@@ -49,14 +49,6 @@ function customErrorHandler($errno, $errstr, $errfile, $errline) {
 set_error_handler("customErrorHandler");
 
 
-//
-// False by default, if present it is set
-//
-function getBoolArg( $name )
-{
-    global $argv;
-    return in_array($name,$argv);    
-}
 
 //
 // Target transfer id
@@ -71,7 +63,7 @@ if (!$target) {
 //
 // Mainly a developer feature. Do not send emails to allow rapid testing
 //
-$testingMode = getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
+$testingMode = Args::getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
 //$testingMode = true;
 if( $testingMode ) {
     Mail::TESTING_SET_DO_NOT_SEND_EMAIL();

--- a/scripts/StorageFilesystemForward/forward-SCP.php
+++ b/scripts/StorageFilesystemForward/forward-SCP.php
@@ -49,14 +49,6 @@ function customErrorHandler($errno, $errstr, $errfile, $errline) {
 set_error_handler("customErrorHandler");
 
 
-//
-// False by default, if present it is set
-//
-function getBoolArg( $name )
-{
-    global $argv;
-    return in_array($name,$argv);
-}
 
 //
 // Target transfer id
@@ -71,7 +63,7 @@ if (!$target) {
 //
 // Mainly a developer feature. Do not send emails to allow rapid testing
 //
-$testingMode = getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
+$testingMode = Args::getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
 //$testingMode = true;
 if( $testingMode ) {
     Mail::TESTING_SET_DO_NOT_SEND_EMAIL();

--- a/scripts/task/S3bucketmaintenance.php
+++ b/scripts/task/S3bucketmaintenance.php
@@ -41,27 +41,11 @@ require_once(dirname(__FILE__).'/../../includes/init.php');
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('S3 Bucket Maintenance script started');
 
-//
-// False by default, if present it is set
-//
-function getBoolArg( $name )
-{
-    global $argv;
-    
-    $ret = (count($argv) > 1) ? $argv[1]==$name : false;
-    if( !$ret && count($argv) > 2 ) {
-        $ret = ($argv[2]==$name);
-        if( !$ret && count($argv) > 3 ) {
-            $ret = ($argv[3]==$name);
-        }
-    }
-    return $ret;
-}
 
 //
 // Print some messages to give a hint to the user on progress
 //
-$verbose = getBoolArg('--verbose');
+$verbose = Args::getBoolArg('--verbose');
 
 if( $verbose ) {
     echo "S3bucketmaintenance.php starting up...\n";

--- a/scripts/task/cron.php
+++ b/scripts/task/cron.php
@@ -36,27 +36,11 @@ require_once(dirname(__FILE__).'/../../includes/init.php');
 Logger::setProcess(ProcessTypes::CRON);
 Logger::info('Cron started');
 
-//
-// False by default, if present it is set
-//
-function getBoolArg( $name )
-{
-    global $argv;
-    
-    $ret = (count($argv) > 1) ? $argv[1]==$name : false;
-    if( !$ret && count($argv) > 2 ) {
-        $ret = ($argv[2]==$name);
-        if( !$ret && count($argv) > 3 ) {
-            $ret = ($argv[3]==$name);
-        }
-    }
-    return $ret;
-}
 
 //
 // Print some messages to give a hint to the user on progress
 //
-$verbose = getBoolArg('--verbose');
+$verbose = Args::getBoolArg('--verbose');
 
 //
 // If one or more files in the transfer can not be deleted
@@ -66,12 +50,12 @@ $verbose = getBoolArg('--verbose');
 // deleted some files and the system is halting when it tries
 // to delete those same files.
 //
-$force = getBoolArg('--force');
+$force = Args::getBoolArg('--force');
 
 //
 // Mainly a developer feature. Do not send emails to allow rapid testing
 //
-$testingMode = getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
+$testingMode = Args::getBoolArg('--testing-mode'); // (count($argv) > 1) ? $argv[1]=='--testing-mode' : false;
 if( $testingMode ) {
     Mail::TESTING_SET_DO_NOT_SEND_EMAIL();
 }


### PR DESCRIPTION
More of a cleanup on the util method `getBoolArg` following  https://github.com/filesender/filesender/pull/2365