### PR TITLE
validation: check the user doesn't try to sneak a value

### DIFF
--- a/classes/exceptions/BadExceptions.class.php
+++ b/classes/exceptions/BadExceptions.class.php
@@ -152,6 +152,25 @@ class BadOptionNameException extends DetailedException
 }
 
 /**
+ * Bad option name value
+ */
+class BadOptionValueException extends DetailedException
+{
+    /**
+     * Constructor
+     *
+     * @param string $name
+     */
+    public function __construct($name, $notetoadmin = '')
+    {
+        parent::__construct(
+            'bad_option_value', // Message to give to the user
+            array('name' => $name,'noteToAdmin' => $notetoadmin) // Details to log
+        );
+    }
+}
+
+/**
  * Bad URL exception
  */
 class BadURLException extends DetailedException

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -560,18 +560,31 @@ class RestEndpointTransfer extends RestEndpoint
             );
             
             foreach ($allOptions as $name => $dfn) {
+                $shouldBeAvailable = Utilities::isTrue( $dfn['available'] );
+                $clientProvidedAValue = false;
+                                
                 if (in_array($name, $allowed_options)) {
                     // check if options is object
                     if (is_object( $data->options) ) {
                         if (method_exists($data->options, 'exists')) {
                             if ($data->options->exists($name)) {
+                                $clientProvidedAValue = 1;
                                 $options[$name] = $data->options->$name;
                             }
                         }
                     } else {
                         if (array_search($name, $data->options) !== false) {
+                            $clientProvidedAValue = 1;
                             $options[$name] = 1;
                         }
+                    }
+                }
+
+                if( Utilities::isTrue(Config::get('advanced_validation_transfer_options_not_available_but_selected'))) {
+                    if( !$shouldBeAvailable && $clientProvidedAValue ) {
+                        throw new BadOptionValueException(
+                            $name,
+                            "The option $name is not available to the user but they provided a value for it.");                    
                     }
                 }
             }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -582,8 +582,10 @@ class RestEndpointTransfer extends RestEndpoint
                 if( $name == 'redirect_url_on_complete' ) {
                         $clientProvidedAValue = 0;                  
                 }
-                if (in_array($name, $allowed_options)) {
-                    $options[$name] = $v;
+                if( $clientProvidedAValue ) {
+                  if( in_array($name, $allowed_options)) {
+                      $options[$name] = $v;
+                  }
                 }
                                 
                 if( Utilities::isTrue(Config::get('advanced_validation_transfer_options_not_available_but_selected'))) {

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -558,28 +558,34 @@ class RestEndpointTransfer extends RestEndpoint
                 TransferOptions::EMAIL_RECIPIENT_WHEN_TRANSFER_EXPIRES => $allOptions[TransferOptions::EMAIL_RECIPIENT_WHEN_TRANSFER_EXPIRES]['default'],
                 TransferOptions::HIDE_SENDER_EMAIL => $allOptions[TransferOptions::HIDE_SENDER_EMAIL]['default'],
             );
-            
+
             foreach ($allOptions as $name => $dfn) {
                 $shouldBeAvailable = Utilities::isTrue( $dfn['available'] );
                 $clientProvidedAValue = false;
-                                
-                if (in_array($name, $allowed_options)) {
-                    // check if options is object
-                    if (is_object( $data->options) ) {
-                        if (method_exists($data->options, 'exists')) {
-                            if ($data->options->exists($name)) {
-                                $clientProvidedAValue = 1;
-                                $options[$name] = $data->options->$name;
-                            }
-                        }
-                    } else {
-                        if (array_search($name, $data->options) !== false) {
+
+                // check if options is object
+                $v = '';
+                if (is_object( $data->options) ) {
+                    if (method_exists($data->options, 'exists')) {
+                        if ($data->options->exists($name)) {
                             $clientProvidedAValue = 1;
-                            $options[$name] = 1;
+                            $v = $data->options->$name;
                         }
+                    }
+                } else {
+                    if (array_search($name, $data->options) !== false) {
+                        $clientProvidedAValue = 1;
+                        $v = 1;
                     }
                 }
 
+                if( $name == 'redirect_url_on_complete' ) {
+                        $clientProvidedAValue = 0;                  
+                }
+                if (in_array($name, $allowed_options)) {
+                    $options[$name] = $v;
+                }
+                                
                 if( Utilities::isTrue(Config::get('advanced_validation_transfer_options_not_available_but_selected'))) {
                     if( !$shouldBeAvailable && $clientProvidedAValue ) {
                         throw new BadOptionValueException(

--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -57,6 +57,7 @@ A note about colours;
 * [cookie_domain](#cookie_domain)
 * [rate_limits](#rate_limits) (rate limits for some actions)
 * [valid_filename_regex](#valid_filename_regex)
+* [advanced_validation_transfer_options_not_available_but_selected](#advanced_validation_transfer_options_not_available_but_selected)
 
 
 ## Backend storage
@@ -803,6 +804,19 @@ $config['rate_limits'] = array(
   //  adds '+' in ASCII
   //  adds special character areas, for example MIDDLE DOT U+30FB
 $config['valid_filename_regex'] = '^['."\u{2010}-\u{2027}\u{2030}-\u{205F}\u{2070}-\u{FFEF}\u{10000}-\u{10FFFF}".' \\/\\p{L}\\p{N}_\\.,;:!@#$%^&*+)(\\]\\[_-]+';
+
+
+### advanced_validation_transfer_options_not_available_but_selected
+* __description:__ Validate that options given by client during transfer creation do not include options that are explicitly not available.
+* __mandatory:__ no
+* __type:__ bool
+* __default:__ true
+* __available:__ since version 2.58
+* __comment:__ This will catch explicit nefarious attempts to select options which have no UI elements created for them
+               
+
+
+* [advanced_validation_transfer_options_not_available_but_selected](#advanced_validation_transfer_options_not_available_but_selected)
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -358,6 +358,8 @@ $default = array(
 
     'read_only_mode' => false,
 
+    'advanced_validation_transfer_options_not_available_but_selected' => true,
+
     'validate_csrf_token_for_guests' => true,
 
     'template_config_values_that_can_be_read_in_templates' => array(


### PR DESCRIPTION
The code was ignoring options which were `!available` but were set by the client. The new code does the same thing but also throws if the client has tried to supply a value to an option which should not have been available to the user.

This investigates and resolves https://github.com/filesender/filesender/issues/498
