### PR TITLE
possible fix for firefox on windows / single file storage type

### DIFF
--- a/www/download.php
+++ b/www/download.php
@@ -337,9 +337,20 @@ function downloadSingleFile($transfer, $recipient, $file_id, $recently_downloade
             $length = min($chunk_size, $remaining);
             
             Logger::debug('Send chunk at offset ' . $offset . ' with length ' . $length);
-            
-            //echo $file->readChunk($offset, $length);
-            echo stream_get_contents($stream, $length, $offset);
+
+            // TODO Encryption seems to not like the streams at the moment, should fix this but have a workaround
+            $do_not_use_stream = false;
+            if( $transfer->options['encryption'] == 1 ) {
+                if( strtolower(Config::get('storage_type')) == 'filesystem' ) {
+                    $do_not_use_stream = true;
+                }
+            }
+
+            if( $do_not_use_stream ) {
+                echo $file->readChunk($offset, $length);
+            } else {
+                echo stream_get_contents($stream, $length, $offset);
+            }
             
             // TODO Log download progress ?
             


### PR DESCRIPTION
This fixes a regression where the `readChunk` method has specific handling for encrypted files and the native filessytem stream class does not know about that. The getStream() on StorageFilesystem is ok if you are reading the whole file tip to tail but runs into issues with offsets if you are wanting to read at specific offsets. These things can be fixed but testing is needed to ensure both a working session in download.php aswell as continued working sessions in the server based archive streaming for non encrypted files.
