### PR TITLE
## Fix: invitation detail pagination loses guest_id and ignores offset

### DIFF
--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -132,8 +132,16 @@ if( $found ) {
                     <h2>{tr:invitation_guest_transfer_linked}</h2>
 
                     <?php
-                        $transfers = Transfer::fromGuest($guest);
-                        Template::display('transfers_table', array('transfers' => $transfers, 'show_guest' => true));
+                        $all_transfers = Transfer::fromGuest($guest);
+                        $invite_offset = Utilities::arrayKeyOrDefault($_GET, 'offset', 0, FILTER_VALIDATE_INT);
+                        $invite_limit  = 10;
+                        $paged_transfers = array_slice($all_transfers, $invite_offset, $invite_limit + 1);
+                        Template::display('transfers_table', array(
+                            'transfers'  => $paged_transfers,
+                            'show_guest' => true,
+                            'limit'      => $invite_limit,
+                            'offset'     => $invite_offset,
+                        ));
                     ?>
                 </div>
             </div>

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -293,6 +293,8 @@ EOF;
     if( $havePrev || $haveNext ) {
         echo "<div class='fs-paginator fs-paginator--center'>";
         $base = '?s=' . Template::Q(htmlspecialchars($_GET['s']));
+        $guest_id_pager = Utilities::arrayKeyOrDefault($_GET, 'guest_id', 0, FILTER_VALIDATE_INT);
+        if ($guest_id_pager) { $base .= '&guest_id=' . $guest_id_pager; }
         $cgioffset =    Template::Q($pagerprefix) . 'offset';
         $cgilimit  =    Template::Q($pagerprefix) . 'limit';
         $cgilimitvalue =Template::Q($limit);


### PR DESCRIPTION
### Problem
- `invitation_detail_page.php` always showed the first 2 transfers regardless of the page,
  because it never passed `offset` or `limit` to `transfers_table`.
- Clicking "next" navigated to a URL without `guest_id`, causing "guest not found" error.

### Changes
- **`templates/invitation_detail_page.php`**: read `offset` from GET params, slice transfers
  in PHP, pass `limit=10` and `offset` to `transfers_table`. Shows 10 transfers per page.
- **`templates/transfers_table.php`**: preserve `guest_id` in pagination base URL so next/prev
  links don't lose the guest context.