### PR TITLE
UI3: do not mangle the auditlog popup window

### DIFF
--- a/www/js/transfer_detail_page.js
+++ b/www/js/transfer_detail_page.js
@@ -190,8 +190,6 @@ $(function() {
                 return false;
             });
 
-            // Reset popup position as we may have added lengthy content
-            filesender.ui.relocatePopup(popup);
         });
     };
 


### PR DESCRIPTION
This PR will avoid mangling the auditlog popup leaving it at a size that is large enough and without creating duplicate windows.

This was reported here https://github.com/filesender/filesender/issues/2399
