### PR TITLE
Add from_address as option, fixes case where username matches regex but is not the email address of the user

### DIFF
--- a/scripts/client/filesender.py
+++ b/scripts/client/filesender.py
@@ -134,6 +134,8 @@ else:
 # if username is not a valid email address then ensure user supplies a valid email address
 if username is None or not bool(re.match(r'([^@|\s]+@[^@]+\.[^@|\s]+)', username)):
   requiredNamed.add_argument("-f", "--from_address", help="filesender email from address", required=True)
+else:
+  parser.add_argument("-f", "--from_address", help="filesender email from address")
 
 args = parser.parse_args()
 debug = args.verbose


### PR DESCRIPTION
The client assumes that if the username resembles an email address then use it as the email address.  This fails in some cases, eg. username in form `SurnameF@mydomain.com`  but email address is `First.Surname@mydomain.com` 
This patch adds from_address as optional, keeping the requirement should username not match regex.