### PR TITLE
fix: normalize filenames to NFC to support MacOS (NFD) unicode characters

### DIFF
--- a/www/js/transfer.js
+++ b/www/js/transfer.js
@@ -419,6 +419,12 @@ window.filesender.transfer = function() {
         if (typeof filesender.config.valid_filename_regex == 'string') {
             var regexstr = filesender.config.valid_filename_regex;
             var r = XRegExp(regexstr,'g');
+            
+	    // fix NFD unicode characters problem on OS X, convert to NFC
+            if (file.name) {
+                file.name = file.name.normalize('NFC');
+            }
+
             var testResult = r.test(file.name);
             var lastIndex = r.lastIndex;
             if (lastIndex != file.name.length) {


### PR DESCRIPTION
This PR addresses an issue where users on MacOS encounter an invalid_file_name error when uploading files containing unicode characters (e.g., Turkish characters like Ü, İ, Ş, or German umlauts).

MacOS uses NFD (Normalization Form Decomposed) by default for filenames. In NFD, a character like Ü is stored as two separate code points: U (U+0055) + ¨ (U+0308).

FileSender's filename validation logic in transfer.js uses XRegExp to test the filename. When it encounters these decomposed characters, the regex lastIndex check fails because it expects single-composed characters (NFC - Normalization Form Composed), leading to an incorrect "invalid filename" rejection even if the character itself is technically allowed in the configuration.

Before performing the regex validation in www/js/transfer.js, we now explicitly call file.name.normalize('NFC'). This ensures that any decomposed characters from MacOS are converted into their standard composed forms before the validation logic runs.