### PR TITLE
hide archive buttons on transfer detail page after deleting

### DIFF
--- a/templates/transfer_detail_page.php
+++ b/templates/transfer_detail_page.php
@@ -196,7 +196,7 @@ if(empty($transfer->options['encryption'])) {
                 <div class="fs-transfer-detail__files">
                     <h2>{tr:transferred_files}</h2>
                     <?php if($canDownloadArchive) { ?>
-                        <p>{tr:select_files_to_download}</p>
+                        <p class="fs-download__archive-hint">{tr:select_files_to_download}</p>
 
                         <div class="fs-download__check-all select_all">
                             <label class="fs-checkbox">

--- a/www/css/new-ui/pages/_transfer-detail.css
+++ b/www/css/new-ui/pages/_transfer-detail.css
@@ -110,9 +110,12 @@
     padding-left: var(--fs-spacing-5x);
 }
 
-.fs-transfer-detail[data-status="uploading"] [data-action],
-.fs-transfer-detail[data-status="closed"] [data-action],
-.fs-transfer-detail[data-status="closed"] .fs-transfer-detail__link {
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) [data-action]:not(tr),
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) .fs-transfer-detail__link,
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) .fs-download__actions.archive,
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) .fs-download__check-all,
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) .fs-table__check-action,
+.fs-transfer-detail:is([data-status="uploading"], [data-status="forwarding"], [data-status="closed"]) .fs-download__archive-hint {
     display: none;
 }
 


### PR DESCRIPTION
Ensure the archive download buttons, select-all checkbox, per-file checkboxes, and hint text are hidden via CSS for closed/uploading/forwarding statuses, matching the server-side behavior where these elements are not rendered when the transfer is unavailable. Also fixes the case where clicking the delete button dynamically sets the status to closed but left these elements visible.