### PR TITLE
lack of support for i18n

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -351,7 +351,7 @@ if(empty($transfer->options['encryption'])) {
             <div class="row">
                 <div class="col">
                     <div class="fs-transfer-detail__recipients">
-                        <h2>Recipients</h2>
+                        <h2>{tr:recipients}</h2>
 
                         <div class="fs-transfer__upload-recipients fs-transfer__upload-recipients--show">
                             <span>
@@ -402,7 +402,7 @@ if(empty($transfer->options['encryption'])) {
 
                             <button id="copy-to-clipboard" type="button" class="fs-button">
                                 <i class="fa fa-copy"></i>
-                                Copy
+                                {tr:copy}
                             </button>
                         </div>
                     </div>

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -750,7 +750,7 @@ EOF;
                             <div class="fs-transfer__transfer-settings <?php if(!$show_get_a_link_or_email_choice) { echo 'fs-transfer__transfer-settings--show'; } ?>">
                                 <hr />
 
-                                <strong>Transfer settings</strong>
+                                <strong>{tr:transfer_settings}</strong>
 
                                 <?php render_forward_to_another_server(); ?>
 


### PR DESCRIPTION
Some of the text on the user screen is not internationalized.

* transfer_detail_page.php
    * label: `Recipients`
    * button: `Copy`
* templates/upload_page.php
    * label: `Transfer settings`