### PR TITLE
seems f['size'] is now a string? Let's cast it as an int in python

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -791,7 +791,7 @@ try:
     #Prepare files for transfer
     if f['size'] == 0: #f size can be 0 because of directories, these can be safely skipped.
       continue
-    transfer['files'][indexOfFile]['p_total_chunks'] = ceil(f['size']/upload_chunk_size)
+    transfer['files'][indexOfFile]['p_total_chunks'] = ceil(int(f['size'])/upload_chunk_size)
     transfer['files'][indexOfFile]['p_progressed_chunks'] = 0
     path = files[f['name']+':'+str(f['size'])]['path']
     size = files[f['name']+':'+str(f['size'])]['size']


### PR DESCRIPTION
Seems f['size'] is now a string? Maybe something changed on server side?
Let's cast it as an int in python regardless.