### PR TITLE
Align remote_config with AuthRemote

### DIFF
--- a/classes/data/User.class.php
+++ b/classes/data/User.class.php
@@ -721,7 +721,7 @@ class User extends DBObject
         }
         
         if ($property == 'remote_config') {
-            return $this->auth_secret ? Config::get('site_url').'|'.$this->id.'|'.$this->auth_secret : '';
+            return $this->auth_secret ? Config::get('site_url').'|'.$this->saml_user_identification_uid.'|'.$this->auth_secret : '';
         }
         
         if ($property == 'identity') {


### PR DESCRIPTION
Fix user's remote_config property generation so it  aligns with AuthRemote using the user's saml uid as user id instead of the user's numerical unique id