### PR TITLE
feat: site announcement on logon_page

### DIFF
--- a/language/en_AU/announce.html.php
+++ b/language/en_AU/announce.html.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * Sample announcement file for English (en_AU).
+ * This file produces no output by default.
+ *
+ * To display an announcement, copy this file to config/language/en_AU/announce.html.php
+ * and replace this comment block with your HTML content.
+ * Files in config/language/ take precedence and are not overwritten by upstream updates.
+ *
+ * Example content:
+ *
+ *   General notice (blue):
+ *
+ *     <div class="site-announcement">
+ *         <h2>Notice</h2>
+ *         <p>This site is a test environment (filesender-test).</p>
+ *     </div>
+ *
+ *   Scheduled maintenance (yellow):
+ *
+ *     <div class="site-announcement site-announcement--warning">
+ *         <h2>Scheduled Maintenance Notice</h2>
+ *         <p>System maintenance will be performed on YYYY-MM-DD from HH:MM to HH:MM (UTC+?).<br>
+ *         The service will be unavailable during this period.</p>
+ *     </div>
+ *
+ *   Urgent / outage (red):
+ *
+ *     <div class="site-announcement site-announcement--danger">
+ *         <h2>Service Disruption</h2>
+ *         <p>We are currently experiencing a service disruption. We apologize for the inconvenience.</p>
+ *     </div>
+ */
+?>

--- a/language/ja_JP/announce.html.php
+++ b/language/ja_JP/announce.html.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ * 日本語（ja_JP）用お知らせのサンプルファイルです。
+ * このファイルは何も出力しません。
+ *
+ * お知らせを表示するには、このファイルを config/language/ja_JP/announce.html.php に
+ * コピーして、このコメントブロックをHTMLコンテンツで置き換えてください。
+ * config/language/ のファイルは language/ より優先され、アップデートで上書きされません。
+ *
+ * 記述例:
+ *
+ *   通常のお知らせ（青帯）:
+ *
+ *     <div class="site-announcement">
+ *         <h2>お知らせ</h2>
+ *         <p>このサイトは検証環境（filesender-test）です。</p>
+ *     </div>
+ *
+ *   計画停止のお知らせ（黄帯）:
+ *
+ *     <div class="site-announcement site-announcement--warning">
+ *         <h2>計画停止のお知らせ</h2>
+ *         <p>○月○日（○）○○:○○〜○○:○○ にシステムメンテナンスを実施します。<br>
+ *         この間、本サービスはご利用いただけません。</p>
+ *     </div>
+ *
+ *   緊急・障害（赤帯）:
+ *
+ *     <div class="site-announcement site-announcement--danger">
+ *         <h2>障害のお知らせ</h2>
+ *         <p>現在、サービスの障害が発生しています。ご不便をおかけして申し訳ございません。</p>
+ *     </div>
+ */
+?>

--- a/templates/announce.php
+++ b/templates/announce.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Site announcement displayed on the home page (unauthenticated users).
+ *
+ * To show an announcement, create content files under config/language/:
+ *   cp language/en_AU/announce.html.php config/language/en_AU/announce.html.php
+ *   cp language/ja_JP/announce.html.php config/language/ja_JP/announce.html.php
+ * Then replace the comment block in each file with your HTML content.
+ * Files in config/language/ take precedence over language/ and are not
+ * overwritten by upstream updates.
+ *
+ * To hide the announcement, remove or empty the config/language/ files.
+ *
+ * Language selection:
+ *   FileSender's translation system picks the announce.html.php matching
+ *   the user's current language, falling back to English (en_AU).
+ *
+ * CSS classes (defined in www/css/default.css):
+ *   site-announcement            blue   — general notice
+ *   site-announcement--warning   yellow — maintenance / caution
+ *   site-announcement--danger    red    — urgent / outage
+ */
+
+// language/en_AU/announce.html.php exists but is empty by default,
+// so Lang::translate() never returns '{announce}' in normal operation.
+// The check guards against edge cases where no language file exists at all.
+$_announce_text = (string)Lang::translate('announce');
+if ($_announce_text !== '{announce}') {
+    echo $_announce_text;
+}
+unset($_announce_text);

--- a/templates/logon_page.php
+++ b/templates/logon_page.php
@@ -1,3 +1,4 @@
+<?php include FILESENDER_BASE . '/templates/announce.php'; ?>
 <div class="core">
     {tr:site_splash}
     

--- a/www/css/default.css
+++ b/www/css/default.css
@@ -3278,6 +3278,37 @@ table.paginator a {
 }
 
 
+/* Site announcement banner - displayed via templates/information.php */
+.site-announcement {
+    display: block;
+    margin: 0 0 var(--fs-spacing-3x, 1.5rem);
+    padding: var(--fs-spacing-2x, 1rem) var(--fs-spacing-3x, 1.5rem);
+    border-left: 4px solid var(--fs-info, #155BCB);
+    background-color: var(--fs-blue-100, #edf5ff);
+    border-radius: 0.25rem;
+}
+
+.site-announcement--warning {
+    border-left-color: var(--fs-warning-hover, #DFB41E);
+    background-color: #fffce6;
+}
+
+.site-announcement--danger {
+    border-left-color: var(--fs-danger, #EA4D3C);
+    background-color: #fff2f0;
+}
+
+.site-announcement h2,
+.site-announcement h3 {
+    margin-top: 0;
+    font-size: 1.1em;
+    font-weight: bold;
+}
+
+.site-announcement p:last-child {
+    margin-bottom: 0;
+}
+
 /* Local Variables:    */
 /* mode: text          */
 /* comment-column: 0   */

--- a/www/css/default.scss
+++ b/www/css/default.scss
@@ -1359,6 +1359,37 @@ table.paginator a {
     background-color: #fff3f3 !important;
 }
 
+/* Site announcement banner - displayed via templates/information.php */
+.site-announcement {
+    display: block;
+    margin: 0 0 var(--fs-spacing-3x, 1.5rem);
+    padding: var(--fs-spacing-2x, 1rem) var(--fs-spacing-3x, 1.5rem);
+    border-left: 4px solid var(--fs-info, #155BCB);
+    background-color: var(--fs-blue-100, #edf5ff);
+    border-radius: 0.25rem;
+}
+
+.site-announcement--warning {
+    border-left-color: var(--fs-warning-hover, #DFB41E);
+    background-color: #fffce6;
+}
+
+.site-announcement--danger {
+    border-left-color: var(--fs-danger, #EA4D3C);
+    background-color: #fff2f0;
+}
+
+.site-announcement h2,
+.site-announcement h3 {
+    margin-top: 0;
+    font-size: 1.1em;
+    font-weight: bold;
+}
+
+.site-announcement p:last-child {
+    margin-bottom: 0;
+}
+
 @import "local-variables.scss";
 
 


### PR DESCRIPTION
Our site sometimes wants to display an announcement to users, for example,  a scheduled maintenance notice.
In version 2, the CSS classes `info` and `message` were used to display an announcement on the logon_page.

  - Add .site-announcement CSS classes (blue/yellow/red variants)
  - Add templates/announce.php to display language-aware announcements
  - Include announce.php in logon_page.php
  - Add language/*/announce.html.php sample (empty by default)