### PR TITLE
Fix download verification prompt when config is false-like string

### DIFF
--- a/www/js/download_page.js
+++ b/www/js/download_page.js
@@ -37,7 +37,13 @@ $(function() {
     var verificationCodeObjectThatTiggeredEvent = null;
     var verificationCodePassedPopup = null;
 
-    if( window.filesender.config.download_verification_code_enabled ) {
+    // Config values may be serialized as strings (e.g. "false").
+    // Normalize to a strict boolean to avoid treating non-empty strings as enabled.
+    var verificationCodeEnabled = (function(v) {
+        return v === true || v === 1 || v === '1' || v === 'true';
+    })(window.filesender.config.download_verification_code_enabled);
+
+    if( verificationCodeEnabled ) {
         verificationCodePassed = false;
     }
     
@@ -330,7 +336,7 @@ $(function() {
     }
 
 
-    if( window.filesender.config.download_verification_code_enabled ) {
+    if( verificationCodeEnabled ) {
 
         var transferid = $('.transfer').attr('data-id');
         var rid        = $('.rid').attr('data-id');


### PR DESCRIPTION
## Summary
Fixes an issue where download verification UI logic could be incorrectly enabled when `download_verification_code_enabled` is configured as a false-like string value.

## Problem
In browser JavaScript, non-empty strings are truthy. If config serialization yields values like `'false'`, checks such as:

```js
if (window.filesender.config.download_verification_code_enabled) { ... }
```

will evaluate to true and incorrectly gate downloads behind verification prompts.

## Change
In `www/js/download_page.js`:
- Added strict normalization helper for `download_verification_code_enabled`
- Replaced direct truthiness checks with the normalized boolean

Enabled values are treated as:
- `true`, `1`, `'1'`, `'true'`

Everything else is treated as disabled.

## Related issue
- Closes #2083
