### PR TITLE
fix: Handle undefined xhr.responseText to enable upload retries

### DIFF
--- a/www/js/client.js
+++ b/www/js/client.js
@@ -224,7 +224,7 @@ window.filesender.client = {
         
         // Needs to be done after "var settings" because handler needs that settings variable exists
         settings.error = function(xhr, status, error) {
-            var msg = xhr.responseText.replace(/^\s+/, '').replace(/\s+$/, '');
+            var msg = (xhr.responseText || '').replace(/^\s+/, '').replace(/\s+$/, '');
             
             if( // Ignore 40x, 50x and timeouts if undergoing maintenance
                 (xhr.status >= 400 || status == 'timeout') &&

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -505,7 +505,7 @@ var terasender_worker = {
             return;
             
         }else{ // We have an error
-            var msg = xhr.responseText.replace(/^\s+/, '').replace(/\s+$/, '');
+            var msg = (xhr.responseText || '').replace(/^\s+/, '').replace(/\s+$/, '');
             
             try {
                 var error = JSON.parse(msg);


### PR DESCRIPTION
## Description
This PR fixes a JavaScript crash that occurs during large file uploads, particularly in Firefox when network instability (HTTP/3/QUIC resets) causes XHR responses to be empty or undefined.

### The Problem
When uploading large files, FileSender uses Terasender workers to upload chunks in parallel. If a network error occurs (timeout, connection reset, HTTP/3 instability), the XHR `responseText` property may be `undefined` instead of a string.

The current code attempts to call `.replace()` directly on `responseText`:

```javascript
var msg = xhr.responseText.replace(/^\s+/, '').replace(/\s+$/, '');
```

This causes a `TypeError: Cannot read property 'replace' of undefined`, which:
- Crashes the JavaScript execution
- Prevents the built-in retry mechanism from activating
- Results in a blank error screen for users

**Affected files:**
- `www/js/client.js` (line 227) - General API error handling
- `www/js/terasender/terasender_worker.js` (line 508) - Chunk upload error handling

### The Solution
Added defensive null-checking before accessing `responseText`:

```javascript
var msg = (xhr.responseText || '').replace(/^\s+/, '').replace(/\s+$/, '');
```

This ensures:
- If `responseText` exists → Works exactly as before
- If `responseText` is undefined/null → Uses empty string, preventing crash
- The existing retry mechanism can now activate properly

### Impact
- **Before fix:** Network errors during upload → JS crash → Upload fails permanently
- **After fix:** Network errors during upload → Graceful handling → Retry mechanism activates

### Files Modified
- `www/js/client.js` (line 227)
- `www/js/terasender/terasender_worker.js` (line 508)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Enhancement

## How Has This Been Tested?
Tested in production environment with Firefox where HTTP/3 network resets were causing upload failures on large files (500MB+). After applying the fix, uploads complete successfully with automatic retries when network hiccups occur.
