### PR TITLE
Efficiency: use stream_copy_to_stream to allow lower CPU/RAM use

### DIFF
--- a/classes/data/File.class.php
+++ b/classes/data/File.class.php
@@ -524,6 +524,37 @@ class File extends DBObject
     }
     
     /**
+     * Store a chunk from PUT input to an offset in the file
+     *
+     * @param int chunkSize the chunk data size
+     * @param int $offset the chunk offset in the file, if null appends at end of file
+     */
+    public function writeChunkDelayed($chunkSize, $offset = null)
+    {
+        if (!$this->upload_start) {
+            $this->upload_start = time();
+            $this->save();
+        }
+        
+        $res = Storage::writeChunkDelayed($this, $chunkSize, $offset);
+
+        // Update transfer's last chunk time so the cleanup cron can detect abandoned
+        // uploads vs active ones. Throttled to once per minute to avoid an extra
+        // UPDATE on every single chunk (default 5 MB chunks → thousands per large file).
+        // Since cleanup is measured in days, minute-level precision is more than enough.
+        if (!$this->transfer->last_chunk_time || (time() - $this->transfer->last_chunk_time) >= 60) {
+            $this->transfer->last_chunk_time = time();
+            $this->transfer->save();
+        }
+        
+        Logger::info($this.' chunk['.((int)$offset).'..'.((int)$offset + $chunkSize).'] written'.(Auth::isGuest() ? ' by '.AuthGuest::getGuest() : ''));
+        
+        return $res;
+    }
+
+    
+    
+    /**
      * End file upload
      */
     public function complete()

--- a/classes/rest/RestServer.class.php
+++ b/classes/rest/RestServer.class.php
@@ -108,7 +108,22 @@ class RestServer
             
             // Request data accessor
             $request = new RestRequest();
-            
+
+            if(Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
+                // do not try to read the input for a PUT to file chunks
+                // it will handle that itself.
+                if( $endpoint == "file"  ) {
+                    if( $method == "put" ) {
+                        if (array_key_exists('PATH_INFO', $_SERVER)) {
+                            if( strstr($_SERVER['PATH_INFO'], '/chunk/')) {
+                                Request::$delay_all_reading = true;
+                                Logger::debug("RestServer delaying reading any data for this specific request to later...");
+                            }
+                        }
+                    }
+                }
+            }
+
             // Because php://input can only be read once for PUT requests we rely on a shared getter
             $input = Request::body();
             

--- a/classes/rest/endpoints/RestEndpointFile.class.php
+++ b/classes/rest/endpoints/RestEndpointFile.class.php
@@ -328,6 +328,113 @@ class RestEndpointFile extends RestEndpoint
         }
     }
 
+    /**
+     *
+     * Helper method called by put() method only.
+     * 
+     * put() $mode == chunk might like to verify the chunk size twice.
+     * Firstly to make sure the client has not sent bogus data from
+     * the size they are claiming. Secondly, with this mildly verified
+     * client data size (not too large etc) the data is written to
+     * disk using that size claim. Then the written size is passed in
+     * with $szIsFromWrittenDataBytes true and a second verification
+     * is performed using the number of bytes stored on disk for the
+     * PUT.
+     *
+     * $sz is either the client claimed bytes to write or the number of bytes written
+     * $szIsFromWrittenDataBytes is true if bytes have been written and $sz is thus accurate.
+     * 
+     */
+    public function putSizeChecks( $id, $file, $client, $sz, $mode, $offset, $szIsFromWrittenDataBytes )
+    {
+        $data_length = $sz;
+
+        if ($file->transfer->options['encryption']) {
+
+            // Calculate the correct length
+            $chunkLength = $sz;
+
+            switch( $file->transfer->key_version ) {
+                case CryptoAppConstants::v2018_importKey_deriveKey:
+                case CryptoAppConstants::v2017_digest_importKey:
+                    // The encryption adds padding and a checksum
+                    $paddedLength = 16 - $client['X-Filesender-Chunk-Size'] % 16;
+                    if ($paddedLength == 0) {
+                        $paddedLength = 16;
+                    }
+                    // The initialization vector
+                    $ivLength = 16;
+                    // Content length
+                    $data_length = ($chunkLength - $paddedLength - $ivLength);
+                    break;
+                case CryptoAppConstants::v2019_gcm_importKey_deriveKey:
+                case CryptoAppConstants::v2019_gcm_digest_importKey:
+                    $data_length = $chunkLength - 32;
+                    break;
+            }
+        }
+
+        // Check that the client sent file size the same as the loaded file if given
+        if (!is_null($client['X-Filesender-File-Size'])) {
+            if ($file->size != $client['X-Filesender-File-Size']) {
+                throw new RestSanityCheckFailedException(
+                    'file_size',
+                    $file->size,
+                    $client['X-Filesender-File-Size'],
+                    $file,
+                    $client
+                );
+            }
+        }
+        
+        // Check that the offset from check data and the one in the url are the same if given
+        if (!is_null($client['X-Filesender-Chunk-Offset'])) {
+            if ($offset != $client['X-Filesender-Chunk-Offset']) {
+                throw new RestSanityCheckFailedException(
+                    'chunk_offset',
+                    $offset,
+                    $client['X-Filesender-Chunk-Offset'],
+                    $file,
+                    $client
+                );
+            }
+        }
+        
+        // Check that the sent data size is the one givent by the client
+        if (!is_null($client['X-Filesender-Chunk-Size'])) {
+            if ($data_length != $client['X-Filesender-Chunk-Size']) {
+                throw new RestSanityCheckFailedException(
+                    'chunk_size',
+                    $data_length,
+                    $client['X-Filesender-Chunk-Size'],
+                    $file,
+                    $client
+                );
+            }
+        }
+
+        // Check that data length does not exceed upload_chunk_size (can be smaller at the end of the file)
+        $upload_chunk_size = Config::get('upload_chunk_size');
+        $upload_crypted_chunk_size = Config::get('upload_crypted_chunk_size');
+
+        if ($data_length > $upload_chunk_size) {
+            if (($file->transfer->options['encryption'] && $data_length > $upload_crypted_chunk_size)) {
+                throw new RestSanityCheckFailedException(
+                    'chunk_size',
+                    $data_length,
+                    'max ' . Config::get('upload_chunk_size'),
+                    $file,
+                    $client
+                );
+            }
+        }
+
+        // Check that chunk offset is inside the file bounds
+        if ($offset + $data_length > $file->size) {
+            throw new FileChunkOutOfBoundsException($file, $offset, $data_length, $file->size);
+        }
+        
+    }
 
     /**
      * Add chunk to a file at offset
@@ -406,6 +513,8 @@ class RestEndpointFile extends RestEndpoint
 
         
         // Get request data
+        // if encryption_encode_encrypted_chunks_in_base64_during_upload is not set
+        // then this will set $data to the real PUT data.
         $data = $this->request->input;
 
         
@@ -426,109 +535,46 @@ class RestEndpointFile extends RestEndpoint
             
             // Get integrity check data sent from the client
             $client = array();
-            foreach (array('X-Filesender-File-Size', 'X-Filesender-Chunk-Offset', 'X-Filesender-Chunk-Size', 'X-Filesender-Encrypted') as $h) {
+            foreach (array('X-Filesender-File-Size', 'X-Filesender-Chunk-Offset', 'X-Filesender-Chunk-Size', 'X-Filesender-Encrypted', 'X-Filesender-Chunk-Size-Encrypted' ) as $h) {
                 $k = 'HTTP_' . strtoupper(str_replace('-', '_', $h));
                 $client[$h] = array_key_exists($k, $_SERVER) ? (int) $_SERVER[$k] : null;
             }
 
-            if ($file->transfer->options['encryption']) {
-
-                // get rid of the base64
-                if(Utilities::isTrue(Config::get('encryption_encode_encrypted_chunks_in_base64_during_upload'))) {
-                    $data = base64_decode($data);
-                }
-                // Calculate the correct length
-                $chunkLength = strlen($data);
-
-                switch( $file->transfer->key_version ) {
-                    case CryptoAppConstants::v2018_importKey_deriveKey:
-                    case CryptoAppConstants::v2017_digest_importKey:
-                        // The encryption adds padding and a checksum
-                        $paddedLength = 16 - $client['X-Filesender-Chunk-Size'] % 16;
-                        if ($paddedLength == 0) {
-                            $paddedLength = 16;
-                        }
-                        // The initialization vector
-                        $ivLength = 16;
-                        // Content length
-                        $data_length = ($chunkLength - $paddedLength - $ivLength);
-                        break;
-                    case CryptoAppConstants::v2019_gcm_importKey_deriveKey:
-                    case CryptoAppConstants::v2019_gcm_digest_importKey:
-                        $data_length = $chunkLength - 32;
-                        break;
-                }
-                
+            if(!Request::$delay_all_reading) {
+                $clientSaysSize = strlen($data);
             } else {
-                $data_length = strlen($data);
-            }
-            
-            // Check that the client sent file size the same as the loaded file if given
-            if (!is_null($client['X-Filesender-File-Size'])) {
-                if ($file->size != $client['X-Filesender-File-Size']) {
-                    throw new RestSanityCheckFailedException(
-                        'file_size',
-                        $file->size,
-                                                             $client['X-Filesender-File-Size'],
-                                                             $file,
-                        $client
-                    );
+                $clientSaysSize = $client['X-Filesender-Chunk-Size'];
+                if ($file->transfer->options['encryption']) {
+                    $clientSaysSize = $client['X-Filesender-Chunk-Size-Encrypted'];
                 }
             }
+            Logger::debug("File::PUT clientSaysSize $clientSaysSize ");
             
-            // Check that the offset from check data and the one in the url are the same if given
-            if (!is_null($client['X-Filesender-Chunk-Offset'])) {
-                if ($offset != $client['X-Filesender-Chunk-Offset']) {
-                    throw new RestSanityCheckFailedException(
-                        'chunk_offset',
-                        $offset,
-                                                             $client['X-Filesender-Chunk-Offset'],
-                                                             $file,
-                        $client
-                    );
-                }
-            }
-            
-            // Check that the sent data size is the one givent by the client
-            if (!is_null($client['X-Filesender-Chunk-Size'])) {
-                if ($data_length != $client['X-Filesender-Chunk-Size']) {
-                    throw new RestSanityCheckFailedException(
-                         'chunk_size',
-                         $data_length,
-                                                              $client['X-Filesender-Chunk-Size'],
-                                                              $file,
-                         $client
-                    );
-                }
-            }
+            $this->putSizeChecks( $id, $file, $client, $clientSaysSize, $mode, $offset, false );
 
-            // Check that data length does not exceed upload_chunk_size (can be smaller at the end of the file)
-            $upload_chunk_size = Config::get('upload_chunk_size');
-            $upload_crypted_chunk_size = Config::get('upload_crypted_chunk_size');
-
-            if ($data_length > $upload_chunk_size) {
-                if (($file->transfer->options['encryption'] && $data_length > $upload_crypted_chunk_size)) {
-                    throw new RestSanityCheckFailedException(
-                        'chunk_size',
-                        $data_length,
-                                                             'max ' . Config::get('upload_chunk_size'),
-                                                             $file,
-                        $client
-                    );
-                }
-            }
-
-            // Check that chunk offset is inside the file bounds
-            if ($offset + $data_length > $file->size) {
-                throw new FileChunkOutOfBoundsException($file, $offset, $data_length, $file->size);
-            }
-            
+            $original_offset = $offset;
             // Write data to file and calculate the offset with crypted size in mind
             if ($file->transfer->options['encryption']) {
                 $offset = $offset / Config::get('upload_chunk_size') * Config::get('upload_crypted_chunk_size');
             }
 
-            $write_info = $file->writeChunk($data, $offset);
+            Logger::debug("File::PUT offset $offset ");
+
+            //
+            // Do the writing
+            //
+            if(Config::isFalse('performance_allow_direct_copy_from_put_to_disk')) {
+                if(Utilities::isTrue(Config::get('encryption_encode_encrypted_chunks_in_base64_during_upload'))) {
+                    $data = base64_decode($data);
+                }
+                $write_info = $file->writeChunk( $data, $offset );
+            } else {
+                $write_info = $file->writeChunkDelayed($clientSaysSize, $offset);
+            }
+
+            // recheck the size of data
+            $this->putSizeChecks( $id, $file, $client, $write_info['written'], $mode, $original_offset, true );
+            
             $file->transfer->isUploading();
             
             return $write_info;

--- a/classes/storage/Storage.class.php
+++ b/classes/storage/Storage.class.php
@@ -210,6 +210,51 @@ class Storage
     }
     
     /**
+     * Delegates chunk write delayed if that method is implemented. Otherwise the data is slurped
+     * in from stdin just as in FileSender version late 2023 and before and then handled as an in memory
+     * blob of data.
+     *
+     * @param File $file
+     * @param uint $chunkSize is the number of bytes to expect on the PUT input
+     * @param uint $offset offset in bytes
+     *
+     * @return array with offset and written amount of bytes
+     *
+     * @throws StorageChunkTooLongException
+     */
+    public static function writeChunkDelayed(File $file, $chunkSize, $offset = null)
+    {
+        self::setup();
+        
+        // Forbid to write chunks whose size is over upload_chunk_size config parameter's value
+        if ($chunkSize > (int)Config::get('upload_crypted_chunk_size')) {
+            throw new StorageChunkTooLargeException(strlen($data), (int)Config::get('upload_chunk_size'));
+        }
+        
+        $bench = new Benchmark('writeChunk', 'benchmark_writeChunk');
+        $bench->start();
+
+        $data = '';
+        // Ask underlying class to write data
+        if( is_callable( self::getStorageClass($file).'::writeChunkDelayed' ))
+        {
+            $ret = call_user_func(self::getStorageClass($file).'::writeChunkDelayed', $file, $chunkSize, $offset);
+        }
+        else
+        {
+            // We only get called if performance_allow_direct_copy_from_put_to_disk is true
+            // so we can just slurp the data from stdin and
+            // use the old code path here.
+            Request::$delay_all_reading = false;
+            $data = @file_get_contents('php://input');
+            $ret = self::writeChunk( $file, $data, $offset );
+        }
+        $bench->log();
+        return $ret;
+    }
+    
+    
+    /**
      * Delegates file completion (delegation classes can implement it optionaly)
      *
      * @param File $file

--- a/classes/storage/StorageCloudS3.class.php
+++ b/classes/storage/StorageCloudS3.class.php
@@ -215,6 +215,46 @@ class StorageCloudS3 extends StorageFilesystem
         }
     }
 
+
+    public static function writeChunkDelayed(File $file, $chunkSize, $offset = null)
+    {
+        $chunk_size     = $chunkSize;
+
+        $bucket_name = self::getBucketName( $file );
+        $object_name = self::getObjectName( $file, $offset );
+        
+        try {
+            $client = self::getClient();
+
+            if( !self::usingCustomBucketName( $file )) {
+                $client->createBucket(array(
+                    'Bucket' => $bucket_name,
+                ));
+            }
+
+            $fromss = \fopen("php://input", 'r');
+            
+            $result = $client->putObject(array(
+                'Bucket' => $bucket_name,
+                'Key'    => $object_name,
+                'Body'   => $fromss,
+            ));
+            
+            return array(
+                'offset' => $offset,
+                'written' => $chunk_size
+            );
+        } catch (Exception $e) {
+            $msg = 'S3: writeChunk() Can not write to object_name: ' . $object_name . ' offset ' . $offset;
+            Logger::info($msg);
+            if (is_a($e, 'ConfigMissingParameterException')) {
+                Logger::error("NOTE: MISSING PARAMETER IN CONFIG FILE");
+                $msg .= "  NOTE: MISSING PARAMETER IN CONFIG FILE";
+            }
+            throw new StorageFilesystemCannotWriteException($msg);
+        }
+    }
+    
     /**
      * Handles file completion checks
      *

--- a/classes/storage/StorageFilesystem.class.php
+++ b/classes/storage/StorageFilesystem.class.php
@@ -555,6 +555,67 @@ class StorageFilesystem
             throw new StorageFilesystemCannotWriteException($file_path, $file);
         }
     }
+
+
+    /**
+     * Write a chunk of data to file at offset
+     *
+     * @param File $file
+     * @param uint $chunkSize is the number of bytes to expect on the PUT input
+     * @param uint $offset offset in bytes
+     *
+     * @return array with offset and written amount of bytes
+     *
+     * @throws StorageFilesystemOutOfSpaceException
+     * @throws StorageFilesystemCannotWriteException
+     */
+    public static function writeChunkDelayed(File $file, $chunkSize, $offset = null)
+    {
+        Logger::debug("StorageFilesystem::writeChunkDelayed");
+        
+        $path = static::buildPath($file);
+
+        // If the user is doing something with FUSE
+        // then they might not want to check disk space.
+        if (!Config::get('storage_filesystem_ignore_disk_full_check')) {
+	        // Check that there is enough free space on the storage
+	        $freeSpace = disk_free_space($path);
+	        if ($freeSpace <= $chunkSize) {
+	            throw new StorageNotEnoughSpaceLeftException($chunkSize);
+	        }
+        }
+
+        $file_path = $path.static::buildFilename($file);
+        
+        $mode = file_exists($file_path) ? 'rb+' : 'wb+'; // Create file if it does not exist
+        $fromss = \fopen("php://input", 'r');
+        if ($toss = fopen($file_path, $mode)) {
+
+            if( $offset == null ) {
+                $offset = 0;
+            }
+            // best to seek to the offset ourself and have copy_to_stream() use existing offsets
+            $rc = fseek( $toss, $offset, $whence = SEEK_SET);
+            if( $rc != 0 ) {
+                throw new ChunkWriteException('seek failed on destination file $offset');
+            }
+            $rc = \stream_copy_to_stream( $fromss, $toss, $chunkSize, 0 );
+            $written = $rc;
+
+            // Check that the right amount of data was written and move to next iteration if it fails
+            if ($chunkSize != $written) {
+                throw new ChunkWriteException('chunk_size != bytes written');
+            }
+            
+            return array(
+                'offset' => $offset,
+                'written' => $written
+            );
+        } else {
+            throw new StorageFilesystemCannotWriteException($file_path, $file);
+        }
+    }
+    
     
     /**
      * Handles file completion checks

--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -232,6 +232,86 @@ class StorageFilesystemChunked extends StorageFilesystem
         );
     }
 
+
+    /**
+     * Write a chunk of data to file at offset
+     *
+     * @param File $file
+     * @param uint $chunkSize is the number of bytes to expect on the PUT input
+     * @param uint $offset offset in bytes
+     *
+     * @return array with offset and written amount of bytes
+     *
+     * @throws StorageFilesystemOutOfSpaceException
+     * @throws StorageFilesystemCannotWriteException
+     */
+    public static function writeChunkDelayed(File $file, $chunkSize, $offset = null)
+    {
+        $filePath = self::buildPath($file).$file->uid;
+
+        // If the user is doing something with FUSE
+        // then they might not want to check disk space.
+        if (!Config::get('storage_filesystem_ignore_disk_full_check')) {
+	        // Check that there is enough free space on the storage
+	        $freeSpace = disk_free_space(self::$path);
+	        if ($freeSpace <= $chunkSize) {
+	            throw new StorageNotEnoughSpaceLeftException($chunkSize);
+	        }
+        }
+
+        if (self::file_exists($filePath) === false) {
+            mkdir($filePath, 0770, true);
+        }
+
+        $chunkFile = self::getChunkFilename($file, $filePath, $offset);
+        $validUpload = false;
+
+
+        $data = '';
+        
+        $fromss = \fopen("php://input", 'r');
+        $toss   = \fopen($chunkFile, 'wb' );
+        $rc = \stream_copy_to_stream( $fromss, $toss, $chunkSize );
+        $written = $rc;
+        Logger::debug("AAA writeChunkDelayed to file $chunkFile chunkSize $chunkSize rc $rc ");
+
+        // Check that the right amount of data was written and move to next iteration if it fails
+        if ($chunkSize != $written) {
+            throw new ChunkWriteException('chunk_size != bytes written');
+        }
+
+        // Clear cached values and check the chunk file now exists, otherwise we retry from the beginning
+        if (!self::file_exists($chunkFile)) {
+            throw new ChunkWriteException('file does not exist after write');
+        }
+
+        // Check file size
+        if ($chunkSize != self::filesize($chunkFile)) {
+            throw new ChunkWriteException('chunk_size != filesize()');
+        }
+
+        if (Config::isTrue('storage_filesystem_hash_check')) {
+            $clientHash = Validate::filter_var_sha256("client hash sha256",$_SERVER['HTTP_X_FILESENDER_DIGEST_SHA256']);
+            $fileHash = self::hash_file('sha256', $chunkFile);
+            if ($fileHash !== $clientHash) {
+                throw new ChunkWriteException('checksum validation failed');
+            }
+        }
+        
+        $validUpload = true;
+
+        // Don't reach the end if the chunk is invalid.
+        if( !$validUpload ) {
+            Logger::error("writeChunk() failed: {$chunkFile} was an invalid upload");
+            throw new StorageFilesystemCannotWriteException($filePath, $file, $data, $offset, $written);
+        }
+        
+        return array(
+            'offset' => $offset,
+            'written' => $written
+        );
+    }
+    
     /**
      * Helper method for file_get_contents()
      * @param resource $handle

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -470,7 +470,7 @@ class Config
 
         if(Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
             $st = self::$parameters['storage_type'];
-            if( !in_array( $st, ['filesystemChunked', 'filesystem'] )) {
+            if( !in_array( $st, ['filesystemChunked', 'filesystem', 'CloudS3'] )) {
                 self::$parameters['performance_allow_direct_copy_from_put_to_disk'] = false;
             }
         }

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -474,6 +474,13 @@ class Config
                 self::$parameters['performance_allow_direct_copy_from_put_to_disk'] = false;
             }
         }
+        if (Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
+            // python client
+            if (array_key_exists('signature', $_GET)) {
+                self::$parameters['performance_allow_direct_copy_from_put_to_disk'] = false;
+            }
+        }
+        
         
         // verify classes are happy
         Guest::validateConfig();

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -370,6 +370,15 @@ class Config
                                                         + self::get('upload_crypted_chunk_padding_size');
         
 
+        if(Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
+            if(Config::isTrue('encryption_encode_encrypted_chunks_in_base64_during_upload')) {
+                throw new ConfigBadParameterException(
+                    "You can not use this older compatability option "
+                  . " (encryption_encode_encrypted_chunks_in_base64_during_upload)"
+                  . " with (performance_allow_direct_copy_from_put_to_disk). "
+                  . " You might like to investigate not using encrypted_chunks_in_base64 as it is very old and inefficient.");
+            }
+        }
         
 
         $themeName = self::get('theme');
@@ -449,6 +458,13 @@ class Config
                   + self::$parameters['auditlog_must_be_n_days_longer_than_max_transfer_days_valid'];
             if( self::$parameters['auditlog_lifetime'] < $minv ) {
                 self::$parameters['auditlog_lifetime'] = $minv;
+            }
+        }
+
+        self::$parameters['client_calculate_sha256'] = false;
+        if (Config::isTrue('storage_filesystem_hash_check')) {
+            if(Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
+                self::$parameters['client_calculate_sha256'] = true;
             }
         }
         
@@ -649,6 +665,10 @@ class Config
     public static function isTrue($key)
     {
         return(Utilities::isTrue(Config::get($key)));
+    }
+    public static function isFalse($key)
+    {
+        return !self::isTrue($key);
     }
 
     

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -467,6 +467,13 @@ class Config
                 self::$parameters['client_calculate_sha256'] = true;
             }
         }
+
+        if(Config::isTrue('performance_allow_direct_copy_from_put_to_disk')) {
+            $st = self::$parameters['storage_type'];
+            if( !in_array( $st, ['filesystemChunked', 'filesystem'] )) {
+                self::$parameters['performance_allow_direct_copy_from_put_to_disk'] = false;
+            }
+        }
         
         // verify classes are happy
         Guest::validateConfig();

--- a/classes/utils/Request.class.php
+++ b/classes/utils/Request.class.php
@@ -30,6 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
 // Require environment (fatal)
 if (!defined('FILESENDER_BASE')) {
     die('Missing environment');
@@ -46,6 +47,8 @@ class Request
      * Holds the body
      */
     private static $body = null;
+
+    public static $delay_all_reading = false;
     
     /**
      * Get the body
@@ -53,9 +56,17 @@ class Request
     public static function body()
     {
         if (is_null(self::$body)) {
-            self::$body = @file_get_contents('php://input');
+
+            if( self::$delay_all_reading )
+            {
+                return '';
+            }
+            else
+            {
+                self::$body = @file_get_contents('php://input');
+            }
         }
-        
+
         return self::$body;
     }
 }

--- a/classes/utils/Validate.class.php
+++ b/classes/utils/Validate.class.php
@@ -134,5 +134,14 @@ class Validate
             '/^[-a-z]{1,12}$/'  );
         return $ret;
     }
+
+
+    public static function filter_var_sha256( $msg, $value )
+    {
+        $ret = Validate::filter_var_regex_log(
+            $msg, $value,
+            '/^[a-f0-9]{64}$/'  );
+        return $ret;
+    }
     
 }

--- a/docs/v3.0/admin/configuration/index.md
+++ b/docs/v3.0/admin/configuration/index.md
@@ -95,6 +95,7 @@ A note about colours;
 * [cloud_s3_bucket_prefix](#cloud_s3_bucket_prefix)
 * [cloud_s3_bulk_delete](#cloud_s3_bulk_delete)
 * [cloud_s3_bulk_size](#cloud_s3_bulk_size)
+* [performance_allow_direct_copy_from_put_to_disk](#performance_allow_direct_copy_from_put_to_disk)
 
 ## Shredding
 
@@ -1156,6 +1157,17 @@ deleting up to [cloud_s3_bulk_size](#cloud_s3_bulk_size) chunks per request.
 * __available:__ since version 2.45
 * __comment:__ When [cloud_s3_bulk_delete](#cloud_s3_bulk_delete) is true, this is the maximum size of the delete request.
 Default value to maintain AWS S3 compatibility is 1000. Other storage platforms may use different defaults. OpenStack Swift defaults to 10000, for instance
+
+### performance_allow_direct_copy_from_put_to_disk
+
+* __description:__ Where possible delay reading file PUT data and attempt direct in kernel copy
+* __mandatory:__ no.
+* __type:__ boolean
+* __default:__ true
+* __available:__ since version 3.8
+* __comment:__ Supported only in storage_type filesystemChunked and filesystem as of 3.8. Users of the filesender.py client will be demoted to not using direct copy because of how authorization works for the client.
+               When true this will delay reading bytes in a very specific cases which is uploading file data. By not reading the data until the destination we wish to write those bytes we can allow the opportunity to have the Linux kernel copy the bytes inside the kernel by letting PHP use copy_file_range(2) to avoid memory allocation and extraneous data copying. This significantly reduces CPU use and increases upload speed even on a local installation. See https://github.com/filesender/filesender/pull/2640
+
 
 
 ---

--- a/includes/ConfigDefaults.php
+++ b/includes/ConfigDefaults.php
@@ -425,7 +425,8 @@ $default = array(
     'advanced_validation_token' => true,
     'advanced_validation_user' => true,
     'advanced_validation_principal' => true,
-    
+
+    'performance_allow_direct_copy_from_put_to_disk' => true,
     
     'template_config_values_that_can_be_read_in_templates' => array(
         'default_guest_days_valid',

--- a/www/filesender-config.js.php
+++ b/www/filesender-config.js.php
@@ -218,6 +218,9 @@ $vfregex = str_replace('\\', '\\\\', $vfregex);
     auth_warn_session_expired: <?php echo value_to_TF(Config::get('auth_warn_session_expired')) ?>,
 
     openpgp_enabled: <?php echo value_to_TF(Config::get('openpgp_enabled')) ?>,
+
+    client_calculate_sha256: <?php echo value_to_TF(Config::get('client_calculate_sha256'))  ?>,
+
 };
 
 <?php if(Config::get('force_legacy_mode')) { ?>

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -470,7 +470,7 @@ window.filesender.client = {
      * @param callable done
      * @param callable error
      */
-    putChunk: function(file, blob, offset, progress, done, error, encrypted, encryption_details ) {
+    putChunk: async function(file, blob, offset, progress, done, error, encrypted, encryption_details ) {
         var sz = blob.size;
         if( typeof blob == "string" ) {
             sz = blob.length;
@@ -516,7 +516,19 @@ window.filesender.client = {
                         arrayBuffer,
                         chunkid,
                         encryption_details,
-                        function(encrypted_blob) {
+                        async function(encrypted_blob) {
+
+                            var contentHash = '';
+                            var hashArray = '';
+                            var hashHex = '';
+                            if(window.filesender.config.client_calculate_sha256) {
+                                contentHash = await crypto.subtle.digest('SHA-256', encrypted_blob );
+                                hashArray = Array.from(new Uint8Array(contentHash));
+                                hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+                            }
+                            opts.headers['X-Filesender-Digest-SHA256'] = hashHex;
+                            
+                            opts.headers['X-Filesender-Chunk-Size-Encrypted'] = encrypted_blob.length;
                             var result = $this.put(
                                 file.transfer.authenticatedEndpoint(
                                     '/file/' + file.id + '/chunk/' + offset,
@@ -526,7 +538,21 @@ window.filesender.client = {
                 }
             );
         }else{
-            var result = $this.put(file.transfer.authenticatedEndpoint('/file/' + file.id + '/chunk/' + offset, file), blob, done, opts);
+            
+            var contentHash = '';
+            var hashArray = '';
+            var hashHex = '';
+            if(window.filesender.config.client_calculate_sha256) {
+                var ab = await blob.arrayBuffer();
+                contentHash = await crypto.subtle.digest('SHA-256', ab);
+                hashArray = Array.from(new Uint8Array(contentHash));
+                hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+                blob = ab;
+            }
+            opts.headers['X-Filesender-Digest-SHA256'] = hashHex;
+            
+            var result = $this.put(file.transfer.authenticatedEndpoint('/file/' + file.id + '/chunk/' + offset, file),
+                                   blob, done, opts);
         }
         
         if(error) opts.error = error;

--- a/www/js/terasender/terasender_worker.js
+++ b/www/js/terasender/terasender_worker.js
@@ -106,7 +106,7 @@ var terasender_worker = {
      * 
      * @param object job job to execute
      */
-    executeJob: function(job) {
+    executeJob: async function(job) {
 
         if(job) {
             var worker = this;
@@ -344,6 +344,19 @@ var terasender_worker = {
         try {
 
 	    if (!job.encryption) {
+
+                var contentHash = '';
+                var hashArray = '';
+                var hashHex = '';
+                if(window.filesender.config.client_calculate_sha256) {
+                    var ab = await blob.arrayBuffer();
+                    contentHash = await crypto.subtle.digest('SHA-256', ab);
+                    hashArray = Array.from(new Uint8Array(contentHash));
+                    hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+                    blob = ab;
+                }
+
+                xhr.setRequestHeader('X-Filesender-Digest-SHA256', hashHex );
                 xhr.send(blob);
 	    } else {
 		var cryptedBlob = null;
@@ -356,9 +369,21 @@ var terasender_worker = {
                         arrayBuffer,
                         job.chunk.id,
                         job.encryption_details,
-                        function (encrypted_blob) {
+                        async function (encrypted_blob) {
+
+                            var contentHash = '';
+                            var hashArray = '';
+                            var hashHex = '';
+                            if(window.filesender.config.client_calculate_sha256) {
+                                contentHash = await crypto.subtle.digest('SHA-256', encrypted_blob);
+                                hashArray = Array.from(new Uint8Array(contentHash));
+                                hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+                            }
 			    xhr.setRequestHeader('X-Filesender-Encrypted', '1');
-			    xhr.send(encrypted_blob);
+                            xhr.setRequestHeader('X-Filesender-Chunk-Size-Encrypted', encrypted_blob.length);
+                            xhr.setRequestHeader('X-Filesender-Digest-SHA256', hashHex );
+                            xhr.send(encrypted_blob);
+                            
 			},
                         function (e) { $this.error(e); } );
                 });
@@ -505,6 +530,7 @@ var terasender_worker = {
             return;
             
         }else{ // We have an error
+            console.log(xhr);
             var msg = window.filesender.client.xhrResponse( xhr );
             
             try {


### PR DESCRIPTION
This PR makes the main code path that is used to write data to disk in the server code more efficient in terms of CPU and memory use.

This update will delay reading bytes in a very specific case which is uploading file data. By not reading the data until the destination we wish to write those bytes we can allow the opportunity to have the Linux kernel copy the bytes inside the kernel by letting PHP use `copy_file_range(2)` to avoid memory allocation and extraneous data copying. This significantly reduces CPU use and increases upload speed even on a local installation.

For local testing I was using CentOS-6.10-x86_64-bin-DVD1.iso which is about 3.8 gb. For a non encrypted upload I saw wall times going from 27 to 20 seconds. For encrypted upload from 34 seconds down to 28 seconds. As one would expect with end-to-end encryption, the encryption does not effect the server load and an even 7-8 seconds for encryption added to both wall times.

I think this is significant as the time being spent between this two code paths is being used to allocate buffers and copy data from kernel to user space and into php memory only to be copied back to the kernel again to write to disk.

In the existing code, during an upload, the chunk data is sent to a PUT REST endpoint which then passes that to the selected "storage" back end in FileSender. The data is made available to php on stdin.

The existing FileSender code reads all the data for an HTTP request into memory at `RestServer::process()` time with a call to `Request::body()`. For a default 5mb chunk size this cases memory allocation of 5mb and data to be copied into that buffer.

For a concrete example the data may be eventually passed to `StorageFilesystemChunked::writeChunk()` which takes the data to save as a method parameter and uses the size of that data as how much data to write to disk.

This PR delays reading input data to the last moment possible. The update in this PR takes the expected size of the chunk from the client and does not read the data into PHP memory at all. The data is indirectly passed to `stream_copy_to_stream` from "php://input" along with the file descriptor to write that data into. This should give `stream_copy_to_stream` the chance to directly use the `copy_file_range(2)` call to copy that data directly in-kernel without needing to allocate or copy data to the user address space at all.

See for example:
https://github.com/php/php-src/blob/00c0a9ba308c899e08a6e959b669092b9b976b1b/main/streams/streams.c#L1680

Apart from code restructuring to make this possible there are some other effects to this change. We are relying on the client to report how large the data to write is going to be. We can check that that reported size is below the expected chunk size but can not know exactly how much data has been supplied until after the PHP `stream_copy_to_stream` call has returned. That function tells the caller how much data was actually written. So we must do the size validation a few times, the first time using the client supplied "size" information and the second time using the actual size of the data provided.

A specific issue with the StorageFilesystemChunked implementation is that `verifyChecksum` can not work as it stands. The current implementation of `verifyChecksum` expects to have the entire chunk passed as an in memory data buffer to verify the written data. This has resulted in an update to optionally have the client calculate the sha256 if we want to have both storage_filesystem_hash_check and performance_allow_direct_copy_from_put_to_disk set. That will result in a performance hit for the clients using this combination but the checksums can still be verified on the server on a per chunk basis.