### PR TITLE
perf: have the database do the natural ordering by default

### DIFF
--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -80,7 +80,6 @@ $showdownloadlinks = Utilities::isTrue(Config::get('download_show_download_links
     if($transfer->status != TransferStatuses::AVAILABLE) throw new TransferNotAvailableException($transfer);
 
     $sortedFiles = $transfer->files;
-    usort($sortedFiles, function( $a, $b ) { return strnatcmp( $a->name, $b->name ); });
 
     $downloadLinks = array();
     $archiveDownloadLink = '#';


### PR DESCRIPTION
This can trim down on busy time in php by a little bit (order of 5-10%) for transfers with 10k files in them.