### PR TITLE
fix: Prevent empty token in download links for authenticated owners

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -94,15 +94,18 @@ if(empty($transfer->options['encryption'])) {
 
     $fileIds = array();
     foreach($transfer->files as $file) {
-        $downloadLinks[$file->id] = Utilities::http_build_query(array(
-            'token' => $token,
-            'files_ids' => $file->id,
-        ), 'download.php?' );
+        $linkParams = array('files_ids' => $file->id);
+        if (!empty($token)) {
+            $linkParams['token'] = $token;
+        }
+        $downloadLinks[$file->id] = Utilities::http_build_query($linkParams, 'download.php?');
         $fileIds[] = $file->id;
     }
-    $archiveDownloadLink = Utilities::http_build_query(array(
-        'token' => $token,
-    ), 'download.php?' );
+    $archiveParams = array();
+    if (!empty($token)) {
+        $archiveParams['token'] = $token;
+    }
+    $archiveDownloadLink = Utilities::http_build_query($archiveParams, 'download.php?');
     $archiveDownloadLinkFileIDs = implode(',', $fileIds);
 
     // forget this here to limit scope.


### PR DESCRIPTION
## Description
This PR fixes the `TokenHasBadFormatException` when a transfer owner tries to download files as an archive from the Transfer Detail page.

Closes #2516

### The Problem
When the owner views their transfer details and clicks "Download as ZIP", the generated download link includes `token=` (empty string). The backend interprets this as "there is a token" and tries to validate it, which fails because an empty string is not a valid UID.

**Root cause:** In `templates/transfer_detail_page.php`, the download link is always built with `'token' => $token`, even when `$token` is empty.

### The Solution
Instead of modifying the backend (as suggested in the issue), this PR fixes the root cause in the frontend:

**Before:**
```php
$archiveDownloadLink = Utilities::http_build_query(array(
    'token' => $token,  // Always included, even if empty
), 'download.php?');
// Result: download.php?token=&files_ids=123  ← causes error
```

**After:**
```php
$archiveParams = array();
if (!empty($token)) {
    $archiveParams['token'] = $token;  // Only included if valid
}
$archiveDownloadLink = Utilities::http_build_query($archiveParams, 'download.php?');
// Result: download.php?files_ids=123  ← works correctly
```

This allows the backend to correctly fall through to the `elseif(Auth::isAuthenticated())` block, which properly validates the owner's session.

### Why Frontend Fix Instead of Backend?
The issue suggested changing `download.php` to use `!empty()` instead of `array_key_exists()`. While that would also work, fixing the frontend is cleaner because:
1. It addresses the root cause (don't send invalid data)
2. It doesn't change backend security logic
3. The backend already has correct logic for authenticated owners

### Files Modified
- `templates/transfer_detail_page.php` - Only include token in download links when it has a valid value

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Enhancement
