### PR TITLE
Fix transfers pagination next-link to pass numeric limit value

### DIFF
--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -128,7 +128,8 @@ if (!function_exists('clickableHeader')) {
         $cgias = Template::Q(Utilities::getGETparam('as',''));
         $cgilimitvalue = Template::Q($limit);
         $as = $cgias . Template::Q($cgiuid) . Template::Q($cgiminmax);
-        $nextLink  = Template::Q("$base&$cgioffset=$nextPage&$cgilimit=$cgilimit&transfersort=$transfersort&as=$as&nextlink=1");
+        // Use actual limit value, not the limit parameter name, when building next-page URL.
+        $nextLink  = Template::Q("$base&$cgioffset=$nextPage&$cgilimit=$cgilimitvalue&transfersort=$transfersort&as=$as&nextlink=1");
         
         if( $havePrev ) {
            $prevPage = Template::Q(max(0,$offset-$limit));


### PR DESCRIPTION
## Summary
Fixes an incorrect query-string value in transfers pagination link generation.

## Problem
In `templates/transfers_table.php`, the next-page URL used the limit parameter name as its value:

- `...&<limit_param>=<limit_param>...`

instead of passing the numeric limit value.

This can break pagination behavior (including empty page / "No loads" style results) depending on request context.

## Change
- Updated next-link generation to use `$cgilimitvalue` (actual numeric limit) instead of `$cgilimit` (parameter name).

## File
- `templates/transfers_table.php`

## Related issue
- Closes #2550
