### PR TITLE
tiny forward UX fix

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -5,10 +5,10 @@ function render_forward_to_another_server($advanced=false) {
         !Auth::isGuest()) {
         echo '<div class="row">'."\n";
         if ($advanced) {
-            echo '    <div class="col-12 basic_options">'."\n";
+            echo '    <div id="fs-forward_options" class="col-12 basic_options">'."\n";
             echo '        <strong>{tr:forward_to_another_server}<strong>'."\n";
         } else {
-            echo '    <div class="col-12">'."\n";
+            echo '    <div id="fs-forward_options" class="col-12">'."\n";
         }
         echo '        <div data-option="forward_to_another_server" class="fs-switch fs-switch--hide">'."\n";
         echo '            <input id="forward_to_another_server" name="forward_to_another_server" type="checkbox">'."\n";

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -2049,6 +2049,7 @@ filesender.ui.onChangeTransferType = function (transferType) {
         const addMeToRecipientsField = $(`#fs-transfer__add-me-to-recipients`);
         const sendAnotherServerField = $(`[data-option='forward_to_another_server']`);
         const sendServerNameField = $(`[data-option='forward_server_name']`);
+        const forwardOptions = $(`#fs-forward_options`);
 
         switch (transferType) {
             case TRANSFER_TYPES.TRANSFER_LINK:
@@ -2056,6 +2057,7 @@ filesender.ui.onChangeTransferType = function (transferType) {
                 addMeToRecipientsField.addClass('fs-switch--hide');
                 sendAnotherServerField.hide();
                 sendServerNameField.hide();
+                forwardOptions.hide();
                 filesender.ui.nodes.options.forward_to_another_server.prop("checked", false);
                 filesender.ui.nodes.encryption.toggle.prop("disabled", false);
                 filesender.ui.getALink = true;
@@ -2070,6 +2072,7 @@ filesender.ui.onChangeTransferType = function (transferType) {
             case TRANSFER_TYPES.TRANSFER_EMAIL:
                 emailField.removeClass('fs-input-group--hide');
                 addMeToRecipientsField.removeClass('fs-switch--hide');
+                forwardOptions.show();
                 sendAnotherServerField.show();
                 $('[data-option="add_me_to_recipients"]').removeClass('fs-switch--hide');
                 filesender.ui.getALink = false;


### PR DESCRIPTION
When forward is enabled in advanced transfer settings and user selects "a transfer link" the forward heading is shown which it shouldn't.