### PR TITLE
reversal of the titles associated with the ‘guest_transfer_settings’ …

### DIFF
--- a/templates/new_invitation_page.php
+++ b/templates/new_invitation_page.php
@@ -294,7 +294,7 @@ use ( $new_guests_can_only_send_to_creator,
                                         </button>
                                         <div class="fs-collapse__content">
                                             <div class="fs-collapse__column">
-                                                <strong>{tr:guest_transfer_settings}</strong>
+                                                <strong>{tr:guest_email_settings}</strong>
 
                                                 <div class="guest_options">
                                                     <?php foreach(Guest::availableOptions(false) as $name => $cfg) {
@@ -317,7 +317,7 @@ use ( $new_guests_can_only_send_to_creator,
                                                 </div>
                                             </div>
                                             <div class="fs-collapse__column">
-                                                <strong>{tr:guest_email_settings}</strong>
+                                                <strong>{tr:guest_transfer_settings}</strong>
 
                                                 <div class="transfer_options">
                                                     <?php foreach(Transfer::availableOptions(false) as $name => $cfg) {


### PR DESCRIPTION
Dear @monkeyiq,

I am currently working on implementing version 3 of Filesender within Belnet (a financial contributor to Filesender).

Whilst writing a new user guide for our users and those of our clients, I noticed that the titles of the options for all new invitations (vouchers) are reversed.


In the file “template/new_invitation_page.php”:
-  the title for the “guest_email_settings” options is currently the one for the “guest_transfer_settings” options
And conversely:
-  the title for the “guest_transfer_settings” options is currently the one for the “guest_email_settings” options

I noticed this in version 3.6, but it is also the case in the latest version 3.9.
<img width="1599" height="1351" alt="new_invitation-template--wrong_titles" src="https://github.com/user-attachments/assets/1c3e9322-f28f-4c59-850d-fe39ead6bf46" />

I have therefore modified the template.
Please accept this pull request and include this in the next release (3.10?).

Best regards,

Ludovic
Managed Services - Belnet