### PR TITLE
perf: only do that lang::tr once per run

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -287,6 +287,8 @@ class Utilities
      *
      * @return string
      */
+    private static $formatBytes_unit = null;
+    
     public static function formatBytes($bytes, $precision = 1)
     {
         // Default
@@ -295,13 +297,16 @@ class Utilities
         }
         // allow sloppy $bytes
         $bytes = floor($bytes);
-        
-        // Variants
-        $unit = Lang::tr('size_unit')->out();
-        if ($unit == '{size_unit}') {
-            $unit = 'b';
+
+        if( !self::$formatBytes_unit ) {
+            // Variants
+            $unit = Lang::tr('size_unit')->out();
+            if ($unit == '{size_unit}') {
+                $unit = 'b';
+            }
+            self::$formatBytes_unit = $unit;
         }
-        
+        $unit = self::$formatBytes_unit;
         $multipliers = array('', 'k', 'M', 'G', 'T');
         
         // Compute multiplier


### PR DESCRIPTION
Again, for 10000 files this call can add up and be responsible for say 2% of the overall execution time. Plus it is a waste of time to do it many times anyway. Save those electrons.