### PR TITLE
Dont use the current upload chunk size here, use from the db.

### DIFF
--- a/classes/storage/StorageFilesystemChunked.class.php
+++ b/classes/storage/StorageFilesystemChunked.class.php
@@ -59,7 +59,6 @@ class StorageFilesystemChunked extends StorageFilesystem
      */
     public static function getOffsetWithinChunkedFile($file, $offset)
     {
-        $file_chunk_size = Config::get('upload_chunk_size');
         $file_chunk_size = $file->chunk_size;
         return ($offset % $file_chunk_size);
     }
@@ -73,7 +72,6 @@ class StorageFilesystemChunked extends StorageFilesystem
      */
     public static function getChunkFilename($file, $filePath, $offset)
     {
-        $file_chunk_size = Config::get('upload_chunk_size');
         $file_chunk_size = $file->chunk_size;
         $offset = $offset - ($offset % $file_chunk_size);
         return $filePath.'/'.str_pad($offset, 24, '0', STR_PAD_LEFT);
@@ -463,10 +461,11 @@ class StorageFilesystemChunked extends StorageFilesystem
      */
     public static function getStream(File $file)
     {
+        $file_chunk_size = $file->chunk_size;
         StorageFilesystemChunkedStream::ensureRegistered();
         $path = self::makeCustomStreamPath( $file, "StorageFilesystemChunkedStream" );
         $fp = \fopen($path, "r+");
-        stream_set_chunk_size($fp, Config::get('upload_chunk_size'));
+        stream_set_chunk_size( $fp, $file_chunk_size );
         return $fp;
     }
 }


### PR DESCRIPTION
Only one reference was still stale here, which would cause an issue streaming an archive download if the chunk size was changed since the upload happened.