### PR TITLE
Allow Admins to download files directly from admin view

### DIFF
--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -162,14 +162,13 @@ class RestEndpointTransfer extends RestEndpoint
             
             // Check that we have a valid token in the url
             if (!array_key_exists('token', $_GET)) {
-                if( Auth::isAuthenticated()) {
-                    $user = Auth::user();
+                if (Auth::isAuthenticated()) {
                     $transfer = Transfer::fromId($id);
-                    // If they own the file then they do not need to confirm download.
-                    // this is used in the transfer details page
-                    if( $user->id == $transfer->userid ) {
-                        $rc = false;
-                        return $rc;
+
+                    // Transfer detail page downloads by the owner or an admin do not
+                    // act on behalf of a recipient, so no recipient notification is needed.
+                    if ($transfer->havePermission()) {
+                        return false;
                     }
                 }
                 throw new RestBadParameterException('token');


### PR DESCRIPTION
## Summary

Closes #2614 — admin users were unable to download files from the transfer detail page because the download endpoint only checked for transfer ownership (`$user->id == $transfer->userid`), excluding admins.

Replace the ownership check with `$transfer->havePermission()`, which returns `true` for both the transfer owner and admin users.

## Changes

- `classes/rest/endpoints/RestEndpointTransfer.class.php`: replace `$user->id == $transfer->userid` with `$transfer->havePermission()`
