### PR TITLE
db: precache files.download_count

### DIFF
--- a/classes/constants/DatabaseSchemaVersions.class.php
+++ b/classes/constants/DatabaseSchemaVersions.class.php
@@ -43,5 +43,6 @@ class DatabaseSchemaVersions extends Enum
 
     // the last version should also be the same as _CURRENT
     const VERSION_22       = 22;
-    const VERSION_CURRENT  = 22;
+    const VERSION_258      = 258;
+    const VERSION_CURRENT  = 258;
 }

--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -132,6 +132,13 @@ class File extends DBObject
             'size' => 170,
             'null' => true
         ),
+
+        'download_count' => array(
+            'type'    => 'uint',
+            'size'    => 'big',
+            'default' => 0,
+            'null'    => false,
+        ),
         
     );
 
@@ -191,6 +198,7 @@ class File extends DBObject
     protected $have_avresults = false;
     protected $storage_class_name = ''; // set in constructor
     protected $storage_path = null;
+    protected $download_count = 0;
    
     /**
      * Related objects cache
@@ -317,6 +325,7 @@ class File extends DBObject
     public function __construct($id = null, $data = null)
     {
         $this->storage_class_name = Storage::getDefaultStorageClass();
+        $this->download_count = 0;
         
         if (!is_null($id)) {
             // Load from database if id given
@@ -517,6 +526,7 @@ class File extends DBObject
         if (in_array($property, array(
             'transfer_id', 'uid', 'name', 'mime_type', 'size', 'encrypted_size', 'upload_start', 'upload_end', 'sha1'
           , 'storage_class_name', 'iv', 'aead', 'have_avresults', 'storage_path'
+          , 'download_count'
         ))) {
             return $this->$property;
         }
@@ -611,6 +621,8 @@ class File extends DBObject
     {
         if ($property == 'name') {
             $this->setName((string)$value);
+        } elseif ($property == 'download_count') {
+            $this->download_count = $value;
         } elseif ($property == 'auditlogs') {
             $this->logsCache = (array)$value;
         } elseif ($property == 'mime_type') {

--- a/classes/utils/Logger.class.php
+++ b/classes/utils/Logger.class.php
@@ -436,6 +436,68 @@ class Logger
             call_user_func($method, $facility, $level, $message);
         }
     }
+
+    public static function backtrace()
+    {
+        $message = "";
+                   
+        // Fecth call stack
+        $stack = debug_backtrace();
+        
+        // Remove Logger internals
+        while ($stack && array_key_exists('class', $stack[0]) && ($stack[0]['class'] == 'Logger')) {
+            array_shift($stack);
+        }
+        
+        // If call context is known        
+        //        if ($stack && array_key_exists('function', $stack[0]) && $stack[0]['function']) {
+        if($stack)
+            foreach( $stack as $caller ) {
+            $caller = $stack[0];
+            
+            // Gather code location data
+            $s = $caller['file'].':'.$caller['line'].' ';
+            if (array_key_exists('class', $caller)) {
+                if (!array_key_exists('type', $caller)) {
+                    $caller['type'] = ' ';
+                }
+                if ($caller['type'] == '::') {
+                    $s .= $caller['class'].'::';
+                } else {
+                    $s .= '('.$caller['class'].')'.$caller['type'];
+                }
+            }
+            
+            // Resolve magics so that log is easier to read
+            if (in_array($caller['function'], array('__call', '__callStatic'))) {
+                $caller['function'] = $caller['args'][0];
+                $caller['args'] = $caller['args'][1];
+            }
+            
+            // Add arguments (objects are mentionned as just "object" without details)
+            $args = array();
+            foreach ($caller['args'] as $arg) {
+                $a = '';
+                if (is_bool($arg)) {
+                    $a = $arg ? '(true)' : '(false)';
+                } elseif (is_scalar($arg)) {
+                    $a = '('.$arg.')';
+                } elseif (is_array($arg)) {
+                    $a = array();
+                    foreach ($arg as $k => $v) {
+                        $a[] = (is_numeric($k) ? '' : $k.' => ').gettype($v).(is_scalar($v) ? (is_bool($v) ? ($v ? '(true)' : '(false)') : '('.$v.')') : '');
+                    }
+                    $a = '('.implode(', ', $a).')';
+                }
+                $args[] = gettype($arg).$a;
+            }
+            
+            $s .= $caller['function'].'('.implode(', ', $args).')';
+            
+            $message = $s."\n".$message;
+        }
+        return $message;
+    }
     
     /**
      * Log message to error_log (stderr)
@@ -543,6 +605,13 @@ class Logger
                 $transfer = $target->transfer;
                 $transfer->download_count++;
                 $transfer->save();
+            }
+        }
+        if( $logEvent == LogEventTypes::DOWNLOAD_ENDED ) {
+            if ($target instanceof File) {
+                $obj = $target;
+                $obj->download_count++;
+                $obj->save();
             }
         }
         

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -362,6 +362,7 @@ $default = array(
 
     'validate_csrf_token_for_guests' => true,
 
+    
     'template_config_values_that_can_be_read_in_templates' => array(
         'default_guest_days_valid',
         'default_transfer_days_valid',

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -570,7 +570,7 @@ try {
                          . " set download_count = ( \n"
                          . "                    select count(*) from $tbl_auditlogs \n"
                          . "                         where target_type = 'File' \n"
-                         . "                           and target_id = cast(files.id as varchar) \n"
+                         . "                           and target_id = cast($tbl_files.id as varchar) \n"
                          . "                           and event = 'download_ended' \n"
                          . "                      ); \n";
 

--- a/scripts/upgrade/database.php
+++ b/scripts/upgrade/database.php
@@ -545,6 +545,7 @@ try {
     if( Database::tableExists($tbl_user)) {
         
         // Perform larger migrations
+        // see classes/constants/DatabaseSchemaVersions.class.php
         if( $currentSchemaVersion != DatabaseSchemaVersions::VERSION_CURRENT ) {
             $schemaVersion = $currentSchemaVersion;
             $dbtype = Config::get('db_type');
@@ -554,7 +555,34 @@ try {
             
             for( ; $schemaVersion <= DatabaseSchemaVersions::VERSION_CURRENT; $schemaVersion++ ) {
 
-                echo "checking for $schemaVersion \n";
+                echo "checking with schemaversion $schemaVersion \n";
+
+                // migtrating from the schema in [2.2,...,2.57] inclusive
+                if( $schemaVersion == DatabaseSchemaVersions::VERSION_22 )
+                {
+                    echo "Migrating database schema to version 2.58\n";
+                    echo "this will take some time to perform...\n";
+
+                    $tbl_files      = call_user_func('File::getDBTable');
+                    $tbl_auditlogs  = call_user_func('AuditLog::getDBTable');
+                    
+                    $sql = " update $tbl_files \n"
+                         . " set download_count = ( \n"
+                         . "                    select count(*) from $tbl_auditlogs \n"
+                         . "                         where target_type = 'File' \n"
+                         . "                           and target_id = cast(files.id as varchar) \n"
+                         . "                           and event = 'download_ended' \n"
+                         . "                      ); \n";
+
+                    echo "SQL: $sql \n";
+                    $s = DBI::prepare($sql);
+                    $s->execute(array());
+                }
+                // migtrating from the schema in [2.58,...,X] inclusive
+                if( $schemaVersion == DatabaseSchemaVersions::VERSION_258 )
+                {
+                }
+                    
                 //
                 // Version 22
                 // ----------
@@ -569,7 +597,7 @@ try {
                 // The saml information is then associated with a specific user using UserPreferences.authid.
                 // These id columns are bigint (8 byte numbers) and should index a lot better than email addresses.
                 //
-                if( $schemaVersion == DatabaseSchemaVersions::VERSION_22 )
+                if( $schemaVersion < DatabaseSchemaVersions::VERSION_22 )
                 {
                     echo "Migrating database schema to version 22.\n";
                     echo "this will take some time to perform...\n";

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -256,9 +256,9 @@ if (!function_exists('clickableHeader')) {
                 $items = array();
                 foreach(array_slice($transfer->files, 0, 3) as $file) {
                     $name = $file->path;
-                    $name_shorten_by = intval(ceil(intval (mb_strlen((string) count($transfer->downloads))+mb_strlen(Lang::tr('see_all'))+3)/2));
+                    $name_shorten_by = intval(ceil(intval (mb_strlen((string) $transfer->download_count)+mb_strlen(Lang::tr('see_all'))+3)/2));
                     if(mb_strlen($name) > 28-$name_shorten_by) {
-                        if(count($transfer->downloads)) $name = mb_substr($name, 0, 23-$name_shorten_by).'...';
+                        if($transfer->download_count) $name = mb_substr($name, 0, 23-$name_shorten_by).'...';
                         else $name = mb_substr($name, 0, 23).'...';
                     }
                     $items[] = '<span title="'.Template::Q($file->path).'">'.Template::Q($name).'</span>';
@@ -272,7 +272,7 @@ if (!function_exists('clickableHeader')) {
             </td>
             
             <td class="downloads">
-                <?php $dc = count($transfer->downloads); echo $dc; if($dc) { ?> (<span class="clickable expand">{tr:see_all}</span>)<?php } ?>
+                <?php $dc = $transfer->download_count; echo $dc; if($dc) { ?> (<span class="clickable expand">{tr:see_all}</span>)<?php } ?>
             </td>
            
             <td class="expires" data-rel="expires">
@@ -471,7 +471,7 @@ if (!function_exists('clickableHeader')) {
                              data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
                              data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"
                         >
-                            <?php echo Template::Q($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo count($file->downloads) ?> {tr:downloads}
+                            <?php echo Template::Q($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo $file->download_count ?> {tr:downloads}
                             
                             <?php if(!$transfer->is_expired) { ?>
                                


### PR DESCRIPTION
This offers significant performance improvements for a my transfers page with transfers containing 10,000 files each. If you have a number of such transfers the load time on that page might got from 2 minutes to less than 10 seconds.

The migration might take a moment as it will run this somewhat expensive query on the auditlog table to find out how many downloads have happened for each file in the database. It is much, much more efficient to precache that count so it is worth doing this the one time for the pleasure of faster load times from then on out.

This relates to https://github.com/filesender/filesender/issues/2405 but does not include the transfer_id (trid) value in the auditlog as yet. That will be a subsequent investigation.

Note that you will have to run the database.php script to create the files.download_count column and it should populate that column at database.php execution time which will take some time.