### PR TITLE
Fix duplicate recipient additions by debouncing Add Recipient modal submit

### DIFF
--- a/www/js/transfers_table.js
+++ b/www/js/transfers_table.js
@@ -167,7 +167,11 @@ $(function() {
             recipients.push($(this).attr('data-email'));
         });
         
+        var submitting_add_recipient = false;
+
         var prompt = filesender.ui.prompt(lang.tr('enter_to_email'), function() {
+            if(submitting_add_recipient) return false;
+
             var input = $(this).find('input');
             $('p.error', this).remove();
             
@@ -211,6 +215,10 @@ $(function() {
                 return false;
             }
             
+            submitting_add_recipient = true;
+            input.prop('disabled', true);
+            $('.ui-dialog-buttonpane button').prop('disabled', true);
+
             var done = 0;
             for(var i=0; i<emails.length; i++) {
                 filesender.client.addRecipient(id, emails[i], function() {


### PR DESCRIPTION
## Summary
This PR fixes duplicate recipient creation caused by rapid repeated clicks on the Add Recipient modal submit action.

## Root cause
The submit callback could be triggered multiple times before the dialog closed / UI reloaded, resulting in repeated `addRecipient` REST calls for the same addresses.

## Changes
- Added a local submission lock (`submitting_add_recipient`) in `www/js/transfers_table.js`
- Early-return if a submit is already in progress
- Disable input and dialog buttons immediately after validation passes and first submit starts

## Result
- Prevents duplicate recipient additions from fast repeated clicks
- Prevents duplicate notification emails triggered by duplicate additions

## Related issue
- Closes #2577
