### PR TITLE
fix: return uid if the transfer has been forwarded

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -75,10 +75,14 @@ class RestEndpointTransfer extends RestEndpoint
             'salt' => $transfer->salt,
             'roundtriptoken' => $creatingTransfer ? $transfer->roundtriptoken : '',
             
-            'files' => array_map(function ($file) use ($files_cids) {
+            'files' => array_map(function ($file) use ($files_cids, $transfer) {
+                $file_uid = $file->uid;
                 $file = RestEndpointFile::cast($file);
                 if ($files_cids && array_key_exists($file['id'], $files_cids)) {
                     $file['cid'] = $files_cids[$file['id']];
+                }
+                if ($transfer->hasBeenForwarded()) {
+                    $file['uid'] = $file_uid;
                 }
                 return $file;
             }, array_values($transfer->files)),

--- a/classes/utils/ForwardAnotherServer.class.php
+++ b/classes/utils/ForwardAnotherServer.class.php
@@ -364,6 +364,7 @@ class ForwardAnotherServer
                         throw new ForwardFileCannotRenameException($src->uid, $dest->uid);
                     }
                     $src->uid = $dest->uid;
+                    $src->puid = $dest->puid;
                     $src->forward_id = $dest->id;
                     if ($storage_class_name) $src->storage_class_name = $storage_class_name;
                     $src->save();


### PR DESCRIPTION
The file forwarding feature needs the file uid as the file name to forward files to another site.
Therefore, the REST return value for the file forwarding includes not only the file puid, but also the uid.

related: https://github.com/filesender/filesender/commit/39de785e6500ed8e728778b7952dea70835a551d