### PR TITLE
Fix Turkish mail templates subject header key

### DIFF
--- a/language/tr_TR/bounce_report.mail.php
+++ b/language/tr_TR/bounce_report.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: İleti teslim hatası
+subject: İleti teslim hatası
 
 {alternative:plain}
 

--- a/language/tr_TR/daily_summary.mail.php
+++ b/language/tr_TR/daily_summary.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Günlük aktarım özeti
+subject: Günlük aktarım özeti
 
 {alternative:plain}
 

--- a/language/tr_TR/download_complete.mail.php
+++ b/language/tr_TR/download_complete.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: İndirme tamamlandı
+subject: İndirme tamamlandı
 
 {alternative:plain}
 

--- a/language/tr_TR/email_feedback.mail.php
+++ b/language/tr_TR/email_feedback.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: {if:target_type=="recipient"}recipient{endif}{if:target_type=="guest"}guest{endif}#{target_id} {target.email} geri bildirim
+subject: {if:target_type=="recipient"}recipient{endif}{if:target_type=="guest"}guest{endif}#{target_id} {target.email} geri bildirim
 
 {alternative:plain}
 

--- a/language/tr_TR/file_deleted.mail.php
+++ b/language/tr_TR/file_deleted.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Dosya artık indirilmek için mevcut değil
+subject: Dosya artık indirilmek için mevcut değil
 
 {alternative:plain}
 

--- a/language/tr_TR/files_downloaded.mail.php
+++ b/language/tr_TR/files_downloaded.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: İndirme bilgisi
+subject: İndirme bilgisi
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_access_upload_page.mail.php
+++ b/language/tr_TR/guest_access_upload_page.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuğun yükleme sayfasına erişimi
+subject: Konuğun yükleme sayfasına erişimi
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_cancelled.mail.php
+++ b/language/tr_TR/guest_cancelled.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuk fişi iptal edildi
+subject: Konuk fişi iptal edildi
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_created.mail.php
+++ b/language/tr_TR/guest_created.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: Konuk fişi alındı                                                                                  
-konu: {guest.subject}
+subject: Konuk fişi alındı                                                                                  
+subject: {guest.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_created_receipt.mail.php
+++ b/language/tr_TR/guest_created_receipt.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuk fişi gönderildi
+subject: Konuk fişi gönderildi
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_reminder.mail.php
+++ b/language/tr_TR/guest_reminder.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: (hatırlatıcı) konuk fişi alındı
-konu: (hatırlatıcı) {guest.subject}
+subject: (hatırlatıcı) konuk fişi alındı
+subject: (hatırlatıcı) {guest.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_upload_complete.mail.php
+++ b/language/tr_TR/guest_upload_complete.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuk dosyaları yüklemeyi tamamladı
+subject: Konuk dosyaları yüklemeyi tamamladı
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_upload_complete_confirmation_to_guest.mail.php
+++ b/language/tr_TR/guest_upload_complete_confirmation_to_guest.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuk dosyaları yüklemeyi tamamladı
+subject: Konuk dosyaları yüklemeyi tamamladı
 
 {alternative:plain}
 

--- a/language/tr_TR/guest_upload_start.mail.php
+++ b/language/tr_TR/guest_upload_start.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Konuk dosyaları yüklemeye başladı
+subject: Konuk dosyaları yüklemeye başladı
 
 {alternative:plain}
 

--- a/language/tr_TR/local_authdb_password_reminder.mail.php
+++ b/language/tr_TR/local_authdb_password_reminder.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu:  {cfg:site_name} kullanım davetiyesi
+subject:  {cfg:site_name} kullanım davetiyesi
 
 {alternative:plain}
 

--- a/language/tr_TR/recipient_deleted.mail.php
+++ b/language/tr_TR/recipient_deleted.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: İndirme izni kaldırıldı
+subject: İndirme izni kaldırıldı
 
 {alternative:plain}
 

--- a/language/tr_TR/recipient_feedback.mail.php
+++ b/language/tr_TR/recipient_feedback.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Alıcınızdan {if:target_type=="recipient"}geri bildirim{endif}{if:target_type=="guest"}guest{endif} {target.email}
+subject: Alıcınızdan {if:target_type=="recipient"}geri bildirim{endif}{if:target_type=="guest"}guest{endif} {target.email}
 
 {alternative:plain}
 

--- a/language/tr_TR/report_attached.mail.php
+++ b/language/tr_TR/report_attached.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: {target.type} #{target.id} hakkında rapor
+subject: {target.type} #{target.id} hakkında rapor
 
 {alternative:plain}
 

--- a/language/tr_TR/report_inline.mail.php
+++ b/language/tr_TR/report_inline.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: {target.type} #{target.id} hakkında rapor
+subject: {target.type} #{target.id} hakkında rapor
 
 {alternative:plain}
 

--- a/language/tr_TR/storage_usage_warning.mail.php
+++ b/language/tr_TR/storage_usage_warning.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Depolama kullanımı uyarısı
+subject: Depolama kullanımı uyarısı
 
 {alternative:plain}
 

--- a/language/tr_TR/transfer_autoreminder_receipt.mail.php
+++ b/language/tr_TR/transfer_autoreminder_receipt.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Dosya gönderi numarası {transfer.id} için gönderilen otomatik hatırlatıcılar konu: (automatic reminders sent) {transfer.subject}
+subject: Dosya gönderi numarası {transfer.id} için gönderilen otomatik hatırlatıcılar konu: (automatic reminders sent) {transfer.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/transfer_available.mail.php
+++ b/language/tr_TR/transfer_available.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: Dosyalar{if:transfer.files>1}{endif} indirmeye hazır
-konu: {transfer.subject}
+subject: Dosyalar{if:transfer.files>1}{endif} indirmeye hazır
+subject: {transfer.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/transfer_deleted_receipt.mail.php
+++ b/language/tr_TR/transfer_deleted_receipt.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: Dosya(lar) silindi
-konu: (files deleted) {transfer.subject}
+subject: Dosya(lar) silindi
+subject: (files deleted) {transfer.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/transfer_expired.mail.php
+++ b/language/tr_TR/transfer_expired.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: Dosya(lar) artık indirilemez
-konu: (dosyalar artık kullanılamaz) {transfer.subject}
+subject: Dosya(lar) artık indirilemez
+subject: (dosyalar artık kullanılamaz) {transfer.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/transfer_expired_receipt.mail.php
+++ b/language/tr_TR/transfer_expired_receipt.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Dosya(lar) zaman aşımına uğradı
+subject: Dosya(lar) zaman aşımına uğradı
 subject: (dosyalar zaman aşımına uğradı) {transfer.subject}
 
 {alternative:plain}

--- a/language/tr_TR/transfer_reminder.mail.php
+++ b/language/tr_TR/transfer_reminder.mail.php
@@ -7,8 +7,8 @@
 // 
 // 
 ?>
-konu: (hatırlatıcı) Dosyalar {if:transfer.files>1} {endif} indirmeye hazır
-konu: (hatırlatıcı) {transfer.subject}
+subject: (hatırlatıcı) Dosyalar {if:transfer.files>1} {endif} indirmeye hazır
+subject: (hatırlatıcı) {transfer.subject}
 
 {alternative:plain}
 

--- a/language/tr_TR/translate_email_footer.mail.php
+++ b/language/tr_TR/translate_email_footer.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: e-posta alt bilgisini çevir, tüm dillerce paylaşılmış
+subject: e-posta alt bilgisini çevir, tüm dillerce paylaşılmış
 
 {alternative:plain}
 

--- a/language/tr_TR/upload_complete.mail.php
+++ b/language/tr_TR/upload_complete.mail.php
@@ -7,7 +7,7 @@
 // 
 // 
 ?>
-konu: Dosyalar {if:transfer.files>1} {endif} başarıyla yüklendi
+subject: Dosyalar {if:transfer.files>1} {endif} başarıyla yüklendi
 
 {alternative:plain}
 


### PR DESCRIPTION
This PR updates Turkish mail templates to use `subject:` instead of `konu:`.

Without this change, subject lines in Turkish mail templates may not be parsed correctly by the mail template system.

Changes were applied to the Turkish template files under `language/tr_TR/`.