### PR TITLE
fix: correct back/first-page links and total_count in pagination

### DIFF
--- a/templates/admin_transfers_section.php
+++ b/templates/admin_transfers_section.php
@@ -72,7 +72,7 @@ $transfers_page = function($status) {
     // are a bunch of results to avoid hitting the database for a count(*) right
     // at the start (there are three views by default and couint(*) might do a
     // seq scan to complete.
-    if( !$offset && !strstr($selector,' AND')) {
+    if( false ) {
         $total_count = $page_size * $display_page_num;
     } else {
         $total_count = Transfer::count(array(
@@ -132,7 +132,7 @@ $transfers_page = function($status) {
     
     if($offset + $page_size < $total_count) {
         $no = $offset + $page_size;
-        $lo = $total_count - ($total_count % $page_size);
+        $lo = max(0, $total_count - ($total_count % $page_size ?: $page_size));
         $navigation .= '<a href="?s=admin&as=transfers&'.Template::Q($status).'_tpo='.Template::Q($no).'&transfersort='.Template::Q($transfersort).Template::Q($cgiminmax).'#'.Template::Q($status).'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
         $navigation .= '<a href="?s=admin&as=transfers&'.Template::Q($status).'_tpo='.Template::Q($lo).'&transfersort='.Template::Q($transfersort).Template::Q($cgiminmax).'#'.Template::Q($status).'_transfers"><span class="fa-stack"><i class="fa fa-square fa-stack-2x"></i><i class="fa fa-angle-double-right fa-stack-1x fa-inverse"></i></span></a>'."\n";
     }

--- a/templates/transfers_table.php
+++ b/templates/transfers_table.php
@@ -306,8 +306,8 @@ EOF;
 
         if( $havePrev ) {
             $prevPage = Template::Q(max(0,$offset-$limit));
-            echo "<a class='fs-link fs-link--circle' href='$base&cgioffset=0&cgilimit=$cgilimitvalue&transfersort=$transfersort&as=$as'><i class='fa fa-angle-double-left'></i></a>";
-            echo "<a class='fs-link fs-link--circle' href='$base&cgioffset=$prevPage&cgilimit=$cgilimitvalue&transfersort=$transfersort&as=$as'><i class='fa fa-angle-left'></i></a>";
+            echo "<a class='fs-link fs-link--circle' href='$base&$cgioffset=0&$cgilimit=$cgilimitvalue&transfersort=$transfersort&as=$as'><i class='fa fa-angle-double-left'></i></a>";
+            echo "<a class='fs-link fs-link--circle' href='$base&$cgioffset=$prevPage&$cgilimit=$cgilimitvalue&transfersort=$transfersort&as=$as'><i class='fa fa-angle-left'></i></a>";
         } else {
             echo "<a class='fs-link fs-link--circle fs-link--disabled' href='javascript:void(0)'><i class='fa fa-angle-double-left'></i></a>";
             echo "<a class='fs-link fs-link--circle fs-link--disabled' href='javascript:void(0)'><i class='fa fa-angle-left'></i></a>";


### PR DESCRIPTION
## Summary

Two independent pagination bugs affecting the transfers list and admin panel.

### Bug 1 — `transfers_table.php`: back/first-page links always reset to page 1

Lines 338–339 used the string literals `cgioffset` and `cgilimit` as URL
parameter names instead of the PHP variables `$cgioffset` and `$cgilimit`.
Those variables resolve to prefix-aware names (`openoffset`, `closedoffset`,
`openlimit`, `closedlimit`, …) depending on the transfer status being shown.
Using the raw literals meant the pagination parameters were never picked up,
so clicking "previous page" or "first page" always reloaded page 1.

**Fix:** replace `cgioffset=` / `cgilimit=` with `$cgioffset=` / `$cgilimit=`
on both lines.

### Bug 2 — `admin_transfers_section.php`: phantom pages and hidden pages

**2a — fake `total_count` optimisation.** When loading the first page with no
active filter the code skipped the `COUNT(*)` query and hardcoded
`total_count = page_size × display_page_num` (= 60). This produced phantom
page links when there were fewer than 60 records, and hid real pages when
there were more than 60.

**Fix:** remove the short-circuit branch; always query `Transfer::count()`.

**2b — off-by-one on last-page offset.** When the total number of records is
an exact multiple of the page size (e.g. 30 records, page size 15) the
expression `$total_count % $page_size` evaluates to 0, making
`$lo = $total_count - 0 = $total_count`, an out-of-range offset that renders
an empty last page.

**Fix:** treat a zero remainder as a full page:
`$lo = max(0, $total_count - ($total_count % $page_size ?: $page_size))`

## Files changed

- `filesender/templates/transfers_table.php` — lines 338–339
- `filesender/templates/admin_transfers_section.php` — lines 74–80, 135

## Test plan

- [ ] Open transfers list; navigate forward and then back — verify correct page
      is shown for each status tab (uploading / available / closed)
- [ ] Load admin transfers panel with fewer than 60 records — verify no phantom
      pages appear in the page navigator
- [ ] Load admin transfers panel with more than 60 records — verify all pages
      are reachable
- [ ] Load admin transfers panel with a record count that is an exact multiple
      of the page size — verify the last-page arrow leads to a non-empty page
