### PR TITLE
use only the values that generatekey relies on for the cache key

### DIFF
--- a/www/js/crypter/crypto_app.js
+++ b/www/js/crypter/crypto_app.js
@@ -498,7 +498,16 @@ window.filesender.crypto_app = function () {
             $this.setCipherAlgorithm( key_version );
             
 
-            var keydesc = JSON.stringify(encryption_details);
+            var pbkdf2details = {
+                password:    encryption_details.password,
+                key_version: encryption_details.key_version,
+                salt:        encryption_details.salt,
+                password_version:         encryption_details.password_version,
+                password_encoding:        encryption_details.password_encoding,
+                password_hash_iterations: encryption_details.password_hash_iterations,
+                client_entropy:           encryption_details.client_entropy,
+            };
+            var keydesc = JSON.stringify(pbkdf2details);
             window.filesender.log("keygen: keydesc cache size " + window.filesender.key_cache.size );
             
             var k = window.filesender.key_cache.get( keydesc );


### PR DESCRIPTION
When many smaller files are uploaded with encryption the pbkdf2 key cache uses more parameters than are needed in the cache key. This PR reduces that to only parameters that are used in the key derivation process.

This was raised here https://github.com/filesender/filesender/issues/2396