### PR TITLE
fix: make this a debug log, not a console dump

### DIFF
--- a/classes/avprograms/AVProgram.class.php
+++ b/classes/avprograms/AVProgram.class.php
@@ -52,7 +52,7 @@ abstract class AVProgram
     public static function getActiveProgramList()
     {
         $desiredList = Config::getArray("avprogram_list");
-        print_r($desiredList);
+        Logger::debug('avprogram_list: '.print_r($desiredList, true));
         
         if( !self::$allPrograms ) {
             self::$allPrograms = array(


### PR DESCRIPTION
In an effort to get to know the codebase better, I am going over it all and doing small fixes while I am at it.

This PR contains moves some `print_r` code into the logger, so that the debug information it discloses ends up with the other debug information.