### PR TITLE
ui3d3 allow the advanced option for guest_options to work on all

### DIFF
--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -243,6 +243,7 @@ A note about colours;
 * [guest_support_enabled](#guest_support_enabled)
 * [guest_transfers_page_support_enabled](#guest_transfers_page_support_enabled)
 * [guest_options](#guest_options)
+* [guest_options_to_force_to_top_array](#guest_options_to_force_to_top_array)
 * [default_guest_days_valid](#default_guest_days_valid)
 * [min_guest_days_valid](#min_guest_days_valid)
 * [max_guest_days_valid](#max_guest_days_valid)
@@ -2661,6 +2662,33 @@ This is only for old, existing transfers which have no roundtriptoken set.
 				'default' => false
 			)
 		);
+
+### guest_options_to_force_to_top_array
+
+* __description:__ An array of options that are picked out and placed out of the advanced section on the UI3 new guest page
+* __mandatory:__ no
+* __type:__ array of string
+* __default:__ array( 'can_only_send_to_me', 'valid_only_one_time' ),
+* __available:__ since version 3.0rc12
+* __1.x name:__
+* __comment:__ Some items were hard code lifted to the top in the UI3. You can use this option in 
+               combination with the existing  guest_options / 'valid_only_one_time' / 'advanced' => true,
+               to allow an option to be presented as advanced when it would have previously been force lifted.
+
+* __*Configuration example:*__
+        $config['guest_options_to_force_to_top_array'] = [  'can_only_send_to_me' ];
+		$config['guest_options'] = array(
+           ...               
+               
+           'valid_only_one_time' => array(
+              'available' => true,
+              'advanced' => true,
+              'default' => false
+           ),
+           ...
+
+This conflicts with the code in 'advanced' => false but is a hard coded option that is lifted out here to allow it to be modified by sites who want to use guest_options.advanced.
+
 
 ### default_guest_days_valid
 

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -510,6 +510,8 @@ $default = array(
 
     'guest_upload_page_hide_unchangable_options' => false,
 
+    'guest_options_to_force_to_top_array' => array( 'can_only_send_to_me', 'valid_only_one_time' ),
+    
     'guest_options' => array(
         'email_upload_started' => array(
             'available' => true,

--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -4,6 +4,9 @@ $cgiuid = "";
 $section = 'invite';
 $sections = array('invite','current','transfers');
 
+$guest_options_to_force_to_top_array = Config::get('guest_options_to_force_to_top_array');
+
+
 if(array_key_exists('as', $_REQUEST))
     $section = $_REQUEST['as'];
 if(!strlen($section)) {
@@ -200,7 +203,7 @@ use ( $new_guests_can_only_send_to_creator,
                                     <div class="guest_options options_box">
                                     <?php
                                     foreach(Guest::availableOptions() as $name => $cfg) {
-                                        if( $name == 'can_only_send_to_me' || $name == 'valid_only_one_time') {
+                                        if( in_array( $name, $guest_options_to_force_to_top_array )) {
                                             $displayoption($name, $cfg, false);
                                         }
                                     }
@@ -248,7 +251,7 @@ use ( $new_guests_can_only_send_to_creator,
 
                                                 <div class="guest_options">
                                                     <?php foreach(Guest::availableOptions(false) as $name => $cfg) {
-                                                        if( $name != 'can_only_send_to_me' && $name != 'valid_only_one_time') {
+                                                        if( !in_array( $name, $guest_options_to_force_to_top_array )) {
                                                             $displayoption($name, $cfg, false);
                                                         }
                                                     } ?>
@@ -258,7 +261,7 @@ use ( $new_guests_can_only_send_to_creator,
                                                 <?php if(count(Guest::availableOptions(true))) {
                                                     foreach(Guest::availableOptions(true) as $name => $cfg) {
                                                         if( !array_key_exists($name, $guest_options_handled)) {
-                                                            if( $name != 'can_only_send_to_me' && $name != 'valid_only_one_time') {
+                                                            if( !in_array( $name, $guest_options_to_force_to_top_array )) {
                                                                 $displayoption($name, $cfg, false);
                                                             }
                                                         }
@@ -271,7 +274,7 @@ use ( $new_guests_can_only_send_to_creator,
 
                                                 <div class="transfer_options">
                                                     <?php foreach(Transfer::availableOptions(false) as $name => $cfg) {
-                                                        if( $name != 'can_only_send_to_me' && $name != 'valid_only_one_time') {
+                                                        if( !in_array( $name, $guest_options_to_force_to_top_array )) {
                                                             $displayoption($name, $cfg, true);
                                                         }
                                                     } ?>
@@ -280,7 +283,7 @@ use ( $new_guests_can_only_send_to_creator,
                                                 <div class="transfer_options">
                                                 <?php if(count(Transfer::availableOptions(true))) {
                                                     foreach(Transfer::availableOptions(true) as $name => $cfg) {
-                                                        if( $name != 'can_only_send_to_me' && $name != 'valid_only_one_time') {
+                                                        if( !in_array( $name, $guest_options_to_force_to_top_array )) {
                                                             $displayoption($name, $cfg, true);
                                                         }
                                                     }


### PR DESCRIPTION
The new option allows a sysadmin to stop items being lifted to the top of the list and put them into the advanced section instead.