### PR TITLE
Remove the `download` class from the delete and auditlog buttons in the transfer detail page.

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -283,12 +283,12 @@ if(empty($transfer->options['encryption'])) {
                                                     <?php } ?>
                                                 <?php } ?>
 
-                                                <span data-action="delete" class="fs-button fs-button--small fs-button--transparent fs-button--danger fs-button--no-text download" title="{tr:delete}">
+                                                <span data-action="delete" class="fs-button fs-button--small fs-button--transparent fs-button--danger fs-button--no-text" title="{tr:delete}">
                                                     <i class="fa fa-trash"></i>
                                                 </span>
 
                                                 <?php if($audit) { ?>
-                                                    <span data-action="auditlog" class="fs-button fs-button--small fs-button--transparent fs-button--info fs-button--no-text download" title="{tr:open_file_auditlog}">
+                                                    <span data-action="auditlog" class="fs-button fs-button--small fs-button--transparent fs-button--info fs-button--no-text" title="{tr:open_file_auditlog}">
                                                         <i class="fa fa-history"></i>
                                                     </span>
                                                 <?php } ?>


### PR DESCRIPTION
## Description
This PR fixes a bug where clicking on action icons (delete, audit log) within file rows would unintentionally trigger a file download.

### The Problem
In the transfer detail page, each file row has multiple action icons:
- **Download** (the main clickable area)
- **Delete** (trash icon)
- **Audit Log** (history icon)

When clicking on the delete or audit log icons:
1. The icons had the `download` CSS class applied to them.
2. This class was being used by the JavaScript to bind download handlers.
3. Clicking these icons would trigger both their intended action (delete/view logs) AND start a download.

**Root cause:** The delete and audit log icons incorrectly had the `download` class, causing the download handler to be bound to them.

### The Solution
I have removed the `download` class from the delete and audit log action icons.

**Frontend ([transfer_detail_page.php](file:///root/ProyectosPruebas/filesender/filesender/templates/transfer_detail_page.php)):**
- Removed the `download` class from delete icon elements.
- Removed the `download` class from audit log icon elements.
- The download functionality now only applies to the intended download buttons/areas.

### Files Modified
- [templates/transfer_detail_page.php](file:///filesender/templates/transfer_detail_page.php) - Removed `download` class from non-download action icons.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Enhancement

## Testing
1. Log in as a user and create a transfer with multiple files.
2. Navigate to "My Transfers" and click on the transfer to view details.
3. Click the **trash icon** (delete) on a file row.
4. **Expected:** Only the delete confirmation dialog appears. No download starts.
5. Click the **history icon** (audit log) on a file row.
6. **Expected:** Only the audit log popup appears. No download starts.
7. **Before this fix:** Clicking these icons would also trigger a file download.