### PR TITLE
db: add an index on files.uid

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -138,7 +138,10 @@ class File extends DBObject
     protected static $secondaryIndexMap = array(
         'transfer_id' => array(
             'transfer_id' => array()
-        )
+        ),
+        'uid' => array(
+            'uid' => array()
+        ),
     );
 
 


### PR DESCRIPTION
This addresses https://github.com/filesender/filesender/issues/2407

For postgresql leaving the uid column as a string the index for 0.5m files is about 58mb. Using the native uuid type for a column that is a copy of the uid column the same index is 17mb. So a migration to the native uuid types in mariadb and postgresql is probably a good idea at some stage.