### PR TITLE
don't allow guests to choose the transfer forward to another server

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -136,7 +136,13 @@ use ( $new_guests_can_only_send_to_creator,
     if($name == TransferOptions::OPENPGP_ENCRYPT_PASSPHRASE_TO_EMAIL && !$openpgpkey ) {
         return;
     }    
-    
+
+    // don't allow guests to choose the transfer forward to another server
+    if( in_array($name, array(TransferOptions::FORWARD_TO_ANOTHER_SERVER,
+                              TransferOptions::FORWARD_SERVER_NAME))) {
+        return;
+    }
+
     $default = $cfg['default'];
     if(Auth::isSP()) {
         if($transfer) {


### PR DESCRIPTION
At "advanced settings" on the new invitation screen, 
the `forward_to_another_server` and `forward_server_name` are displayed as a toggle switch.
But the sender who sends an invitation can't decide them before.