### PR TITLE
Guard REQUEST_URI in HTTPS redirect path for CLI/cron safety

### DIFF
--- a/classes/utils/GUI.class.php
+++ b/classes/utils/GUI.class.php
@@ -304,7 +304,8 @@ class GUI
             
             // ... Redirect the user to HTTPS.
             $host = array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : $_SERVER['SERVER_NAME'];
-            $redirect = sprintf('Location: https://%s%s', $host, $_SERVER['REQUEST_URI']);
+            $request_uri = array_key_exists('REQUEST_URI', $_SERVER) ? $_SERVER['REQUEST_URI'] : '/';
+            $redirect = sprintf('Location: https://%s%s', $host, $request_uri);
             header($redirect);
             exit;
         }

--- a/docker/GUI.class.php
+++ b/docker/GUI.class.php
@@ -308,7 +308,8 @@ class GUI
 
             // ... Redirect the user to HTTPS.
             $host = array_key_exists('HTTP_HOST', $_SERVER) ? $_SERVER['HTTP_HOST'] : $_SERVER['SERVER_NAME'];
-            $redirect = sprintf('Location: https://%s%s', $host, $_SERVER['REQUEST_URI']);
+            $request_uri = array_key_exists('REQUEST_URI', $_SERVER) ? $_SERVER['REQUEST_URI'] : '/';
+            $redirect = sprintf('Location: https://%s%s', $host, $request_uri);
             header($redirect);
             exit;
         }


### PR DESCRIPTION
## Summary
Fixes undefined `REQUEST_URI` access in HTTPS redirect logic when code runs in non-web contexts (cron/CLI).

## Problem
`GUI::forceHTTPS()` referenced `$_SERVER['REQUEST_URI']` directly. In cron/CLI contexts this key can be absent, producing warnings/errors.

## Change
In both runtime and docker GUI helper copies:
- Introduced guarded lookup for `REQUEST_URI`
- Fallback to `'/'` if missing

## Files
- `classes/utils/GUI.class.php`
- `docker/GUI.class.php`

## Related issue
- Closes #2323
