### PR TITLE
chore(csp): provide sane default for 'frame-ancestors' content policy

### DIFF
--- a/classes/utils/Security.class.php
+++ b/classes/utils/Security.class.php
@@ -78,6 +78,7 @@ class Security
              . " style-src 'self' ; "
              . " img-src 'self' data:; "
              . " media-src 'none'; "
+             . " frame-ancestors 'self'; "
              . " frame-src 'self'; "
              . " font-src 'self'; "
              . " connect-src 'self'";


### PR DESCRIPTION
This provides a sane default for the `frame-ancestors` content policy.

This policy will prevent FileSender from being embedded in a frame by default, to prevent clickjacking and is based on a recommendation from a periodic automated security scan.