### PR TITLE
bug: Prevent extending the expiry date of guests set to never expire invitations

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -358,6 +358,9 @@ class RestEndpointGuest extends RestEndpoint
                     throw new RestAdminRequiredException();
                 }
             }
+            if($guest->does_not_expire) {
+                 throw new RestBadParameterException('extend_expiry_date');
+            }
             $guest->extendObjectExpiryDate();
             return self::cast($guest);
         }

--- a/templates/guests_table.php
+++ b/templates/guests_table.php
@@ -30,6 +30,7 @@
         <tr class="guest objectholder fs-table__row fs-table__row--clickable"
             data-id="<?php echo $guest->id ?>"
             data-expiry-extension="<?php echo $guest->expiry_date_extension ?>"
+            data-does-not-expire="<?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? '1' : '0' ?>"
             data-errors="<?php echo count($guest->errors) ? '1' : '' ?>">
 
             <td class="created d-none d-lg-table-cell" data-label="{tr:invitation_was_sent_on}">

--- a/www/js/guests_table.js
+++ b/www/js/guests_table.js
@@ -75,7 +75,8 @@ $(function() {
 
             if(table.is('[data-mode!="admin"]')) {
                 var days = $(this).closest('.objectholder').attr('data-expiry-extension');
-                if( days > 0 ) {
+                var does_not_expire = $(this).closest('.objectholder').attr('data-does-not-expire');
+                if( days > 0 && does_not_expire != '1') {
                     var extend = $('<span data-action="extendguestexpires" class="extend fs-button fs-button--circle fs-button--no-text clickable fa fa-lg fa-clock" />');
                     extend.appendTo(td).attr({
                         title: lang.tr('extend_expiry_date').r({
@@ -90,7 +91,8 @@ $(function() {
 
             if(table.is('[data-mode="admin"]')) {
                 var days = $(this).closest('.objectholder').attr('data-expiry-extension');
-                if( days > 0 ) {
+                var does_not_expire = $(this).closest('.objectholder').attr('data-does-not-expire');
+                if( days > 0 && does_not_expire != '1') {
                     var extend = $('<span data-action="extendexpires" class="extend adminaction fs-button fs-button--circle fs-button--no-text clickable fa fa-lg fa-clock" />');
                     extend.appendTo(td).attr({
                         title: lang.tr('extend_expiry_date').r({


### PR DESCRIPTION
## Description
This PR fixes a bug where extending a guest invitation that is set to "Never expire" results in the expiration date being reset to the Unix Epoch (Feb 1, 1970), causing the invitation to expire immediately.

### The Problem
When a guest invitation is created with the "does not expire" option, its `expires` field is stored as `null` (or 0).
When the "Extend" action is triggered:
1. The backend (`DBObject::extendObjectExpiryDate`) adds the extension duration (e.g., 30 days) to the current `expires` value.
2. Since `expires` is 0/null, the calculation becomes `0 + duration`.
3. The result is a timestamp corresponding to early 1970.

**Root cause:** The system allows extending a date that doesn't exist (infinite), and the math operation treats "infinite" as zero.

### The Solution
I have implemented a safeguard in both the frontend and backend to prevent this action for non-expiring guests.

**Frontend ([guests_table.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/templates/guests_table.php:0:0-0:0) & [guests_table.js](cci:7://file:///root/ProyectosPruebas/filesender/filesender/www/js/guests_table.js:0:0-0:0)):**
- Added a `data-does-not-expire` attribute to the guest rows.
- The Javascript now checks this attribute. If the guest does not expire, the "Extend" (clock icon) button is **hidden**.

**Backend ([RestEndpointGuest.class.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/classes/rest/endpoints/RestEndpointGuest.class.php:0:0-0:0)):**
- Added a check in the [put](cci:1://file:///root/ProyectosPruebas/filesender/filesender/classes/rest/endpoints/RestEndpointGuest.class.php:308:4-369:5) method.
- If a request tries to extend a guest that has `does_not_expire` set to true, the server throws a `RestBadParameterException`. This prevents API calls (intentional or accidental) from corrupting the date.

### Files Modified
- [templates/guests_table.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/templates/guests_table.php:0:0-0:0) - Expose `does_not_expire` status to the DOM.
- [www/js/guests_table.js](cci:7://file:///root/ProyectosPruebas/filesender/filesender/www/js/guests_table.js:0:0-0:0) - Hide the extend button if the guest does not expire.
- [classes/rest/endpoints/RestEndpointGuest.class.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/classes/rest/endpoints/RestEndpointGuest.class.php:0:0-0:0) - Block extension requests for non-expiring guests.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Enhancement