### PR TITLE
Fix guest transfer recipient validation to avoid undefined-key 500 and return proper no-recipient error

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -702,15 +702,21 @@ class RestEndpointTransfer extends RestEndpoint
             }
             
             // No recipients, not get_a_link and no way to get a recipient from options ? Fail if so
+            // Use safe defaults to avoid undefined-key notices in guest flows.
+            $get_a_link = !empty($options[TransferOptions::GET_A_LINK]);
+            $add_me_to_recipients = !empty($options[TransferOptions::ADD_ME_TO_RECIPIENTS]);
+            $guest_add_me_to_recipients = $guest ? !empty($guest->transfer_options[TransferOptions::ADD_ME_TO_RECIPIENTS]) : false;
+            $guest_can_only_send_to_me = $guest ? !empty($guest->options[GuestOptions::CAN_ONLY_SEND_TO_ME]) : false;
+
             if (
                 !count($data->recipients) &&
-                !$options[TransferOptions::GET_A_LINK] &&
-                !$options[TransferOptions::ADD_ME_TO_RECIPIENTS] &&
+                !$get_a_link &&
+                !$add_me_to_recipients &&
                 (
                     !$guest ||
                     (
-                        !$guest->transfer_options[TransferOptions::ADD_ME_TO_RECIPIENTS] &&
-                        !$guest->options[GuestOptions::CAN_ONLY_SEND_TO_ME]
+                        !$guest_add_me_to_recipients &&
+                        !$guest_can_only_send_to_me
                     )
                 )
             ) {


### PR DESCRIPTION
## Summary
This PR hardens recipient validation in transfer creation for guest flows where recipient lists can be empty depending on voucher options.

## Problem
In guest upload scenarios (no explicit recipients, `get_a_link=false`, `add_me_to_recipients=false`), validation logic could read option keys directly and trigger undefined-key notices under PHP 8+, which may surface as HTTP 500.

## Changes
In `RestEndpointTransfer::post` recipient guard:
- Introduced safe boolean locals with defaults:
  - `$get_a_link`
  - `$add_me_to_recipients`
  - `$guest_add_me_to_recipients`
  - `$guest_can_only_send_to_me`
- Switched condition to use these safe values instead of direct array key reads.

## Result
- Prevents undefined-key notice/500 behavior in guest edge cases
- Keeps intended behavior: requests with no valid recipient path fail with `TransferNoRecipientsException` rather than server error

## Related issue
- Closes #2567
