### PR TITLE
Fix/guest expiry time preserves creation hour

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -165,7 +165,7 @@ class Guest extends DBObject
     const AVAILABLE = "status = 'available' ORDER BY created DESC";
     // Note that if the guest does not expire then expires is null 
     // so that tuple will not be returned by the below fragment.
-    const EXPIRED = "expires < :date ORDER BY expires ASC";
+    const EXPIRED = "expires < :datetime ORDER BY expires ASC";
     // For these fragments we want to find the guests that have
     // expires is null because they are still considered active
     const FROM_USER           = "userid = :userid AND (expires is null or expires > :date) ORDER BY created DESC";
@@ -376,7 +376,7 @@ class Guest extends DBObject
      */
     public static function allExpired()
     {
-        return self::all(self::EXPIRED, array(':date' => date('Y-m-d')));
+        return self::all(self::EXPIRED, array(':datetime' => date('Y-m-d H:i:s')));
     }
     
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -338,9 +338,9 @@ class Transfer extends DBObject
     const UPLOADING = "status = 'uploading' ORDER BY created DESC";
     const AVAILABLE = "status = 'available' ORDER BY created DESC";
     const CLOSED = "status = 'closed' ORDER BY created DESC";
-    const EXPIRED = "expires <= :date ORDER BY expires ASC";
+    const EXPIRED = "expires < :datetime ORDER BY expires ASC";
     const FAILED = "last_chunk_time < :date AND (status = 'created' OR status = 'started' OR status = 'uploading') ORDER BY expires ASC";
-    const AUDITLOG_EXPIRED = "expires < :date ORDER BY expires ASC";
+    const AUDITLOG_EXPIRED = "expires < :datetime ORDER BY expires ASC";
     const FROM_USER = "userid = :userid AND status='available' ORDER BY created DESC";
     const FROM_USER_CLOSED = "userid = :userid AND status='closed' ORDER BY created DESC";
     const FROM_GUEST = "guest_id = :guest_id AND status='available' ORDER BY created DESC";
@@ -353,7 +353,7 @@ class Transfer extends DBObject
     const FROM_IDP_NO_ORDER   = "idpid = :idp ";
     const FROM_IDP_UPLOADING = "status = 'uploading' and idpid = :idp ORDER BY created DESC";
     const FROM_IDP_AVAILABLE = "status = 'available' and idpid = :idp ORDER BY created DESC";
-    const FROM_IDP_EXPIRED   = "expires <= :date and idpid = :idp ORDER BY expires ASC";
+    const FROM_IDP_EXPIRED   = "expires < :datetime and idpid = :idp ORDER BY expires ASC";
 
     const ROUNDTRIPTOKEN_ENTROPY_BYTE_COUNT = 16;
     
@@ -796,7 +796,7 @@ class Transfer extends DBObject
     public static function allExpired( $idp = null )
     {
         if (!$idp) {
-            return self::all(self::EXPIRED, array(':date' => date('Y-m-d')));
+            return self::all(self::EXPIRED, array(':datetime' => date('Y-m-d H:i:s')));
         }
 
         return self::all(array(
@@ -804,7 +804,7 @@ class Transfer extends DBObject
                              'where' => self::FROM_IDP_EXPIRED
                          ),
                          array(':idp' => $idp,
-                               ':date' => date('Y-m-d')
+                               ':datetime' => date('Y-m-d H:i:s')
                          )
         );
     }
@@ -834,7 +834,7 @@ class Transfer extends DBObject
         if (is_null($days)) {
             $days = 0;
         }
-        return self::all(self::EXPIRED, array(':date' => date('Y-m-d', time() - ($days * 24 * 3600))));
+        return self::all(self::EXPIRED, array(':datetime' => date('Y-m-d H:i:s', time() - ($days * 24 * 3600))));
     }    
 
     /**

--- a/templates/guests_table.php
+++ b/templates/guests_table.php
@@ -48,7 +48,7 @@
             </td>
 
             <td class="expires" data-rel="expires" data-label="{tr:expiration}">
-                <?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires) ?>
+                <?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires, true) ?>
             </td>
 
             <td class="guest_transfers" data-label="{tr:guest_transfers}">

--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -74,7 +74,7 @@ if( $found ) {
                     <div class="fs-info fs-info--aligned">
                         <strong>{tr:expiration_date}:</strong>
                         <span>
-                            <?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires) ?>
+                            <?php echo $guest->getOption(GuestOptions::DOES_NOT_EXPIRE) ? Lang::tr('never') : Utilities::formatDate($guest->expires, true) ?>
                         </span>
                     </div>
                     <div class="fs-info fs-info--aligned">

--- a/www/js/new_invitation_page.js
+++ b/www/js/new_invitation_page.js
@@ -211,16 +211,19 @@ filesender.ui.send = function() {
     var options = {guest: {}, transfer: {}};
 
     var expires = 0;
-    
+    const now = new Date();
+
     if( filesender.config.ui_use_datepicker_for_guest_expire_time_selection ) {
-        expires = filesender.ui.nodes.expires.datepicker('getDate').getTime() / 1000;
+        // Set expiry to the current time-of-day on the selected date, so "select March 20"
+        // means "expires March 20 at the same time you created the invitation".
+        var expiresSelected = filesender.ui.nodes.expires.datepicker('getDate');
+        expiresSelected.setHours(now.getHours(), now.getMinutes(), now.getSeconds(), 0);
+        expires = expiresSelected.getTime() / 1000;
     } else {
         const expiresDays = $('#expires-select').find(":selected").val();
-        const now = new Date();
-        now.setHours(0, 0, 0, 0);
-        const expiresDate = now.setDate(now.getDate() + parseInt(expiresDays, 10));
-
-        expires = expiresDate / 1000;
+        const expiresDate = new Date(now);
+        expiresDate.setDate(expiresDate.getDate() + parseInt(expiresDays, 10));
+        expires = expiresDate.getTime() / 1000;
     }
     
     var from = null;

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1514,9 +1514,9 @@ filesender.ui.startUpload = function() {
         } else {
             const expiresDays = $('#expires-select').find(":selected").val();
             const now = new Date();
-            now.setHours(0, 0, 0, 0);
-            const expiresDate = now.setDate(now.getDate() + parseInt(expiresDays, 10));
-            this.transfer.expires = expiresDate / 1000;
+            const expiresDate = new Date(now);
+            expiresDate.setDate(expiresDate.getDate() + parseInt(expiresDays, 10));
+            this.transfer.expires = expiresDate.getTime() / 1000;
         }
 
         if(filesender.ui.nodes.from.length)


### PR DESCRIPTION
Same problem as https://github.com/filesender/filesender/pull/2624.

But this time for invitation expiration dates/hours.

As before, the time was always defaulted to 00:00.