### PR TITLE
Do not mangle the transfer logs on my transfers page

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -357,9 +357,6 @@ $(function() {
                 return false;
             });
 
-            // Reset popup position as we may have added lengthy content
-            filesender.ui.relocatePopup(popup);
-
         });
     };
 


### PR DESCRIPTION
This fixes https://github.com/filesender/filesender/issues/2458

It seems a few places might have that `relocatePopup` call sprinkled around and it may not do what the person calling it intended.