### PR TITLE
ui3: allow one upload and recently expired guest to see past uploads

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -447,6 +447,21 @@ class Guest extends DBObject
         return $this->expires < $today;
     }
 
+    public function canStillSeePastUploads()
+    {
+        if( is_null($this->expires)) {
+            return false;
+        }
+        $d = (24 * 3600) * floor(time() / (24 * 3600));
+        $v = Config::get("guest_transfers_page_number_of_days_expired_guest_can_return");
+        if( !$v ) {
+            return $this->isExpired();
+        }
+        $d -= (24 * 3600 * $v );
+        return $this->expires > $d;
+        
+    }
+    
     /**
      * Tells wether the guest has expired before a given number of days
      * from now

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -242,6 +242,7 @@ A note about colours;
 
 * [guest_support_enabled](#guest_support_enabled)
 * [guest_transfers_page_support_enabled](#guest_transfers_page_support_enabled)
+* [guest_transfers_page_number_of_days_expired_guest_can_return](#guest_transfers_page_number_of_days_expired_guest_can_return)
 * [guest_options](#guest_options)
 * [guest_options_to_force_to_top_array](#guest_options_to_force_to_top_array)
 * [default_guest_days_valid](#default_guest_days_valid)
@@ -2619,8 +2620,17 @@ This is only for old, existing transfers which have no roundtriptoken set.
 * __1.x name:__
 * __comment:__ The list of uploads is somewhat limited, for example it does not allow downloading those files
 
+### guest_transfers_page_number_of_days_expired_guest_can_return
 
-* [guest_transfers_page_support_enabled](#guest_transfers_page_support_enabled)
+* __description:__ Allow a guest to see a list of their uploads this many days after they have expired.
+* __mandatory:__ no
+* __type:__ int
+* __default:__ 0
+* __available:__ since version 3.0rc12
+* __1.x name:__
+* __comment:__ The defaut value disables this feature. It is a number of days, for example, 10 for 10 days after the guest has expired.
+
+
 
 
 ### guest_options

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -511,6 +511,9 @@ $default = array(
     'guest_upload_page_hide_unchangable_options' => false,
 
     'guest_options_to_force_to_top_array' => array( 'can_only_send_to_me', 'valid_only_one_time' ),
+
+    'guest_transfers_page_number_of_days_expired_guest_can_return' => 0,
+
     
     'guest_options' => array(
         'email_upload_started' => array(

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -902,3 +902,7 @@ $lang['you_have_a_openpgp_public_key_known_to_system'] = 'You have a OpenPGP pub
 $lang['your_download_link'] = 'Here\'s your download link';
 $lang['your_invitation_was_sent_to'] = 'Your invitation was sent to';
 $lang['your_transfer_was_sent'] = 'Your transfer was sent to the following email addresses';
+
+$lang['guest_token_expired_title'] = 'Guest access expired';
+$lang['guest_token_expired_page'] = 'Your guest access has expired. You will need a new guest access token in order to upload new files. Thank you for using FileSender.';
+    

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -256,6 +256,44 @@ if( $openpgp_encrypt_passphrase ) {
 <?php
     return;
 }
+
+if(Auth::isGuest()) {
+    $guest = AuthGuest::getGuest();
+    $daysAgo = Config::get("guest_transfers_page_number_of_days_expired_guest_can_return");
+    // this default should not happen as the guest can only be
+    // flexible if the above config has been set. But expired
+    // is a good default here.
+    $expired = $guest->isExpired();
+    if( $daysAgo > 0 ) {
+        // do not worry about canStillSeePastUploads() here
+        // we are only hanlding this to present a nice expired
+        // page to the guest if they are not AVAIABLE any more.
+        if( !$expired ) {
+            $expired = ($guest->status != GuestStatuses::AVAILABLE);
+        }
+    }
+    if( $expired ) {
+        echo <<<EOF
+<div id="dialog-expired" title="Access expired" class="fs-base-page">
+    <div class="container">
+        <div class="row">
+            <div class="col">
+                <div class="fs-base-page__header">
+                    <h1>{tr:guest_token_expired_title}</h1>
+                </div>
+
+                <div class="fs-base-page__content">
+                    {tr:guest_token_expired_page}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+EOF;
+        return;
+        
+    }
+}
 ?>
 
 <div class="container">


### PR DESCRIPTION
The past uploads are only the time and file names. The guest can not download the files so they can not use this is a distribution center.

This PR adds a new option
guest_transfers_page_number_of_days_expired_guest_can_return which can allow guests to view files in a grace time of this many days. A guest who can only upload once will expire right away. Without this provision they can not see that their upload has succeeded later on.

I am still testing this PR.

This was requested by an NREN and I recorded that in https://github.com/filesender/filesender/issues/2428