### PR TITLE
It seems that the hanlding of the trailing '?' diverged d2-d3

### DIFF
--- a/classes/auth/AuthSPOidc.class.php
+++ b/classes/auth/AuthSPOidc.class.php
@@ -147,7 +147,7 @@ class AuthSPOidc
         $url = Utilities::http_build_query(array(
             'action' => 'login',
             'target' => $target,
-        ), 'oidc.php' . '?');
+        ), 'oidc.php');
         
         return $url;
 	}
@@ -164,7 +164,7 @@ class AuthSPOidc
         $url = Utilities::http_build_query(array(
             'action' => 'logout',
             'target' => $target,
-        ), 'oidc.php' . '?');
+        ), 'oidc.php');
         
         return $url;
 	}

--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -472,6 +472,8 @@ class Utilities
      * On the other hand if path is relative then it is converted to absolute
      * by this call.
      *
+     * The '?' will be added after path if needed.
+     *
      * CGI parameters are given in $q which can be an array like;
      * array( 'foo' => 'bar', 'baz' => 7 )
      *
@@ -484,13 +486,18 @@ class Utilities
     public static function http_build_query($q, $path = null)
     {
         if ($path == null) {
-            $path = Config::get('site_url') . '?';
+            $path = Config::get('site_url');
         } else {
             if (!Utilities::startsWith($path, 'http')) {
                 $path = Config::get('site_url') . $path;
             }
         }
+        
         $ret = $path;
+        if(!str_ends_with($ret,"?")) {
+            $ret .= "?";
+        }
+
         $sep = ini_get('arg_separator.output');
         if (phpversion() < 5.4) {
             // CIFIXME remove this branch when CI php is upgraded.


### PR DESCRIPTION
This makes the handling of the trailing ? part of the build_query wrapper function so that the caller doesn't have to worry about it anymore.

This was raised in https://github.com/filesender/filesender/issues/2687