### PR TITLE
Add the hour +59m59s of same day to getMaxExpire()

### DIFF
--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -702,7 +702,7 @@ class Transfer extends DBObject
             $days = Config::get('default_daysvalid');
         } // @deprecated legacy
         
-        return strtotime('+'.$days.' day');
+        return strtotime('+'.date('G').' hour', strtotime('+'.$days.' day'))+3599;
     }
     
     /**

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -703,7 +703,7 @@ class Transfer extends DBObject
         } // @deprecated legacy
 
         if (!empty($_COOKIE['x-filesender-timezone'])) {
-            return strtotime('+'.$days.' day') + (new Utilities)->getTimezoneOffset($_COOKIE['x-filesender-timezone']);
+            return strtotime('+'.$days.' day') + Utilities::getTimezoneOffset($_COOKIE['x-filesender-timezone']);
         }
         return strtotime('+'.$days.' day');
     }

--- a/classes/data/Transfer.class.php
+++ b/classes/data/Transfer.class.php
@@ -701,8 +701,11 @@ class Transfer extends DBObject
         if (!$days) {
             $days = Config::get('default_daysvalid');
         } // @deprecated legacy
-        
-        return strtotime('+'.date('G').' hour', strtotime('+'.$days.' day'))+3599;
+
+        if (!empty($_COOKIE['x-filesender-timezone'])) {
+            return strtotime('+'.$days.' day') + (new Utilities)->getTimezoneOffset($_COOKIE['x-filesender-timezone']);
+        }
+        return strtotime('+'.$days.' day');
     }
     
     /**

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -208,7 +208,7 @@ class Utilities
      *
      * @return int offset in seconds
      */
-    function getTimezoneOffset($custom_timezone_string) {
+    public static function getTimezoneOffset($custom_timezone_string) {
         $server_tz = new DateTimeZone(Config::get('default_timezone'));
         $custom_tz = new DateTimeZone($custom_timezone_string);
         $datetime = new DateTime("now", $server_tz);

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -201,7 +201,22 @@ class Utilities
         return preg_match('/' .  Config::get('valid_filename_regex') . '$/u', $filename);
     }
 
-    
+    /**
+     * Get timezone offset
+     *
+     * @param string $custom_timezone_string the timezone you want to convert from
+     *
+     * @return int offset in seconds
+     */
+    function getTimezoneOffset($custom_timezone_string) {
+        $server_tz = new DateTimeZone(Config::get('default_timezone'));
+        $custom_tz = new DateTimeZone($custom_timezone_string);
+        $datetime = new DateTime("now", $server_tz);
+        $server_offset = $server_tz->getOffset($datetime);
+        $custom_offset = $custom_tz->getOffset($datetime);
+        $offset_difference = $custom_offset - $server_offset;
+        return $offset_difference;
+    }
     
     /**
      * Format a date according to configuration


### PR DESCRIPTION
Since adding the hour to expire date, when picking the maximum day from the datepicker causes a BadExpireException because getMaxExpire() returns the unix time for the day only.

This change fixes this, but please double check the logic.