### PR TITLE
chore(docs): Update 3.x to be release, move 2.x to security-fixes-only

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,13 @@
 
 We provide security updates for the following versions:
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 3.x     | ⚠️ Not supported (yet) |
-| 2.x     | ✅ Supported       |
-| < 2.x   | ⚠️ Not supported   |
+| Version | Support Status |
+|---------|----------------|
+| 3.x     | ✅ Supported |
+| 2.x     | ⚠️  Security fixes only |
+| < 2.x   | ❌ Not supported |
 
-We do not provide security patches to any releases below 2.x and expect to start supporting 3.x as soon as the first release is made.
+We do not provide security patches to any releases below 2.x and fully support version 3.x.
 We encourage all users to upgrade to the latest stable release.
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,10 +30,10 @@ from the [github releases
 page](https://github.com/filesender/filesender/releases).
 
 There are two active release streams; a version 2.x stream and a 3.x
-stream. The 3.x beta release steam has a different UI and will become
-the stable release at some stage.
+stream. The 3.x release steam has a different UI and is not considered
+the stable release.
 
-Version 3 and Version 2 should have the same functionality but version
+Version 3 and Version 2 have the same functionality but version
 3 uses custom CSS to present a more modern UI. The uploaded files
 storage handling is the same in version 2 and version 3. The database
 schema is very similar between the two and should be identical at
@@ -43,13 +43,18 @@ that it is feature compatible with 2.30. So you should be able to
 direct 3.0alpha2 at the same uploaded files and database and have the
 system function.
 
-The release numbering for the 2.x series follows the pattern 2.1, 2.2,
-2.30 etc. Each of these releases builds on version 2.0 adding bugfixes
-and features. Each new release in the 2.x series will describe if
-database updates are needed (most often by running a script) and if
-web page templates have been updated in case you customize those on
-your site. If is intended that you can migrate an active site to new
-releases with very minimal downtime.
+The release numbering for the 3.x series follows the pattern 3.0, 3.1,
+etc. Each of these releases builds on version 3.0 adding bugfixes and
+features. Each new release in the 3.x series will describe if database
+updates are needed and if web page templates have been updated in case
+you customize those on your site. It is intended that you can migrate an
+active site to new releases with very minimal downtime.
+
+The 2.x series follows the same release pattern and practises, however
+after releasing the 3.x series, FileSender 2.x has entered maintenance mode.
+
+No new features are planned for FileSender 2.x and only security updates
+will be provided.
 
 The very old 1.6.x series should not be used.
 
@@ -57,9 +62,7 @@ The very old 1.6.x series should not be used.
 
 There are two distinct trees of documentation, one for [documentation
 for versions 2.x](v2.0/) and one for [documentation for versions
-3.x](v3.0/). These were identical as of June 2024 and will diverge as
-updates are made to better describe the changes in the 3.x series over
-time.
+3.x](v3.0/). Additions are made to the 3.x documentation only.
 
 ### License
 
@@ -80,8 +83,8 @@ page if you have a feature you would like to see added to FileSender.
 
 ### Features
 
-For a more detailed list of version 2.x features see the [v2.0
-features page](v2.0/features/).
+For a more detailed list of version 3.x features see the [v3.0
+features page](v3.0/features/).
 
 * light-weight server footprint, optimized for least possible dependencies
 * share arbitrarily large files from standard desktop environments, no client-side deployment required
@@ -108,7 +111,5 @@ features page](v2.0/features/).
 
 Some storage, either MariaDB or PostgreSQL for database, either Apache
 or nginx for web server, PHP and SimpleSamlPhp. Please see the
-[installation](v2.0/install/) page for minimum version requirements
+[installation](v3.0/install/) page for minimum version requirements
 and advice.
-
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,20 +15,16 @@ Current priorities for the Filesender Roadmap are:
 
 ### Priority 1
 
+* Security updates
 * Bugfix release
-* Object-store storage
 * Complete automated CI tests
-* Translation portal
 * Packaging and documentation
-
 
 ### Priority 2
 
 * Smooth UI
 * Statistics
 * Download link protection
-* Improve TeraSender speed and robustness
-* Address-book: link with group info sources
 
 ### Unofficial
 
@@ -145,16 +141,12 @@ stored in the same filesender database.
 https://github.com/filesender/filesender/issues/100
 
 
-### Selenium
-
-Improved UI testing with Selenium and renabling this in github actions.
-
 ### Better documentation and email handling
 
 Clearly documentation is an issue for this. It seems that the bounce
 handling is a great example of an area that documentation can still
-improve. The current [admin configuration](v2.0/admin/configuration/)
-still has much orange "to be checked" areas relating to email.
+improve. The current [admin configuration](v3.0/admin/configuration/)
+still has some orange "to be checked" areas relating to email.
 
 It seems that the cited bounce script is this one scripts/task/
 emailfeedback.php. The emailfeedback.php script is looking at incoming
@@ -218,5 +210,5 @@ Perhaps include previews of files?
 Have a look at the following to see if there are best practices not
 yet followed.
 
-https://github.com/coreinfrastructure/best-practices-badge/blob/master/doc/criteria.md
+https://github.com/coreinfrastructure/best-practices-badge/blob/master3/doc/criteria.md
 

--- a/docs/v3.0/dev/contributing/index.md
+++ b/docs/v3.0/dev/contributing/index.md
@@ -18,20 +18,11 @@ branch just prior to the release.
 This arrangement of development and master branches was desired by the
 Filesender board.
 
-For the 2.x series changes should be made on a branch of development and a pull
-request made for the development branch on the Filesender github project.
-
-For changes that apply only to the 3.x series one should make a pull
-request against development3. The respective master branch is called
-master3 for the 3.x series.
+For the 3.x series changes should be made on a branch of development and a pull
+request made for the development3 branch on the Filesender github project.
 
 This naming convention will allow future major releases to be made and
 avoid confusion about which git branch will match which major release.
 
-You should make changes against the development branch and pull requests
-against that branch. The exception to this is if you are updating something
-in the UI for the 3.x series, in which case please make pull requests 
-against development3.
-
-Changes made in development are ported and merged into development3 at
-release time.
+You should make changes against the development3 branch and pull requests
+against that branch.

--- a/docs/v3.0/install/index.md
+++ b/docs/v3.0/install/index.md
@@ -609,9 +609,7 @@ On Debian, run:
 
 Create the filesender database. It is recommended to create two users for the database,
 one for normal web usage and another with higher abilities to allow the database setup
-and migration script to use. This setup requires the code in FileSender release 2.6 or above to work.
-If you are on a lower version of FileSender you will have to grant permission to the normal filesender
-user and perhaps grant and remove the DROP and REFERENCES from that user when running database.php.
+and migration script to use. 
 
 ```
 mysql -u root -p

--- a/docs/v3.0/upgrade/index.md
+++ b/docs/v3.0/upgrade/index.md
@@ -44,9 +44,9 @@ are set properly after the update.
 
 Download the source archive into a directory, for example ~/src. Lets
 assume you have downloaded a release and have a file at
-~/src/filesender-2.41.tar.gz. This can be directly extracted into your
+~/src/filesender-3.0.tar.gz. This can be directly extracted into your
 /opt/filesender directory by being in the right directory and telling
-tar to strip the leading filesender-filesender-2.41.
+tar to strip the leading filesender-filesender-3.0.
 
 
 ```
@@ -62,11 +62,11 @@ tar --extract \
 
 #### Using FileSender using git
 
-For the 3.x series the master branch tracks the releases. This means
-that if 2.41 is the latest release the master should also be version
-2.41. Each release has a tag and git commit associated with it and you
+For the 3.x series the master3 branch tracks the releases. This means
+that if 3.0 is the latest release the master should also be version
+3.0. Each release has a tag and git commit associated with it and you
 can use that to checkout the source code for an exact version if you
-like. The two last git commands below checkout version 2.41 and the
+like. The two last git commands below checkout version 3.0 and the
 current 3.x series release respectively. You may receive an error message
 trying to switch to another version if you have modified the templates directory. 
 This is considered in the next section.
@@ -75,8 +75,8 @@ This is considered in the next section.
 cd  /opt/filesender
 git fetch origin
 
-git checkout filesender-2.41
-git checkout master
+git checkout 3.0
+git checkout master3
 ```
 
 ### The templates directory


### PR DESCRIPTION
Also update documentation references from 2.x to 3.x as needed:

- Security policy is updated to reflect this
- Updated some links pointing to v2 docs now go to v3
- Updated the `roadmap.md` a bit, but this still seems out-of-date
- Updated contributing guidelines (maybe we should create a `CONTRIBUTING.md` ?)
- Removed some passages that mention a minimum required version 2.x, that now is outdated since we are on 3.x

Feel free to suggest changes :)