### PR TITLE
additional validation

### DIFF
--- a/classes/rest/RestRequest.class.php
+++ b/classes/rest/RestRequest.class.php
@@ -173,4 +173,9 @@ class RestInput
         
         return array_key_exists($key, $this->data) ? $this->data[$key] : null;
     }
+
+    public function __set($key, $v)
+    {
+        $this->data[$key] = $v;
+    }
 }

--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -173,6 +173,24 @@ class RestEndpointGuest extends RestEndpoint
         // Raw guest data
         $data = $this->request->input;
 
+        if( Utilities::isTrue(Config::get('advanced_validation_create_guest')))
+        {
+            $data->from = Validate::filter_var_email(
+                "guest.from",
+                $data->from );
+            $data->recipient = Validate::filter_var_email(
+                "guest.recipient",
+                $data->recipient );
+            $data->subject = Validate::filter_var_regex_log(
+                "transfer.subject",
+                $data->subject,
+                '/^.*$/'  );
+            $data->expires = Validate::filter_var_regex_log(
+                "transfer.expires", $data->expires,
+                "|^[0-9]{1,32}$|"  );
+        }
+
+
         // Check Guest creation limits
         $existingGuests = Guest::fromUserAvailable($user);
         if (count($existingGuests) >= Config::get('guest_limit_per_user')) {

--- a/classes/rest/endpoints/RestEndpointPrincipal.class.php
+++ b/classes/rest/endpoints/RestEndpointPrincipal.class.php
@@ -81,6 +81,12 @@ class RestEndpointPrincipal extends RestEndpoint
         
         if( $data->service_aup_version ) {
 
+            if( Utilities::isTrue(Config::get('advanced_validation_principal'))) {
+                $data->service_aup_version = Validate::filter_var_number(
+                    "service_aup_version",
+                    $data->service_aup_version );
+            }
+        
             if( $data->service_aup_version != Config::get('service_aup_min_required_version')) {
                 throw new RestBadParameterException('service_aup_version');
             }

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -426,6 +426,7 @@ class RestEndpointTransfer extends RestEndpoint
         
         return $out;
     }
+
     
     /**
      * Create new transfer or add recipient to an existing transfer
@@ -521,6 +522,81 @@ class RestEndpointTransfer extends RestEndpoint
             
             // Raw data
             $data = $this->request->input;
+
+            
+            if( Utilities::isTrue(Config::get('advanced_validation_create_transfer'))) {
+                
+                $data->encryption = Validate::filter_var_bool("encryption", $data->encryption);
+                $data->encryption_key_version = Validate::filter_var_regex_log(
+                    "transfer.encryption_key_version",
+                    $data->encryption_key_version,
+                    "|^[0-9]+$|" );
+                $data->encryption_password_encoding = Validate::filter_var_regex_log(
+                    "transfer.encryption_password_encoding",
+                    $data->encryption_password_encoding,
+                    '/^(none|base64|ascii85)$/' );
+                $data->encryption_password_version = Validate::filter_var_regex_log(
+                    "transfer.encryption_password_version",
+                    $data->encryption_password_version,
+                    "|^[0-9]+$|"  );
+                $data->encryption_password_hash_iterations = Validate::filter_var_regex_log(
+                    "transfer.encryption_password_hash_iterations",
+                    $data->encryption_password_hash_iterations,
+                    "|^[0-9]{1,15}$|"  );
+                $data->encryption_client_entropy = Validate::filter_var_regex_log(
+                    "transfer.encryption_client_entropy",
+                    $data->encryption_client_entropy,
+                    "|^[-A-Za-z0-9+/]*={0,3}$|"  );
+                foreach ($data->files as $d) {
+                    $d->name = Validate::filter_var_regex_log(
+                        "transfer.files.name",
+                        $d->name,
+                        '/^.*$/'  );
+                    $d->size = Validate::filter_var_regex_log(
+                        "transfer.files.size",
+                        $d->size,
+                        "|^[0-9]+$|"  );
+                    $d->mime_type = Validate::filter_var_mimetype(
+                        "transfer.files.mime_type",
+                        $d->mime_type );
+                    $d->cid = Validate::filter_var_regex_log(
+                        "transfer.files.cid",
+                        $d->cid,
+                        '/^file_[0-9]+_[0-9]+_[0-9]+_$/'  ); 
+                    $d->iv = Validate::filter_var_regex_log(
+                        "transfer.files.iv",
+                        $d->iv,
+                        '|^[-A-Za-z0-9+/]*={0,3}$|'  ); 
+                    $d->aead = Validate::filter_var_regex_log(
+                        "transfer.files.aead",
+                        $d->aead,
+                        '|^[-A-Za-z0-9+/]*={0,3}$|'  );
+                    
+                }            
+                
+                $r = Utilities::ensureArray($data->recipients);
+                foreach ($r as $email) {
+                    $value = Validate::filter_var_email( "recipients.email", $email );
+                    if($value == "" ) {
+                        Validate::filter_var_log("transfer.recipients email");
+                        $data->recipients = array();
+                        break;
+                    }
+                }
+                
+                $data->subject = Validate::filter_var_regex_log(
+                    "transfer.subject",
+                    $data->subject,
+                    '/^.*$/'  );
+                $data->lang = Validate::filter_var_lang(
+                    "transfer.lang",
+                    $data->lang );
+                $data->expires = Validate::filter_var_regex_log(
+                    "transfer.expires", $data->expires,
+                    "|^[0-9]{1,32}$|"  );
+                $data->aup_checked = Validate::filter_var_bool("aup_checked", $data->aup_checked);
+            }
+            
             
             // Is it created by a guest ?
             $guest = null;
@@ -857,7 +933,7 @@ class RestEndpointTransfer extends RestEndpoint
                                             ["options" => ["regexp" => "|^[-A-Za-z0-9+/]*={0,3}$|" ]] );                
 
 
-
+                $file = null;
                 if( $usebulk ) {
 
                     $puid = Utilities::generateRandomUID();
@@ -878,8 +954,10 @@ class RestEndpointTransfer extends RestEndpoint
                     $file = $transfer->addFile( $filedata->name, $filedata->size, $filedata->mime_type,
                                                 $filedata->iv, $filedata->aead );
                 }
-                
-                $files_cids[$file->id] = $filedata->cid;
+
+                if($file) {
+                    $files_cids[$file->id] = $filedata->cid;
+                }
             }
 
             // recheck that get_a_link is not being attempted
@@ -1005,8 +1083,11 @@ class RestEndpointTransfer extends RestEndpoint
                 $puid = null;
                 
                 if ($data->sendVerificationCodeToYourEmailAddress || $data->checkVerificationCodeWithServer) {
+                    if( Utilities::isTrue(Config::get('advanced_validation_token'))) {
+                        $data->token = Validate::filter_var_token( "token", $data->token );
+                    }
                     $token = $data->token;
-                    
+                        
                     if(!Utilities::isValidUID($token)) {
                         throw new Exception();
                     }
@@ -1129,6 +1210,9 @@ class RestEndpointTransfer extends RestEndpoint
             $pass = bin2hex($bytes);
             
             $rid = 0;
+            if( Utilities::isTrue(Config::get('advanced_validation_token'))) {
+                $data->token = Validate::filter_var_token( "token", $data->token );
+            }
             $token = $data->token;
                 
             if(Utilities::isValidUID($token)) {

--- a/classes/rest/endpoints/RestEndpointUser.class.php
+++ b/classes/rest/endpoints/RestEndpointUser.class.php
@@ -298,8 +298,14 @@ class RestEndpointUser extends RestEndpoint
         
         // Update data
         $data = $this->request->input;
-        
+
         if ($data->lang) {
+            if( Utilities::isTrue(Config::get('advanced_validation_user'))) {
+                $data->lang = Validate::filter_var_lang(
+                    "user.lang",
+                    $data->lang );
+            }
+            
             // Lang property update, fail if not allowed
             
             if (!Config::get('lang_userpref_enabled')) {
@@ -349,6 +355,12 @@ class RestEndpointUser extends RestEndpoint
             if (!Auth::isAdmin()) {
                 throw new RestAdminRequiredException();
             }
+            if( Utilities::isTrue(Config::get('advanced_validation_user'))) {
+                $data->guest_expiry_default_days = Validate::filter_var_number(
+                    "user.lang",
+                    $data->guest_expiry_default_days );
+            }
+            
             $user->guest_expiry_default_days = $data->guest_expiry_default_days;
             $user->save();
             

--- a/classes/utils/Template.class.php
+++ b/classes/utils/Template.class.php
@@ -223,6 +223,9 @@ class Template
      */
     public static function sanitize($data)
     {
+        if($data === null) {
+            return $data;
+        }
         return str_replace(array('{', '}'), array('&#123;', '&#125;'), $data);
     }
     

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -433,6 +433,8 @@ class Utilities
      */
     public static function sanitizeOutput($output)
     {
+        if(!$output)
+            return $output;
         return htmlentities($output, ENT_QUOTES, 'UTF-8');
     }
 

--- a/classes/utils/Validate.class.php
+++ b/classes/utils/Validate.class.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * FileSender www.filesender.org
+ *
+ * Copyright (c) 2009-2012, AARNet, Belnet, HEAnet, SURF, UNINETT
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * *	Redistributions of source code must retain the above copyright
+ * 	notice, this list of conditions and the following disclaimer.
+ * *	Redistributions in binary form must reproduce the above copyright
+ * 	notice, this list of conditions and the following disclaimer in the
+ * 	documentation and/or other materials provided with the distribution.
+ * *	Neither the name of AARNet, Belnet, HEAnet, SURF and UNINETT nor the
+ * 	names of its contributors may be used to endorse or promote products
+ * 	derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Require environment (fatal)
+if (!defined('FILESENDER_BASE')) {
+    die('Missing environment');
+}
+
+/**
+ * Data validation
+ */
+class Validate
+{
+    /**
+     * Log a message about a property that has failed filter_var.
+     * 
+     * This is a function to allow outside code to also log failures
+     * in the same way.
+     */ 
+    public static function filter_var_log( $msg )
+    {
+        Logger::info("Validate FAILING. REST data filtering failing for $msg");
+    }
+    
+    /**
+     * This will only accept 1 or true as being true, any other input
+     * is assumed to be false. The $msg is included as things may be
+     * expanded to check for false,0 values and log for out of range
+     * input.
+     */
+    public static function filter_var_bool( $msg, $value )
+    {
+        $ret = Utilities::isTrue( $value );
+        return $ret;
+    }
+
+    public static function filter_var_number( $msg, $value )
+    {
+        $ret = self::filter_var_regex_log(
+            $msg,
+            $value,
+            "|^[0-9]{1,32}$|" );
+        return $ret;
+    }
+
+
+    public static function filter_var_token( $msg, $value )
+    {
+        $ret = self::filter_var_regex_log(
+            $msg,
+            $value,
+            "|^[-a-z0-9]{1,40}$|" );
+        return $ret;
+    }
+    
+    
+    /**
+     * Similar to filter_var but a message ($msg) is logged if
+     * validation does not return the same value as was passed.
+     */
+    public static function filter_var_regex_log( $msg, $value, $r )
+    {
+        if( $value === null ) {
+            return $value;
+        }
+        $value = rtrim($value,"\n\r");
+        $filter = FILTER_VALIDATE_REGEXP;
+        $original = $value;
+        $ret = filter_var( $value, $filter,
+                           ["options" => ["regexp" => $r ]] );
+        if( $ret != $value ) {
+            self::filter_var_log($msg);
+        }
+        return $ret;
+    }
+
+    public static function filter_var_mimetype( $msg, $value )
+    {
+        if( $value === null ) {
+            return $value;
+        }
+        
+        // trim off (obj) or +ext and other trailing stuff
+        $value = preg_replace('/[+ (].*$/','',$value );
+
+        return self::filter_var_regex_log( $msg,
+                                           $value,
+                                           '|^[.a-zA-Z0-9]+/[.a-zA-Z0-9]+$|' );
+            
+    }
+
+    public static function filter_var_email( $msg, $value )
+    {
+        if(!Utilities::validateEmail($value)) {
+            self::filter_var_log($msg);
+            return "";
+        }
+        return $value;
+    }
+
+    public static function filter_var_lang( $msg, $value )
+    {
+        $ret = Validate::filter_var_regex_log(
+            $msg, $value,
+            '/^[-a-z]{1,12}$/'  );
+        return $ret;
+    }
+    
+}

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -367,6 +367,15 @@ $default = array(
 
 
     'create_transfer_uses_bulk_insert_threshold' => 0,    
+
+
+
+    'advanced_validation_create_transfer' => true,
+    'advanced_validation_create_guest' => true,
+    'advanced_validation_token' => true,
+    'advanced_validation_user' => true,
+    'advanced_validation_principal' => true,
+    
     
     'template_config_values_that_can_be_read_in_templates' => array(
         'default_guest_days_valid',


### PR DESCRIPTION
This includes additional validation for creating transfers and guests. It should not effect normal use but is intended to chase explicitly nefarious use.

These options are enabled by default with the new settings

```
    'advanced_validation_create_transfer' => true,
    'advanced_validation_create_guest' => true,
    'advanced_validation_token' => true,
    'advanced_validation_user' => true,
    'advanced_validation_principal' => true,
```

There may be teething issues so being able to toggle things on or off is useful at the start. After a while these options may be removed and the advanced validation will always be performed.

I would have REALLY liked to use a schema validation language or framework to perform these tasks. Doing that is not inline with the wishes of the FileSender board.