### PR TITLE
Use queried user for quota evaluation

### DIFF
--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -222,7 +222,7 @@ class RestEndpointUser extends RestEndpoint
             // Compute size used by user's transfers
             $used = array_sum(array_map(function ($t) {
                 return $t->size;
-            }, Transfer::fromUser(Auth::user())));
+            }, Transfer::fromUser($user)));
             
             return array(
                 'total' => $user_quota,


### PR DESCRIPTION
Fix User endpoint to evaluate requested user quota when not using @me id, before Auth::user was used thus ignoring requested user id when admin wanted to check another user's quota