### PR TITLE
Fix Guest::getMaxExpire() to consider user timezone offset

### DIFF
--- a/classes/data/Guest.class.php
+++ b/classes/data/Guest.class.php
@@ -355,10 +355,13 @@ class Guest extends DBObject
         if (!$days) {
             $days = Config::get('default_daysvalid');
         } // @deprecated legacy
-        
+
+        if (!empty($_COOKIE['x-filesender-timezone'])) {
+            return strtotime('+'.$days.' day') + Utilities::getTimezoneOffset($_COOKIE['x-filesender-timezone']);
+        }
         return strtotime('+'.$days.' day');
     }
-    
+
     /**
      * Get available guests
      *


### PR DESCRIPTION
# Bug: Guest::getMaxExpire() does not consider user timezone

## Context

PR [filesender/filesender#2645](https://github.com/filesender/filesender/pull/2645) fixed a `BadExpireException` that occurred when `client_send_current_timezone_to_server = true` and the user was in a timezone with a large offset from the server (e.g. UTC+10 with a UTC server).

The fix was applied to `Transfer::getMaxExpire()` (`classes/data/Transfer.class.php`, line 703), which now adds the user's timezone offset when calculating the maximum allowed expiry.

## Pending issue

There is a second `Guest::getMaxExpire()` function in `classes/data/Guest.class.php` (line 348) that **was not included in the fix** and still calculates the maximum without considering the user's timezone:

```php
public static function getMaxExpire()
{
    $days = Config::get('max_guest_days_valid');
    if (!$days) {
        $days = Config::get('max_transfer_days_valid');
    }
    if (!$days) {
        $days = Config::get('default_daysvalid');
    }
    return strtotime('+'.$days.' day');  // Does not consider user timezone
}
```

This function is used to validate invitation (guest) expiry. The same bug can be reproduced when creating or editing an invitation and selecting the maximum date in the datepicker, if the following conditions are met:

1. `client_send_current_timezone_to_server = true`
2. The user is in a timezone significantly ahead of the server (e.g. UTC+10)

## Expected fix

Apply the same pattern used in `Transfer::getMaxExpire()`:

```php
if (!empty($_COOKIE['x-filesender-timezone'])) {
    return strtotime('+'.$days.' day') + Utilities::getTimezoneOffset($_COOKIE['x-filesender-timezone']);
}
return strtotime('+'.$days.' day');
```
