### PR TITLE
allow downloading archive from transfers detail page

### DIFF
--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -162,7 +162,7 @@ A note about colours;
 * [auth_sp_saml_can_view_aggregate_statistics_entitlement](#auth_sp_saml_can_view_aggregate_statistics_entitlement)
 * [read_only_mode](#read_only_mode)
 * [template_config_values_that_can_be_read_in_templates](#template_config_values_that_can_be_read_in_templates)
-
+* [ui3_allow_selecting_files_on_transfer_details_page](#ui3_allow_selecting_files_on_transfer_details_page)
 
 ## Transfers
 
@@ -1730,7 +1730,14 @@ Inside of files_downloaded.mail.php for example
      list and they can be added to the default.
 
 
-* [template_config_values_that_can_be_read_in_templates](#template_config_values_that_can_be_read_in_templates)
+
+### ui3_allow_selecting_files_on_transfer_details_page
+* __description:__  Allow the user to select which files to download in an archive on the transfers details page.
+* __mandatory:__ no
+* __type:__ bool
+* __default:__ true
+* __available:__ since version 3.0 rc12
+* __comment:__ 
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -399,6 +399,8 @@ $default = array(
     'validate_csrf_token_for_guests' => true,
 
     'file_forwarding_enabled' => false,
+
+    'ui3_allow_selecting_files_on_transfer_details_page' => true,
     
     'template_config_values_that_can_be_read_in_templates' => array(
         'default_guest_days_valid',

--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -59,6 +59,44 @@ if( !$found ) {
     echo $transfer_not_found;
     return;
 }
+
+$canDownloadArchive = count($transfer->files) > 1;
+$canDownloadAsTar = true;
+$canDownloadAsZip = true;
+if($isEncrypted) {
+    // Streaming to a local decrypted archive requires StreamSaver feature
+    $canDownloadArchive = false;
+    // no stream to tar file support yet.
+    $canDownloadAsTar = false;
+    if( Browser::instance()->allowStreamSaver ) {
+        $canDownloadArchive = true;
+    }
+}
+$ui3_allow_file_selection = Utilities::isTrue(Config::get('ui3_allow_selecting_files_on_transfer_details_page'));
+if( !$ui3_allow_file_selection ) {
+    $canDownloadArchive = false;
+}
+
+      
+$downloadLinks = array();
+$archiveDownloadLink = '#';
+$archiveDownloadLinkFileIDs = '';
+
+if(empty($transfer->options['encryption'])) {
+    $fileIds = array();
+    foreach($transfer->files as $file) {
+        $downloadLinks[$file->id] = Utilities::http_build_query(array(
+            'token' => $token,
+            'files_ids' => $file->id,
+        ), 'download.php?' );
+        $fileIds[] = $file->id;
+    }
+    $archiveDownloadLink = Utilities::http_build_query(array(
+        'token' => $token,
+    ), 'download.php?' );
+    $archiveDownloadLinkFileIDs = implode(',', $fileIds);
+}
+
 ?>
 
 <div class="fs-transfer-detail transfer_details"
@@ -140,8 +178,22 @@ if( !$found ) {
             <div class="col col-sm-12 col-md-6 col-lg-6">
                 <div class="fs-transfer-detail__files">
                     <h2>{tr:transferred_files}</h2>
+                    <?php if($canDownloadArchive) { ?>
+                        <p>{tr:select_files_to_download}</p>
+
+                        <div class="fs-download__check-all select_all">
+                            <label class="fs-checkbox">
+                                <label for="check-all" class="select_all_text">
+                                    {tr:click_to_check_all}
+                                </label>
+                                <input id="check-all" type="checkbox">
+                                <span class="fs-checkbox__mark toggle-select-all"></span>
+                            </label>
+                        </div>
+                    <?php } ?>
+                    
                     <div class="fs-transfer__list">
-                        <div class="fs-transfer__files"">
+                        <div class="fs-transfer__files" data-count="<?php echo ($canDownloadArchive)?count($transfer->files):'1' ?>" >
                             <table class="fs-table files">
                                 <tbody>
                                 <?php foreach($transfer->files as $file) { ?>
@@ -157,6 +209,15 @@ if( !$found ) {
                                         data-fileaead="<?php echo $file->aead; ?>"
                                         data-transferid="<?php echo $transfer->id; ?>"
                                     >
+                                            <?php if($canDownloadArchive) { ?>
+                                                <td class="fs-table__check-action">
+                                                    <label class="fs-checkbox select" title="{tr:select_for_archive_download}">
+                                                        <input id="check-<?php echo Template::Q($file->id) ?>" type="checkbox">
+                                                        <span class="fs-checkbox__mark"></span>
+                                                    </label>
+                                                </td>
+                                            <?php } ?>
+                                        
                                         <td>
                                             <div>
                                                 <span class="name"><?php echo Utilities::sanitizeOutput($file->path) ?></span>
@@ -229,6 +290,34 @@ if( !$found ) {
                             <?php echo Utilities::formatBytes($transfer->size) ?>
                         </span>
                     </div>
+                    <?php if($canDownloadArchive) { ?>
+                        <div class="fs-download__actions archive">
+                            <button type="button" class="fs-button archive_download_frame archive_download" title="{tr:archive_download}">
+                                <i class="fa fa-download"></i>
+                                <span>{tr:archive_download}</span>
+                            </button>
+                            <?php if($canDownloadAsTar) { ?>
+                                <button type="button" class="fs-button archive_tar_download_frame archive_tar_download" title="{tr:archive_tar_download}">
+                                    <i class="fa fa-download"></i>
+                                    <span>{tr:archive_tar_download}</span>
+                                </button>
+
+                            <?php } ?>
+
+                            <div class="archive_download_framex hidden">
+                                <form id="dlarchivepost" action="<?php echo Template::Q($archiveDownloadLink) ?>" method="post">
+                                    <input class="hidden archivefileids" name="files_ids" value="<?php echo Template::Q($archiveDownloadLinkFileIDs); ?>" />
+                                    <input id="dlarchivepostformat" class="hidden " name="archive_format" value="zip" />
+                                    <button type="submit"
+                                            name="your_name" value="your_value"
+                                            class="btn-link">DOWNLOAD
+                                    </button>
+                                </form>
+                            </div>
+                            <span class="downloadprogress"/>
+                        </div>
+                    <?php } ?>
+                    
                 </div>
             </div>
         </div>
@@ -386,6 +475,10 @@ if( !$found ) {
             </div>
         </div>
     </div>
+
+    
 </div>
+
+<div class="token not_displayed"><?php echo $transfer->first_recipient->token ?></div>
 
 <script type="text/javascript" src="{path:js/transfer_detail_page.js}"></script>

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -943,5 +943,371 @@ window.filesender.client = {
                         {checkVerificationCodeWithServer: pass, token: token},
                         callback, ecb );
     },
+
+    token: null,
+    page: null,
+
+    verificationCodePassed: true,
+    verificationCodeObjectThatTiggeredEvent: null,
+    verificationCodePassedPopup: null,
     
+    
+
+    getTokenFromLocation: function() {
+        // Get recipient token
+        var m = window.location.search.match(/token=([0-9a-f-]+)/);
+        this.token = m[1];
+    },
+
+    setToken: function( t ) {
+        this.token = t;
+    },
+    
+    setPage: function( v ) {
+        this.page = v;
+
+        this.verificationCodePassed = true;
+        this.verificationCodeObjectThatTiggeredEvent = null;
+        this.verificationCodePassedPopup = null;
+
+        window.filesender.pbkdf2dialog.setup( true );
+        
+        if( window.filesender.config.download_verification_code_enabled ) {
+            this.verificationCodePassed = false;
+        }
+        
+    },
+    
+    dl: function(ids, confirm, encrypted, progress, archive_format ) {
+        if(typeof ids == 'string') ids = [ids];
+
+        var page = this.page;
+
+        // the dlcb handles starting the download for
+        // all non encrypted downloads
+        var dlcb = function(notify) {
+            notify = notify ? '&notify_upon_completion=1' : '';
+            return function() {
+                if( archive_format ) {
+                    console.log("Starting download using POST method...");
+                    $('#dlarchivepostformat').attr( 'value', archive_format );
+                    filesender.client.updateSelectedFilesForArchiveDownload();
+                    $('#dlarchivepost').submit();
+                } else {
+                    filesender.ui.redirect( filesender.config.base_path
+                        + 'download.php?token=' + token
+                        + '&archive_format=' + archive_format
+                        + '&files_ids=' + ids.join(',') + notify);
+                }
+            };
+        };
+        if (!encrypted && confirm){
+            filesender.ui.confirm(lang.tr('confirm_download_notify'), dlcb(true), dlcb(false), true);
+        }else{
+            if(encrypted){
+                if(!filesender.supports.crypto ) {
+                    filesender.ui.alert('error', lang.tr('file_encryption_description_disabled'));
+                    return;
+                }
+
+                var crypto_app = window.filesender.crypto_app();
+
+                if( window.filesender.config.use_streamsaver ) {
+                    var streamsaverenabled = page.find('#streamsaverenabled').is(':checked');
+                    crypto_app.disable_streamsaver = !streamsaverenabled;
+                }
+                console.log("download page has worked out if streamsaver should be disabled: " , crypto_app.disable_streamsaver );
+
+                if( archive_format || ids.length > 1 ) {
+                    //
+                    // Stream encrypted files to browser and add the decrypted content
+                    // into a zip64 file in the browser.
+                    //
+                    var onFileOpen = function( blobSink, fileid )
+                    {
+                        var progress = page.find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        progress.html("");
+                        blobSink.progress = progress;
+
+                        var overall = page.find(".archive_message");
+
+
+                        var msg = lang.tr('encrypted_archive_download_overall_progress').r(
+                            {
+                                id: 0
+                                , currentfilenumber:    blobSink.currentFileNumber+1
+                                , totalfilestodownload: blobSink.totalFilesToDownload
+                            }).out();
+                        overall.html(msg);
+                    };
+                    var onFileClose = function( blobSink, fileid )
+                    {
+                        var progress = page.find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        progress.html(window.filesender.config.language.download_complete);
+
+                    };
+                    var onComplete = function( blobSink )
+                    {
+                        var overall = page.find(".archive_message");
+                        overall.html(window.filesender.config.language.download_complete);
+                    };
+
+                    // generate zip in browser from decrypted files.
+                    var selectedFiles = [];
+                    var i = 0;
+                    for(; i < ids.length; i++ ) {
+
+                        var dataid  = "[data-id='" + ids[i] + "']";
+                        var dataid0 = "[data-id='" + ids[0] + "']";
+                        
+                        var el                 = page.find(dataid);
+                        var fileaead           = el.attr('data-fileaead');
+                        var key_version        = el.attr('data-key-version');
+                        var fileivcoded        = el.attr('data-fileiv');
+                        var transferid         = $('.transfer').attr('data-id');
+                        var chunk_size         = el.attr('data-chunk-size');
+                        var crypted_chunk_size = el.attr('data-crypted-chunk-size');
+                        
+                        selectedFiles.push({
+                            fileid:ids[i]
+                            , filename           : el.attr('data-name')
+                            , filesize           : el.attr('data-size')
+                            , encrypted_filesize : el.attr('data-encrypted-size')
+                            , mime               : el.attr('data-mime')
+                            , key_version        : el.attr('data-key-version')
+                            , salt               : el.attr('data-key-salt')
+                            , password_version   : el.attr('data-password-version')
+                            , password_encoding  : el.attr('data-password-encoding')
+                            , password_hash_iterations : el.attr('data-password-hash-iterations')
+                            , client_entropy     : el.attr('data-client-entropy')
+                            , fileiv             : window.filesender.crypto_app().decodeCryptoFileIV(fileivcoded,key_version)
+                            , fileaead           : fileaead.length?atob(fileaead):null
+                            , transferid         : transferid
+                        });
+
+                        // clear any previous progress message
+                        var progress = el.find('.downloadprogress');
+                        progress.html("");
+                    }
+                    window.filesender.crypto_encrypted_archive_download = true;
+                    crypto_app.decryptDownloadToZip( filesender.config.base_path
+                                                     + 'download.php?token=' + token
+                                                     + '&files_ids='
+                                                     , transferid
+                                                     , chunk_size
+                                                     , crypted_chunk_size
+                                                     , selectedFiles
+                                                     , progress
+                                                     , onFileOpen, onFileClose, onComplete
+                                                   );
+
+
+                }
+                else
+                {
+                    // single file download
+                    var dataid = "[data-id='" + ids[0] + "']";
+                    var el = page.find(dataid);
+                    var transferid               = $('.transfer').attr('data-id');
+                    var chunk_size               = el.attr('data-chunk-size');
+                    var crypted_chunk_size       = el.attr('data-crypted-chunk-size');
+                    var filename                 = el.attr('data-name');
+                    var filesize                 = el.attr('data-size');
+                    var encrypted_filesize       = el.attr('data-encrypted-size');
+                    var mime                     = el.attr('data-mime');
+                    var key_version              = el.attr('data-key-version');
+                    var salt                     = el.attr('data-key-salt');
+                    var password_version         = el.attr('data-password-version');
+                    var password_encoding        = el.attr('data-password-encoding');
+                    var password_hash_iterations = el.attr('data-password-hash-iterations');
+                    var client_entropy           = el.attr('data-client-entropy');
+                    var fileiv                   = el.attr('data-fileiv');
+                    var fileaead                 = el.attr('data-fileaead');
+                    if( fileaead.length ) {
+                        fileaead = atob(fileaead);
+                    }
+
+                    window.filesender.crypto_encrypted_archive_download = false;
+                    crypto_app.decryptDownload( filesender.config.base_path
+                                                + 'download.php?token=' + token
+                                                + '&files_ids=' + ids.join(','),
+                                                transferid, chunk_size, crypted_chunk_size,
+                                                mime, filename, filesize, encrypted_filesize,
+                                                key_version, salt,
+                                                password_version, password_encoding,
+                                                password_hash_iterations,
+                                                client_entropy,
+                                                window.filesender.crypto_app().decodeCryptoFileIV(fileiv,key_version),
+                                                fileaead,
+                                                progress );
+                }
+            }
+            else
+            {
+                var notify = false;
+                dlcb( notify ).call();
+            }
+        }
+    },
+
+    // Bind download buttons
+    bindDownloadButton: function( n ) {
+        var page = this.page;
+
+        page.find( n ).button().on('click', function() {
+            var id = $(this).closest('.file').attr('data-id');
+            var encrypted = $(this).closest('.file').attr('data-encrypted');
+            var progress = $(this).closest('.file').find('.downloadprogress');
+
+            var transferid = $('.transfer').attr('data-id');
+
+            filesender.client.verificationCodeObjectThatTiggeredEvent = $(this);
+            if( !filesender.client.verificationCodePassed ) {
+                filesender.client.verificationCodePassedPopup = filesender.ui.relocatePopup($(".verify_email_to_download"));
+            } else {
+                filesender.client.getTransferOption(transferid, 'enable_recipient_email_download_complete', token, function(dl_complete_enabled){
+                    dl(id, dl_complete_enabled, encrypted, progress );
+                });
+            }
+            return false;
+        });
+    },
+
+    bindDownloadArchive: function() {
+        var page = this.page;
+        var dlArchive = function( archive_format, button ) {
+            var ids = [];
+            page.find('.file[data-selected="1"]').each(function() {
+                ids.push($(this).attr('data-id'));
+            });
+
+            if(!ids.length) { // No files selected, supose we want all of them
+                page.find('.file').each(function() {
+                    ids.push($(this).attr('data-id'));
+                });
+            }
+
+
+            var transferid = $('.transfer').attr('data-id');
+            var encrypted = $('.transfer_is_encrypted').text()==1;
+
+            filesender.client.verificationCodeObjectThatTiggeredEvent = button;
+            if( !filesender.client.verificationCodePassed ) {
+                filesender.client.verificationCodePassedPopup = filesender.ui.relocatePopup($(".verify_email_to_download"));
+            } else {
+                filesender.client.getTransferOption(transferid,
+                                                    'enable_recipient_email_download_complete',
+                                                    filesender.client.token,
+                                                    function(dl_complete_enabled){
+                    filesender.client.dl(ids, dl_complete_enabled, encrypted, null, archive_format );
+                });
+            }
+            return false;
+        };
+
+        // Bind archive download button
+        page.find('.archive .archive_download').on('click', function() {
+            return dlArchive( 'zip', $(this) );
+        });
+        page.find('.archive .archive_tar_download').on('click', function() {
+            return dlArchive( 'tar', $(this) );
+        });
+    },
+
+    updateSelectedFilesForArchiveDownload: function()  {
+        var page = this.page;
+        var ids = [];
+        page.find('.file[data-selected="1"]').each(function() {
+            ids.push($(this).attr('data-id'));
+        });
+        var idlist = ids.join(',');
+        $('.archivefileids').attr('value', idlist );
+    },
+    
+
+    bindFileCheckButtons: function() {
+
+        var page = this.page;
+
+        // Bind file selectors
+        page.find('.file input[type=checkbox]').on('change', function(e) {
+            const el = $(this);
+            const isChecked = e.target.checked;
+            const f = el.closest('.file');
+            f.attr('data-selected', isChecked ? '1' : '0');
+
+            if (!isChecked) {
+                const checkAll = $('#check-all');
+                checkAll.prop("checked", false);
+            }
+
+            filesender.client.checkHideDownloadButtons();
+            filesender.client.updateSelectedFileSize();
+
+            e.stopPropagation();
+        });
+
+        // Bind global selector
+        page.find('#check-all').on('change', function(e) {
+            const isChecked = $('#check-all').is(":checked");
+            const files = page.find('.file');
+            files.attr('data-selected', isChecked ? '1' : '0');
+
+            const checkBoxes = $('.file input[type=checkbox]');
+            checkBoxes.prop("checked", isChecked);
+
+            filesender.client.checkHideDownloadButtons();
+            filesender.client.updateSelectedFileSize();
+
+            e.stopPropagation();
+        });
+    },
+    
+    checkHideDownloadButtons: function() {
+        var page = this.page;
+        
+        const ids = [];
+        page.find('.file[data-selected="1"]').each(function() {
+            ids.push($(this).attr('data-id'));
+        });
+
+        if(!ids.length) {
+            $('.fs-download__actions').addClass('fs-download__actions--hide');
+            $('.fs-download__zip64-info').addClass('fs-download__zip64-info--hide');
+        } else {
+            $('.fs-download__actions').removeClass('fs-download__actions--hide');
+            $('.fs-download__zip64-info').removeClass('fs-download__zip64-info--hide');
+        }
+    },
+    
+    updateSelectedFileSize: function () {
+        var page = this.page;
+
+        let totalSize = 0;
+        page.find('.file[data-selected="1"]').each(function() {
+            totalSize = totalSize + parseInt($(this).attr('data-size'), 10);
+        });
+
+        const formattedTotalSize = filesender.client.formatBytes(totalSize);
+
+        $('.fs-download__total-size span').text(formattedTotalSize);
+
+        if (totalSize > 0) {
+            $('.fs-download__total-size').addClass('fs-download__total-size--show');
+        } else {
+            $('.fs-download__total-size').removeClass('fs-download__total-size--show');
+        }
+    },
+
+    formatBytes: function (bytes, decimals = 2) {
+        if (!+bytes) return '0 Bytes'
+
+        const k = 1024
+        const dm = decimals < 0 ? 0 : decimals
+        const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+        const i = Math.floor(Math.log(bytes) / Math.log(k))
+
+        return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+    },    
 };

--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -31,6 +31,8 @@
  */
 
 $(function() {
+    var page = $('.transfer_detail_page');
+    if(!page.length) return;
 
     // File download buttons when the files are encrypted
     $('.transfer_detail_page .file [data-action="download"]').on('click', function() {
@@ -410,5 +412,13 @@ $(function() {
             filesender.ui.redirect($(this).text());
         });
     }
+
+
+    filesender.client.setPage( $(this) );
+    filesender.client.setToken( $('.token').text() );
+    filesender.client.bindDownloadButton('.file .download');
+    filesender.client.bindDownloadArchive();
+    filesender.client.bindFileCheckButtons();
+    
     
 });


### PR DESCRIPTION
This difference in functionality was raised in https://github.com/filesender/filesender/issues/2372

There is still some code on the download page to incorporate into the client class. Then the more nervous work of porting the download page over to using the new common code remains.
 