### PR TITLE
Fix Partial downloads

### DIFF
--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -465,7 +465,7 @@ class StorageFilesystemChunked extends StorageFilesystem
         StorageFilesystemChunkedStream::ensureRegistered();
         $path = self::makeCustomStreamPath( $file, "StorageFilesystemChunkedStream" );
         $fp = \fopen($path, "r+");
-        stream_set_chunk_size($fp, Config::get('upload_chunk_size'));
+        stream_set_chunk_size($fp, Config::get('download_chunk_size'));
         return $fp;
     }
 }

--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -73,7 +73,6 @@ class StorageFilesystemChunked extends StorageFilesystem
      */
     public static function getChunkFilename($file, $filePath, $offset)
     {
-        $file_chunk_size = Config::get('upload_chunk_size');
         $file_chunk_size = $file->chunk_size;
         $offset = $offset - ($offset % $file_chunk_size);
         return $filePath.'/'.str_pad($offset, 24, '0', STR_PAD_LEFT);

--- a/classes/storage/StorageFilesystemChunkedStream.class.php
+++ b/classes/storage/StorageFilesystemChunkedStream.class.php
@@ -37,7 +37,6 @@ if (!defined('FILESENDER_BASE')) {
 
 /**
  * Allow reading a chunked file as a normal php stream
- * only in order start to finish reading is supported as yet.
  */
 class StorageFilesystemChunkedStream extends StorageFilesystemStreamBase
 {
@@ -62,47 +61,54 @@ class StorageFilesystemChunkedStream extends StorageFilesystemStreamBase
     {
         $file   = $this->file;
         $offset = $this->offset;
+        $totaldata = '';
+        $datalength = 0;
 
         if ($this->gameOver) {
             return false;
         }
-        
-        $file_path = StorageFilesystem::buildPath($file).$file->uid;
-        $chunkFile = StorageFilesystemChunked::getChunkFilename($file, $file_path, $offset);
 
-        if (!$this->currentChunkFile || ($this->currentChunkFile && strcmp($this->currentChunkFile, $chunkFile))) {
+        while ($datalength < $count && $offset < $file->size) {
+            $file_path = StorageFilesystem::buildPath($file).$file->uid;
+            $chunkFile = StorageFilesystemChunked::getChunkFilename($file, $file_path, $offset);
 
-            // if we try to open the file after the last chunk then we return FALSE
-            $fh = fopen($chunkFile, 'r');
-            if ($fh == false) {
-                $this->gameOver = true;
-                return false;
+            if (!$this->currentChunkFile || ($this->currentChunkFile && strcmp($this->currentChunkFile, $chunkFile))) {
+
+                // if we try to open the file after the last chunk then we return FALSE
+                $fh = fopen($chunkFile, 'r');
+                if ($fh == false) {
+                    $this->gameOver = true;
+                    return false;
+                }
+
+                $rc = fseek($fh, StorageFilesystemChunked::getOffsetWithinChunkedFile($file, $offset));
+                if ($rc == -1) {
+                    $this->gameOver = true;
+                    if ($this->fh) {
+                        fclose($this->fh);
+                    }
+                    return false;
+                }
+
+                $this->fh = $fh;
+                $this->currentChunkFile = $chunkFile;
             }
-            
-            $rc = fseek($fh, StorageFilesystemChunked::getOffsetWithinChunkedFile($file, $offset));
-            if ($rc == -1) {
+
+            $data = fread($this->fh, $count-$datalength);
+            if ($data == false) {
                 $this->gameOver = true;
                 if ($this->fh) {
                     fclose($this->fh);
                 }
                 return false;
             }
-            
-            $this->fh = $fh;
-            $this->currentChunkFile = $chunkFile;
-        }
 
-        $data = fread($this->fh, $count);
-        if ($data == false) {
-            $this->gameOver = true;
-            if ($this->fh) {
-                fclose($this->fh);
-            }
-            return false;
+            $totaldata.=$data;
+            $datalength = strlen($totaldata);
+            $this->offset += strlen($data);
+            $offset += strlen($data);
         }
-        
-        $this->offset += strlen($data);
-        return $data;
+        return $totaldata;
     }
 
     public function stream_eof()

--- a/www/download.php
+++ b/www/download.php
@@ -332,6 +332,7 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
         if($transfer->options['encryption'] == 1){
             $end = $file->encrypted_size;
             $chunk_size = $file->crypted_chunk_size;
+            stream_set_chunk_size($stream, $chunk_size);
         }else{
             $end = $file->size;
         }
@@ -344,12 +345,8 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
             
             Logger::debug('Send chunk at offset ' . $offset . ' with length ' . $length);
             
-            // TODO Encryption seems to not like the streams at the moment, should fix this but have a workaround
-            if ($transfer->options['encryption'] == 1) {
-                echo $file->readChunk($offset, $length);
-            } else {
-                echo stream_get_contents($stream, $length, $offset);
-            }
+            //echo $file->readChunk($offset, $length);
+            echo stream_get_contents($stream, $length, $offset);
             
             // TODO Log download progress ?
             

--- a/www/download.php
+++ b/www/download.php
@@ -331,6 +331,7 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
 
         if($transfer->options['encryption'] == 1){
             $end = $file->encrypted_size;
+            $chunk_size = $file->crypted_chunk_size;
         }else{
             $end = $file->size;
         }
@@ -343,8 +344,12 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
             
             Logger::debug('Send chunk at offset ' . $offset . ' with length ' . $length);
             
-            //echo $file->readChunk($offset, $length);
-            echo stream_get_contents($stream, $length, $offset);
+            // TODO Encryption seems to not like the streams at the moment, should fix this but have a workaround
+            if ($transfer->options['encryption'] == 1) {
+                echo $file->readChunk($offset, $length);
+            } else {
+                echo stream_get_contents($stream, $length, $offset);
+            }
             
             // TODO Log download progress ?
             

--- a/www/download.php
+++ b/www/download.php
@@ -253,12 +253,6 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     if(!$file->transfer->is($transfer))
         throw new FileNotFoundException(array('transfer_id : ' . $transfer->id, 'file_id : ' . $file_id));
 
-    $stream = Storage::getStream($file);
-    if (!$stream) {
-        $path = Storage::buildPath($file) . $file->uid;
-        throw new ForwardException('Cannot read storage: '.$path);
-    }
-
     $ranges = null;
     if (array_key_exists('HTTP_RANGE', $_SERVER) && $_SERVER['HTTP_RANGE']) {
         try {

--- a/www/download.php
+++ b/www/download.php
@@ -253,6 +253,12 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     if(!$file->transfer->is($transfer))
         throw new FileNotFoundException(array('transfer_id : ' . $transfer->id, 'file_id : ' . $file_id));
 
+    $stream = Storage::getStream($file);
+    if (!$stream) {
+        $path = Storage::buildPath($file) . $file->uid;
+        throw new ForwardException('Cannot read storage: '.$path);
+    }
+
     $ranges = null;
     if (array_key_exists('HTTP_RANGE', $_SERVER) && $_SERVER['HTTP_RANGE']) {
         try {
@@ -309,19 +315,22 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     };
     register_shutdown_function($abort_handler);
 
-    $read_range = function($range = null) use($file, $recipient, $abort_handler, $transfer) {
+    $read_range = function($range = null) use($stream, $file, $recipient, $abort_handler, $transfer) {
 
         $abort_handler();
 
+        $stream = Storage::getStream($file);
+        if (!$stream) {
+            $path = Storage::buildPath($file) . $file->uid;
+            throw new ForwardException('Cannot read storage: '.$path);
+        }
+
         $offset = $range ? $range['start'] : 0;
 
-        $chunk_size = $file->chunk_size;
-        if (!$chunk_size)
-            $chunk_size = 1024 * 1024;
+        $chunk_size = Config::get('download_chunk_size');
 
         if($transfer->options['encryption'] == 1){
             $end = $file->encrypted_size;
-            $chunk_size = $file->crypted_chunk_size;
         }else{
             $end = $file->size;
         }
@@ -334,13 +343,14 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
             
             Logger::debug('Send chunk at offset ' . $offset . ' with length ' . $length);
             
-            echo $file->readChunk($offset, $length);
+            //echo $file->readChunk($offset, $length);
+            echo stream_get_contents($stream, $length, $offset);
             
             // TODO Log download progress ?
             
             $abort_handler();
         }
-        
+        fclose($stream);
         return ($offset >= $file->size);
     };
 

--- a/www/download.php
+++ b/www/download.php
@@ -326,18 +326,17 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
         }
 
         $offset = $range ? $range['start'] : 0;
+        $chunk_size = $file->chunk_size;
+        $end = $file->size;
 
-        $chunk_size = Config::get('download_chunk_size');
-
-        if($transfer->options['encryption'] == 1){
+        if ($transfer->options['encryption'] == 1) {
             $end = $file->encrypted_size;
             $chunk_size = $file->crypted_chunk_size;
             stream_set_chunk_size($stream, $chunk_size);
-        }else{
-            $end = $file->size;
         }
-        if ($range)
+        if ($range) {
             $end = $range['end'];
+        }
         
         for (; $offset < $end; $offset += $chunk_size) {
             $remaining = $end - $offset + 1;

--- a/www/download.php
+++ b/www/download.php
@@ -385,7 +385,7 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
 
             header('Content-Type: ' . $file->mime_type);
             header('Content-Length: ' . ($range['end'] - $range['start'] + 1));
-            header('Content-Range: bytes ' . $range['start'] . '-' . $range['end'] . '/' . $file->size);
+            header('Content-Range: bytes ' . $range['start'] . '-' . ($range['end'] - 1) . '/' . $file->size);
             
             // Read range data
             $done = $read_range($range);

--- a/www/download.php
+++ b/www/download.php
@@ -309,7 +309,7 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
     };
     register_shutdown_function($abort_handler);
 
-    $read_range = function($range = null) use($stream, $file, $recipient, $abort_handler, $transfer) {
+    $read_range = function($range = null) use($file, $recipient, $abort_handler, $transfer) {
 
         $abort_handler();
 


### PR DESCRIPTION
When using wget -c on an interrupted download wget fails.

This PR fixes that by fixing the HTTP Headers and upgrading the StorageFilesystemChunkedStream to be more flexible. It also means we no longer need to force download_chunk_size=upload_chunk_size.

It seems while this fixes partial downloads, it breaks encryption downloads which needs investigating. @monkeyiq any ideas? For now I have made it use the old method so encryptions work. I bet I am missing some chunksize encryption logic somewhere, maybe in the StorageFilesystemChunked class