### PR TITLE
Skip recipient-context emails when recipient address is empty

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -1807,6 +1807,12 @@ class Transfer extends DBObject
      */
     public function sendToRecipient($translation_id, $recipient)
     {
+        // Defensive guard: avoid sending recipient-context emails when recipient address is empty.
+        if (!$recipient || !trim((string)$recipient->email)) {
+            Logger::warning('Mail#'.$translation_id.' skipped due to empty recipient email for '.$this);
+            return;
+        }
+
         $args = func_get_args();
         $args[] = $this;
         


### PR DESCRIPTION
## Summary
Adds a defensive guard to avoid sending recipient-context emails when recipient email is empty.

## Problem
In some edge cases (e.g. link-only style flows / malformed recipient data), recipient-context mail sending could be attempted with an empty destination, leading to invalid/empty `To:` headers.

## Change
In `Transfer::sendToRecipient(...)`:
- Early return if recipient is missing or `recipient->email` is empty
- Log a warning instead of attempting to send

## Result
- Prevents invalid recipient email sends
- Avoids empty `To:` header behavior

## Related issue
- Closes #2403
