### PR TITLE
fix: Corrected the `cgilimit` parameter in pagination links to use `$limit` instead of `$cgilimit`.

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -303,8 +303,8 @@ EOF;
 
         if( $havePrev ) {
             $prevPage = Template::Q(max(0,$offset-$limit));
-            echo "<a class='fs-link fs-link--circle' href='$base&cgioffset=0&cgilimit=$cgilimit&transfersort=$transfersort&as=$as'><i class='fa fa-angle-double-left'></i></a>";
-            echo "<a class='fs-link fs-link--circle' href='$base&cgioffset=$prevPage&cgilimit=$cgilimit&transfersort=$transfersort&as=$as'><i class='fa fa-angle-left'></i></a>";
+            echo "<a class='fs-link fs-link--circle' href='$base&$cgioffset=0&$cgilimit=$limit&transfersort=$transfersort&as=$as'><i class='fa fa-angle-double-left'></i></a>";
+            echo "<a class='fs-link fs-link--circle' href='$base&$cgioffset=$prevPage&$cgilimit=$limit&transfersort=$transfersort&as=$as'><i class='fa fa-angle-left'></i></a>";
         } else {
             echo "<a class='fs-link fs-link--circle fs-link--disabled' href='javascript:void(0)'><i class='fa fa-angle-double-left'></i></a>";
             echo "<a class='fs-link fs-link--circle fs-link--disabled' href='javascript:void(0)'><i class='fa fa-angle-left'></i></a>";


### PR DESCRIPTION
## Bug Description
The single left arrow (previous page) was behaving like the double left arrow (first page), always returning to the beginning instead of going back one page.

## Root Cause
The pagination links were using literal strings `cgioffset` and `cgilimit` instead of the variables `$cgioffset` and `$cgilimit` in the href URLs.

## Solution
Changed lines 306-307 in [templates/transfers_table.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/templates/transfers_table.php:0:0-0:0) to use the correct variables, matching the pattern already used in the "next page" button (line 302).

## Files Changed
- [templates/transfers_table.php](cci:7://file:///root/ProyectosPruebas/filesender/filesender/templates/transfers_table.php:0:0-0:0) (2 lines)