### PR TITLE
Fix expiry date off-by-one by sending selected date string from UI

### DIFF
--- a/www/js/guests_page.js
+++ b/www/js/guests_page.js
@@ -210,7 +210,8 @@ filesender.ui.evalSendEnabled = function() {
 filesender.ui.send = function() {
     var options = {guest: {}, transfer: {}};
     
-    var expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
+    // Send the selected calendar date as a date string to avoid client timezone epoch drift (off-by-one day).
+    var expires = filesender.ui.nodes.expires.val();
     
     var from = null;
     if(filesender.ui.nodes.from.length)

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1178,7 +1178,8 @@ filesender.ui.startUpload = function() {
     window.filesender.pbkdf2dialog.reset();
 
     if(!filesender.ui.nodes.required_files) {
-        this.transfer.expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
+        // Send the selected calendar date as a date string to avoid client timezone epoch drift (off-by-one day).
+        this.transfer.expires = filesender.ui.nodes.expires.val();
         
         if(filesender.ui.nodes.from.length)
             this.transfer.from = filesender.ui.nodes.from.val();


### PR DESCRIPTION
## Summary
This PR fixes an expiry-date off-by-one issue in UI flows where selected validity days could display one day earlier than expected.

## Root cause
The UI sent expiry as a Unix timestamp derived from datepicker local-midnight:
- `datepicker('getDate').getTime()/1000`

That value is timezone-dependent and can drift by one day when interpreted/rendered server-side in a different timezone.

## Changes
- `www/js/upload_page.js`
  - send `expires` as the selected date string (`filesender.ui.nodes.expires.val()`) instead of local-midnight epoch
- `www/js/guests_page.js`
  - same change for guest voucher flow

## Why this works
The REST layer already accepts date strings for expiry. Sending the user-selected calendar date avoids client timezone epoch conversion drift.

## Related issue
- Closes #2549
