### PR TITLE
bug: change send invitation button icon from `fa-send` to `fa-paper-plane

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -336,7 +336,7 @@ use ( $new_guests_can_only_send_to_creator,
 
                                     <div class="fs-new-invitation__actions">
                                         <button type="button" class="fs-button send">
-                                            <i class="fa fa-send"></i>
+                                            <i class="fa fa-paper-plane"></i>
                                             <span>{tr:send_invitation}</span>
                                         </button>
                                     </div>


### PR DESCRIPTION
# Description
This PR fixes a missing icon issue in the "New Invitation" page caused by the upgrade to Font Awesome 7 in FileSender v3.

## The Problem
In FileSender v3, the UI has been updated to use Font Awesome 7. The class `fa-send`, which was an alias for `paper-plane` in older versions of Font Awesome, has been removed/deprecated. As a result, the "Send Invitation" button displays no icon (it renders as `<i class="fa fa-send"></i>` which paints nothing), causing a visual inconsistency in the interface.

## The Solution
The code in [templates/new_invitation_page.php](./filesender/templates/new_invitation_page.php) has been updated to use the canonical class name `fa-paper-plane` instead of `fa-send`. This ensures the paper plane icon (representing "Send") renders correctly in the new UI environment provided by FileSender v3.