### PR TITLE
ui3: respect transfer_days_valid range and guest_days_valid

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -52,6 +52,22 @@ foreach (Guest::allOptions() as $name => $dfn) {
 }
 
 
+$possibleExpireDays = array( 7, 15, 30, 40 );
+array_push( $possibleExpireDays, Config::get('default_guest_days_valid'));
+asort( $possibleExpireDays );
+$expireDays = array_filter( $possibleExpireDays, function($k) {
+    return $k < Config::get('max_guest_days_valid')
+        && $k > Config::get('min_guest_days_valid');
+});
+$expireDaysSelected = Config::get('default_guest_days_valid');
+if( !in_array( $expireDaysSelected, $expireDays )) {
+    // got filtered? $possibleExpireDays count should be >1 from default setup
+    $v = array_slice($expireDays, -1);
+    $expireDaysSelected = $v[0];
+}
+
+
+
 //
 // Note that this needs to be called inside a div with guest_options or transfer_options
 //
@@ -196,10 +212,15 @@ use ( $new_guests_can_only_send_to_creator,
                                             {tr:expires_after}
                                         </label>
                                         <select id="expires-select" name="expires-select">
-                                            <option value="7" selected>7 {tr:days}</option>
-                                            <option value="15">15 {tr:days}</option>
-                                            <option value="30">30 {tr:days}</option>
-                                            <option value="40">40 {tr:days}</option>
+                                                <?php foreach( $expireDays as $k => $v ) { ?>
+                                                    <?php 
+                                                    $sel = "";
+                                                    if( $expireDaysSelected == $v ) {
+                                                        $sel = " selected ";
+                                                    }
+                                                     ?>
+                                                    <option value="<?php echo $v ?>" <?php echo $sel ?> ><?php echo $v ?> {tr:days}</option>
+                                                <?php } ?>
                                         </select>
                                     </div>
 

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -222,9 +222,18 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 
 
 $possibleExpireDays = array( 7, 15, 30, 40 );
-$expireDays = array_filter(array( 7, 15, 30, 40 ), function($k) {
+array_push( $possibleExpireDays, Config::get('default_transfer_days_valid'));
+asort( $possibleExpireDays );
+$expireDays = array_filter( $possibleExpireDays, function($k) {
     return $k < Config::get('max_transfer_days_valid');
 });
+$expireDaysSelected = Config::get('default_transfer_days_valid');
+if( !in_array( $expireDaysSelected, $expireDays )) {
+    // got filtered? $possibleExpireDays count should be >1 from default setup
+    $v = array_slice($expireDays, -1);
+    $expireDaysSelected = $v[0];
+}
+
 
 if( Auth::isGuest() && $openpgp_encrypt_passphrase ) {
     $guest = AuthGuest::getGuest();
@@ -716,8 +725,14 @@ if( $openpgp_encrypt_passphrase ) {
                                                 {tr:expires_after}
                                             </label>
                                             <select id="expires-select" name="expires-select">
-                                                <?php foreach( $expireDays as $v ) { ?>
-                                                    <option value="<?php echo $v ?>" selected><?php echo $v ?> {tr:days}</option>
+                                                <?php foreach( $expireDays as $k => $v ) { ?>
+                                                    <?php 
+                                                    $sel = "";
+                                                    if( $expireDaysSelected == $v ) {
+                                                        $sel = " selected ";
+                                                    }
+                                                     ?>
+                                                    <option value="<?php echo $v ?>" <?php echo $sel ?> ><?php echo $v ?> {tr:days}</option>
                                                 <?php } ?>
                                             </select>
                                         </div>


### PR DESCRIPTION
The UI3 sent to some hard coded values for these. For some installations using
ui_use_datepicker_for_transfer_expire_time_selection could allow a mitigation for this functionality. If the direct drop down (default) is desired this PR will move towards respecting the configured values again.

This relates to https://github.com/filesender/filesender/issues/1576