### PR TITLE
Fix: hide archive download button while transfer is still uploading

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -60,7 +60,7 @@ if( !$found ) {
     return;
 }
 
-$canDownloadArchive = count($transfer->files) > 1;
+$canDownloadArchive = count($transfer->files) > 1 && $transfer->status == TransferStatuses::AVAILABLE;
 $canDownloadAsTar = true;
 $canDownloadAsZip = true;
 if($isEncrypted) {


### PR DESCRIPTION
Archive download button (zip/tar) was shown on the transfer detail page
whenever a transfer had more than 1 file, regardless of its status.
This allowed downloading an incomplete archive while files were still uploading.

Fixed by adding a status check: `$canDownloadArchive` is now only `true`
when `status == AVAILABLE`.