### PR TITLE
auditlog when recipients are added

### DIFF
--- a/classes/constants/LogEventTypes.class.php
+++ b/classes/constants/LogEventTypes.class.php
@@ -70,13 +70,14 @@ class LogEventTypes extends Enum
 
    
    /* TRANSFER */
-    const TRANSFER_STARTED         = 'transfer_started';         // Transfer started
-   const TRANSFER_AVAILABLE       = 'transfer_available';     // Transfer started
-   const TRANSFER_SENT            = 'transfer_sent';     // Transfer started
+    const TRANSFER_STARTED         = 'transfer_started';      // Transfer started
+   const TRANSFER_AVAILABLE       = 'transfer_available';     // Transfer available
+   const TRANSFER_SENT            = 'transfer_sent';          // Transfer sent
    const TRANSFER_EXPIRED         = 'transfer_expired';       // Transfer expired
    const TRANSFER_CLOSED          = 'transfer_closed';        // Transfer closed
    const TRANSFER_DELETED         = 'transfer_deleted';       // Transfer deleted
    const TRANSFER_DECRYPT_FAILED  = 'transfer_decrypt_failed';// Transfer decrypt failed at client
+   const TRANSFER_ADDED_RECIPIENT = 'transfer_added_recipient';// Transfer added recipient
    
    /* UPLOAD */
     const UPLOAD_STARTED           = 'upload_started';   // Upload stated

--- a/classes/rest/endpoints/RestEndpointTransfer.class.php
+++ b/classes/rest/endpoints/RestEndpointTransfer.class.php
@@ -522,6 +522,7 @@ class RestEndpointTransfer extends RestEndpoint
                     // Send email if transfer is live already
                     if ($transfer->status == TransferStatuses::AVAILABLE) {
                         TranslatableEmail::quickSend('transfer_available', $recipient, $transfer);
+                        Logger::logActivity(LogEventTypes::TRANSFER_ADDED_RECIPIENT, $transfer, $recipient);
                     }
                 }
                 

--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -556,6 +556,7 @@ $lang['report_event_file_forwarded'] = 'File {file.path} ({size:file.size}) forw
 $lang['report_event_file_uploaded'] = 'File {file.path} ({size:file.size}) uploaded (took {time:time_taken})';
 $lang['report_event_forward_ended'] = 'Forward another server ended';
 $lang['report_event_forward_started'] = 'Forward another server started';
+$lang['report_event_transfer_added_recipient'] = 'Download link sent to added recipient {author.identity}';
 $lang['report_event_transfer_available'] = 'Transfer became available (took {time:time_taken})';
 $lang['report_event_transfer_closed'] = 'Transfer was closed on request';
 $lang['report_event_transfer_decrypt_failed'] = 'Decryption failed';

--- a/language/ja_JP/lang.php
+++ b/language/ja_JP/lang.php
@@ -554,6 +554,7 @@ $lang['report_event_file_forwarded'] = 'ファイル{file.path}({size:file.size}
 $lang['report_event_file_uploaded'] = 'ファイル{file.path}({size:file.size})がアップロードされました({time:time_taken} かかりました)';
 $lang['report_event_forward_ended'] = '他サーバーへの転送が終了';
 $lang['report_event_forward_started'] = '他サーバーへの転送が開始';
+$lang['report_event_transfer_added_recipient'] = '追加された受信者{author.identity}にダウンロードリンクが送信されました';
 $lang['report_event_transfer_available'] = '転送が利用可能になりました({time:time_taken}かかりました)';
 $lang['report_event_transfer_closed'] = '転送はリクエストにより閉鎖されました';
 $lang['report_event_transfer_decrypt_failed'] = '復号に失敗しました';


### PR DESCRIPTION
When recipients are added to a transfer, it is not recorded in the audit log.

I'm not sure what FileSender's policy is regarding what should be recorded in the audit log, but our user has requested that it be recorded when a recipient is added to a transfer.
And I'm not sure how to add new text to POEditor, too.