### PR TITLE
Normalize boolean guest/transfer options in guest creation payload

### DIFF
--- a/classes/rest/endpoints/RestEndpointGuest.class.php
+++ b/classes/rest/endpoints/RestEndpointGuest.class.php
@@ -230,7 +230,11 @@ class RestEndpointGuest extends RestEndpoint
             foreach (Guest::allOptions() as $name => $dfn) {
                 if (in_array($name, $allowed_options)
                     && $data->options->guest->exists($name)) {
-                    $guest_options[$name] = $data->options->guest->$name;
+                    $v = $data->options->guest->$name;
+                    if (array_key_exists('default', $dfn) && is_bool($dfn['default'])) {
+                        $v = Utilities::isTrue($v);
+                    }
+                    $guest_options[$name] = $v;
                 }
             }
         }
@@ -257,7 +261,11 @@ class RestEndpointGuest extends RestEndpoint
             foreach (Transfer::allOptions() as $name => $dfn) {
                 if (in_array($name, $allowed_transfer_options)
                     && $data->options->transfer->exists($name)) {
-                    $transfer_options[$name] = $data->options->transfer->$name;
+                    $v = $data->options->transfer->$name;
+                    if (array_key_exists('default', $dfn) && is_bool($dfn['default'])) {
+                        $v = Utilities::isTrue($v);
+                    }
+                    $transfer_options[$name] = $v;
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR normalizes boolean option values in guest creation payload handling.

## Problem
API payloads may provide booleans as strings (e.g. `"false"`).
Without normalization, these values are copied as-is and can be interpreted as truthy later in PHP checks, causing guest recipient option logic inversion.

## Change
In `RestEndpointGuest::post`:
- For both `options.guest` and `options.transfer` payload loops
- If an option default is boolean, normalize value via `Utilities::isTrue(...)` before storing

## Why this helps
This makes boolean behavior deterministic independent of payload representation (`false` vs `"false"`).

## Related issue
- Closes #1889
