### PR TITLE
Use raw string in filesender.py to silence escapement warning

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -131,7 +131,7 @@ else:
   parser.add_argument("-b", "--base_url")
 
 # if username is not a valid email address then ensure user supplies a valid email address
-if username is None or not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", username)):
+if username is None or not bool(re.match(r'([^@|\s]+@[^@]+\.[^@|\s]+)', username)):
   requiredNamed.add_argument("-f", "--from_address", help="filesender email from address", required=True)
 
 args = parser.parse_args()


### PR DESCRIPTION
Filesender.py was throwing out the following escapement warning :

`SyntaxWarning: invalid escape sequence '\s'
  if username is None or not bool(re.match("([^@|\s]+@[^@]+\.[^@|\s]+)", username)):`

Using a raw string instead of a double-quoted one fixes the issue.