### PR TITLE
2026/june/enc md update 1

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -912,3 +912,4 @@ $lang['you_have_a_openpgp_public_key_known_to_system'] = 'You have a OpenPGP pub
 $lang['your_download_link'] = 'Here\'s your download link';
 $lang['your_invitation_was_sent_to'] = 'Your invitation was sent to';
 $lang['your_transfer_was_sent'] = 'Your transfer was sent to the following email addresses';
+$lang['encrypted_metadata_file_size_hidden'] = 'Hidden';

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -1,5 +1,6 @@
 <?php
 
+
 $canDownload = true;
 
 if (!function_exists('str_starts_with')) {
@@ -135,6 +136,18 @@ if(array_key_exists('hide_sender_email', $transfer->options) && $transfer->optio
 }
 $sender_email_clean = Template::sanitizeOutputEmail($sender_email);
 
+$hasEncryptedMetadata = false;
+if($isEncrypted) {
+    $hasEncryptedMetadata = isset($transfer->options['encrypted_metadata']) && $transfer->options['encrypted_metadata'];
+}
+
+$formatFileSizeForDisplayQ = function( $filesz ) use ($hasEncryptedMetadata)
+{
+    if( $hasEncryptedMetadata ) {
+        return "{tr:encrypted_metadata_file_size_hidden}";
+    }
+    return Template::Q(Utilities::formatBytes($filesz));
+}
 
 ?>
 
@@ -267,7 +280,7 @@ $sender_email_clean = Template::sanitizeOutputEmail($sender_email);
                                         <td>
                                             <div>
                                                 <span class="name"><?php echo Template::Q($file->path) ?></span>
-                                                <span class="size"><?php echo Template::Q(Utilities::formatBytes($file->size)) ?></span>
+                                                <span class="size">x <?php echo $formatFileSizeForDisplayQ($file->size) ?></span>
                                                 <span class="downloadprogress"></span>
                                                 <span class="remove stage1">
                                                     <a rel="nofollow" href="<?php echo empty($downloadLinks[$file->id]) ? '#' : Template::Q($downloadLinks[$file->id]) ?>" class="fs-button fs-button--small fs-button--transparent fs-button--info fs-button--no-text download" title="{tr:download_file}">

--- a/templates/download_page.php
+++ b/templates/download_page.php
@@ -280,7 +280,7 @@ $formatFileSizeForDisplayQ = function( $filesz ) use ($hasEncryptedMetadata)
                                         <td>
                                             <div>
                                                 <span class="name"><?php echo Template::Q($file->path) ?></span>
-                                                <span class="size">x <?php echo $formatFileSizeForDisplayQ($file->size) ?></span>
+                                                <span class="size"><?php echo $formatFileSizeForDisplayQ($file->size) ?></span>
                                                 <span class="downloadprogress"></span>
                                                 <span class="remove stage1">
                                                     <a rel="nofollow" href="<?php echo empty($downloadLinks[$file->id]) ? '#' : Template::Q($downloadLinks[$file->id]) ?>" class="fs-button fs-button--small fs-button--transparent fs-button--info fs-button--no-text download" title="{tr:download_file}">

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -1439,6 +1439,8 @@ window.filesender.client = {
 
     handlePossibleEncryptedMetadata: async function ()
     {
+        var $this = this;
+       
         var page = $('.download_page');
         if(!page.length) page = $('.transfer_detail_page');
         if(!page.length) return;
@@ -1501,12 +1503,15 @@ window.filesender.client = {
 
                         pobj.attr("data-name",name);
                         pobj.attr("data-mime",v["mimetype"]);
+                        pobj.attr("data-size",v["size"]);
+                        pobj.find(".size").text($this.formatBytes(v["size"]));
                         pobj.find(".name").text(name);
                     }
 
                     window.filesender.md = md;
 
                 } catch (error) {
+                    console.log(error);
                     var msg = window.filesender.config.language.file_encryption_metadata_wrong_password;
                     filesender.ui.alert( "error", msg );                    
                 }


### PR DESCRIPTION
Hide the size metadata from the most basic view and replace the placeholder when the enc md block is decrypted.

In the future we could tighten things up by hiding the size information from many of the REST api calls relying on the client to magically "know" that by being able to process the encrypted_metadata packet to unlock it.
