### PR TITLE
manyfiles: improved performance on my transfers, new limit option

### DIFF
--- a/docs/v2.0/admin/configuration/index.md
+++ b/docs/v2.0/admin/configuration/index.md
@@ -207,6 +207,7 @@ A note about colours;
 * [log_authenticated_user_download_by_ensure_user_as_recipient](#log_authenticated_user_download_by_ensure_user_as_recipient)
 * [transfer_automatic_reminder](#transfer_automatic_reminder)
 * [transfers_table_show_admin_full_path_to_each_file](#transfers_table_show_admin_full_path_to_each_file)
+* [large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page](#large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page)
 
 ## Graphs
 
@@ -2324,7 +2325,14 @@ This is only for old, existing transfers which have no roundtriptoken set.
                will be subdirectories that are calculated from the timestamp in the uuid which may not
                be immediately obvious to a human.
 
+### large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page
 
+* __description:__ Transfers with more than this many files will not have their files shown on the my transfers page
+* __mandatory:__ no
+* __type:__ int
+* __default:__ -1
+* __available:__ since before version 2.58
+* __comment:__ The default -1 is "no limit". One might consider using something like 1000 here for reasonable sizes to limit page load times.
 
 
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -362,6 +362,9 @@ $default = array(
 
     'validate_csrf_token_for_guests' => true,
 
+
+    'large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page' => -1,
+    
     
     'template_config_values_that_can_be_read_in_templates' => array(
         'default_guest_days_valid',

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -453,50 +453,82 @@ if (!function_exists('clickableHeader')) {
                     <?php } ?>
                 </div>
                 <?php } ?>
+
+                <?php
+                $showfiles = true;
+                $file_count = count($transfer->files);
+                if( Config::get('large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page') >= 0 ) {
+                    $showfiles = $file_count < Config::get('large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page');
+                }
+
+                if( $showfiles ) {
+                ?>
                 
                 <div class="files">
                     <h2>{tr:files}</h2>
+
+                    <?php
+
+                    $tp_transfer_key_version      = Template::Q($transfer->key_version);
+                    $tp_transfer_salt             = Template::Q($transfer->salt);
+                    $tp_transfer_password_version = Template::Q($transfer->password_version);
+                    $tp_transfer_password_encoding_string = Template::Q($transfer->password_encoding_string);
+                    $tp_transfer_password_hash_iterations = Template::Q($transfer->password_hash_iterations);
+                    $tp_transfer_client_entropy   = Template::Q($transfer->client_entropy);
+                    $tp_transfer_id               = Template::Q($transfer->id);
+                    $tp_transfer_is_encrypted     = $transfer->is_encrypted ? 'true' : 'false';
+                    ?>
                     
-                    <?php foreach($transfer->files as $file) { ?>
-                        <div class="file" data-id="<?php          echo Template::Q($file->id) ?>"
-                             data-key-version="<?php              echo Template::Q($transfer->key_version); ?>"
-                             data-key-salt="<?php                 echo Template::Q($transfer->salt); ?>"
-                             data-password-version="<?php         echo Template::Q($transfer->password_version); ?>"
-                             data-password-encoding="<?php        echo Template::Q($transfer->password_encoding_string); ?>"
-                             data-password-hash-iterations="<?php echo Template::Q($transfer->password_hash_iterations); ?>"
-                             data-client-entropy="<?php           echo Template::Q($transfer->client_entropy); ?>"
-                             data-fileiv="<?php                   echo Template::Q($file->iv); ?>"
-                             data-fileaead="<?php                 echo Template::Q($file->aead); ?>"
-                             data-transferid="<?php               echo Template::Q($transfer->id); ?>"
-                             data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
-                             data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"
+                    <?php foreach($transfer->files as $file) {
+                        $tp_file_id                   = Template::Q($file->id);
+                        $tp_file_iv                   = Template::Q($file->iv);
+                        $tp_file_aead                 = Template::Q($file->aead);
+                        $tp_file_chunk_size           = Template::Q($file->chunk_size);
+                        $tp_file_crypted_chunk_size   = Template::Q($file->crypted_chunk_size);
+                        $tp_file_mime_type            = Template::Q($file->mime_type);
+                        $tp_file_path                 = Template::Q($file->path);
+                        $tp_file_size                 = Template::Q($file->size);
+                        $tp_file_encrypted_size       = Template::Q($file->encrypted_size);
+                    ?>
+                        <div class="file" data-id="<?php          echo $tp_file_id ?>"
+                             data-key-version="<?php              echo $tp_transfer_key_version ?>"
+                             data-key-salt="<?php                 echo $tp_transfer_salt; ?>"
+                             data-password-version="<?php         echo $tp_transfer_password_version ?>"
+                             data-password-encoding="<?php        echo $tp_transfer_password_encoding_string ?>"
+                             data-password-hash-iterations="<?php echo $tp_transfer_password_hash_iterations ?>"
+                             data-client-entropy="<?php           echo $tp_transfer_client_entropy; ?>"
+                             data-fileiv="<?php                   echo $tp_file_iv; ?>"
+                             data-fileaead="<?php                 echo $tp_file_aead; ?>"
+                             data-transferid="<?php               echo $tp_transfer_id; ?>"
+                             data-chunk-size="<?php               echo $tp_file_chunk_size; ?>"
+                             data-crypted-chunk-size="<?php       echo $tp_file_crypted_chunk_size; ?>"
                         >
-                            <?php echo Template::Q($file->path) ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo $file->download_count ?> {tr:downloads}
+                            <?php echo $tp_file_path ?> (<?php echo Utilities::formatBytes($file->size) ?>) : <?php echo $file->download_count ?> {tr:downloads}
                             
                             <?php if(!$transfer->is_expired) { ?>
                                
                                 <?php if(isset($transfer->options['encryption']) && $transfer->options['encryption'] === true) { ?>
-                                <span class="fa fa-lg fa-download transfer-file transfer-download" title="{tr:download}" data-id="<?php echo Template::Q($file->id) ?>" 
-                                        data-encrypted="<?php echo isset($transfer->options['encryption'])?Template::Q($transfer->options['encryption']):'false'; ?>" 
-                                        data-mime="<?php              echo Template::Q($file->mime_type); ?>" 
-                                        data-name="<?php              echo Template::Q($file->path); ?>"
-                                        data-size="<?php              echo Template::Q($file->size); ?>"
-                                        data-encrypted-size="<?php    echo Template::Q($file->encrypted_size); ?>"
-                                        data-key-version="<?php       echo Template::Q($transfer->key_version); ?>"
-                                        data-key-salt="<?php          echo Template::Q($transfer->salt); ?>"
-                                        data-password-version="<?php  echo Template::Q($transfer->password_version); ?>"
-                                        data-password-encoding="<?php echo Template::Q($transfer->password_encoding_string); ?>"
-                                        data-password-hash-iterations="<?php echo Template::Q($transfer->password_hash_iterations); ?>"
-                                        data-client-entropy="<?php    echo Template::Q($transfer->client_entropy); ?>"
-                                        data-fileiv="<?php            echo Template::Q($file->iv); ?>"
-                                        data-fileaead="<?php          echo Template::Q($file->aead); ?>"
-                                        data-transferid="<?php        echo Template::Q($transfer->id); ?>"
-                                        data-chunk-size="<?php               echo Template::Q($file->chunk_size); ?>"
-                                        data-crypted-chunk-size="<?php       echo Template::Q($file->crypted_chunk_size); ?>"
+                                <span class="fa fa-lg fa-download transfer-file transfer-download" title="{tr:download}" data-id="<?php echo $tp_file_id ?>" 
+                                        data-encrypted="<?php                echo $tp_transfer_is_encrypted; ?>" 
+                                        data-mime="<?php                     echo $tp_file_mime_type ?>" 
+                                        data-name="<?php                     echo $tp_file_path ?>"
+                                        data-size="<?php                     echo $tp_file_size ?>"
+                                        data-encrypted-size="<?php           echo $tp_file_encrypted_size ?>"
+                                        data-key-version="<?php              echo $tp_transfer_key_version ?>"
+                                        data-key-salt="<?php                 echo $tp_transfer_salt ?>"
+                                        data-password-version="<?php         echo $tp_transfer_password_version ?>"
+                                        data-password-encoding="<?php        echo $tp_transfer_password_encoding_string ?>"
+                                        data-password-hash-iterations="<?php echo $tp_transfer_password_hash_iterations ?>"
+                                        data-client-entropy="<?php           echo $tp_transfer_client_entropy; ?>"
+                                        data-fileiv="<?php                   echo $tp_file_iv; ?>"
+                                        data-fileaead="<?php                 echo $tp_file_aead; ?>"
+                                        data-transferid="<?php               echo $tp_transfer_id; ?>"
+                                        data-chunk-size="<?php               echo $tp_file_chunk_size; ?>"
+                                        data-crypted-chunk-size="<?php       echo $tp_file_crypted_chunk_size; ?>"
                                 ></span>
                                         
                                 <?php } else {?>
-                            <a class="fa fa-lg fa-download" title="{tr:download}" href="download.php?files_ids=<?php echo Template::Q($file->id) ?>"></a>
+                            <a class="fa fa-lg fa-download" title="{tr:download}" href="download.php?files_ids=<?php echo $tp_file_id ?>"></a>
                                 <?php } ?>
                             <?php } ?>
 
@@ -520,6 +552,7 @@ if (!function_exists('clickableHeader')) {
                         </div>
                     <?php } ?>
                 </div>
+                <?php } ?>
                 <div class="fieldcontainer" id="encryption_description_not_supported">
                     {tr:file_encryption_disabled}
                 </div>


### PR DESCRIPTION
One might consider setting
large_transfer_handling_maximum_files_to_show_inline_on_my_transfers_page to something like 1000

For me, for a page with many 10,000 file transfers I might see 5 second load times without a limit and less than 2 seconds with one.

The limit might be useful if you plan to regularly make transfers with 1 to 10 million files in them.

All the files are there, the my transfers page just doesn't show them explicitly in the expanded transfer in the table.

I moved the `Template::Q` calls out so that one call can service 2 sites. Quoting like that is expensive when you are doing it millions of times. 