### PR TITLE
appear both deleting for "transfer" and "invitation"

### DIFF
--- a/templates/invitation_detail_page.php
+++ b/templates/invitation_detail_page.php
@@ -231,7 +231,7 @@ if( $found ) {
             <div class="row">
                 <div class="col-12">
                     <div class="fs-invitation-detail__actions">
-                        <button type="button" class="fs-button fs-button--danger delete">
+                        <button type="button" class="fs-button fs-button--danger delete-invitation">
                             <i class="fa fa-trash"></i>
                             <span>{tr:delete_invitation}</span>
                         </button>

--- a/www/js/invitation_detail_page.js
+++ b/www/js/invitation_detail_page.js
@@ -125,7 +125,7 @@ $(function() {
 
 
     // Delete button
-    $('.delete').on('click', function() {
+    $('.delete-invitation').on('click', function() {
         var id = $('.fs-invitation-detail').attr('data-id');
         if(!id || isNaN(id)) return;
 


### PR DESCRIPTION
When the "Delete" button is pressed on a transfer on the invitation details screen, both the "Delete Transfer" pop-up screen and the "Delete Invitation" pop-up screen appear.