### PR TITLE
Fix expiry message shown when guest invite has no expiration

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -370,8 +370,11 @@ use ( $new_guests_can_only_send_to_creator,
                             </div>
                         </div>
                         <br />
-                        <p>
+                        <p id="expires-info">
                             {tr:invitation_expires_in} <span id="expires-days">7</span> {tr:days}.
+                        </p>
+                        <p id="no-expiry-info" style="display:none;">
+                            {tr:does_not_expire}.
                         </p>
                         <br />
                         <ul class="fs-list fs-list--inline">

--- a/www/js/new_invitation_page.js
+++ b/www/js/new_invitation_page.js
@@ -262,13 +262,20 @@ filesender.ui.send = function() {
                 });
             }
 
-            const expireDays = new Date(expires * 1000);
-            const now = new Date();
-            now.setHours(0, 0, 0, 0);
-            const dateDiff = expireDays.getTime() - now.getTime();
-            const daysToExpire = Math.ceil(dateDiff / (1000 * 3600 * 24));
+            if (filesender.ui.nodes.does_not_expire.is(':checked')) {
+                $('#expires-info').hide();
+                $('#no-expiry-info').show();
+            } else {
+                const expireDays = new Date(expires * 1000);
+                const now = new Date();
+                now.setHours(0, 0, 0, 0);
+                const dateDiff = expireDays.getTime() - now.getTime();
+                const daysToExpire = Math.ceil(dateDiff / (1000 * 3600 * 24));
 
-            $('#expires-days').text(daysToExpire);
+                $('#expires-days').text(daysToExpire);
+                $('#expires-info').show();
+                $('#no-expiry-info').hide();
+            }
 
             filesender.ui.notify('success', lang.tr('guest_vouchers_sent').r({sent: sent}), function() {
                 // filesender.ui.reload();


### PR DESCRIPTION
When creating a guest invitation with the "does not expire" option, the result screen incorrectly displayed "The invitation expires in X days." instead of showing the no-expiry message.