### PR TITLE
'announce.html.php' is currently not connected to the language dictionary build path.

### DIFF
--- a/classes/utils/Lang.class.php
+++ b/classes/utils/Lang.class.php
@@ -510,7 +510,16 @@ class Lang
             // Main translation file
             if (file_exists($path.'/lang.php')) {
                 $lang = array();
-                include $path.'/lang.php';
+		include $path.'/lang.php';
+		if (file_exists($path.'/announce.html.php')) {
+                    ob_start();
+                    include $path.'/announce.html.php';
+                    $announce_html = ob_get_clean();
+
+                    if (trim($announce_html) !== '') {
+                        $lang['announce'] = $announce_html;
+                    }
+                }
                 foreach ($lang as $id => $s) {
                     $dictionary[self::cleanId($id)] = array('text' => $s);
                 }


### PR DESCRIPTION
### Summary

I tested the `site announcement on logon_page` feature (introduced in #2692)  on a stock FileSender 3.10 installation and found that `announce.html.php` is currently not connected to the language dictionary build path.

The feature works correctly if I set `$lang['announce']` directly in `config/language/<locale>/lang.php`, including full HTML markup. However, creating `config/language/<locale>/announce.html.php` as documented in `templates/announce.php` **has no effect**.

### What I verified

`templates/logon_page.php` includes:

```php
<?php include FILESENDER_BASE . '/templates/announce.php'; ?>
```
templates/announce.php renders:
```
$_announce_text = (string)Lang::translate('announce');
if ($_announce_text !== '{announce}') {
    echo $_announce_text;
}
```
So the display path itself is fine.
I also confirmed that HTML content renders correctly when assigned directly to the announce translation key in _config/language/fr_FR/lang.php_, for example (i left the text in english for this PR even if locale lang is fr_FR) :
```
$lang['announce'] = '
<div class="site-announcement site-announcement--danger">
    <h2>Service disruption</h2>
    <p>We are currently experiencing a service disruption.</p>
</div>';
```
This produces the expected styled announcement on the unauthenticated logon page.

### Root cause
The issue appears to be in Lang.class.php.
At the point where the dictionary is built, the current code does this:

```
// Main translation file
if (file_exists($path.'/lang.php')) {
    $lang = array();
    include $path.'/lang.php';
    foreach ($lang as $id => $s) {
        $dictionary[self::cleanId($id)] = array('text' => $s);
    }
}
```

This means that only entries coming from lang.php are added to the dictionary.
I could not find any code path that loads announce.html.php and maps it to $lang['announce'] before the dictionary is built.
As a result:

- $lang['announce'] in lang.php works
- announce.html.php does not
- the current comments in templates/announce.php and the shipped 
- language/*/announce.html.php files suggest behavior that is not actually implemented

### Proposed fix
The most natural place to support announce.html.php is inside the same block in Lang.class.php, after loading lang.php and before copying $lang into $dictionary.

Proposed patch:
```
// Main translation file
if (file_exists($path.'/lang.php')) {
    $lang = array();
    include $path.'/lang.php';

    /*
     * Optional HTML announcement body.
     * If present, map it to the "announce" translation key so that
     * templates/announce.php can render it through Lang::translate('announce').
     */
    if (file_exists($path.'/announce.html.php')) {
        ob_start();
        include $path.'/announce.html.php';
        $announce_html = ob_get_clean();

        if (trim($announce_html) !== '') {
            $lang['announce'] = $announce_html;
        }
    }

    foreach ($lang as $id => $s) {
        $dictionary[self::cleanId($id)] = array('text' => $s);
    }
}
```

### Why this fix is appropriate

- it keeps templates/announce.php unchanged
- it preserves the existing language dictionary build flow
- it makes announce.html.php behave as currently documented/intended
- it keeps language resolution and fallback behavior unchanged
- it keeps the existing override precedence (config/language/... over language/...) because the file is loaded during the normal language path iteration

### Additional note
The current stock lang.php files define:
```
$lang['announce'] = ' ';
```

So at the moment, the reason Lang::translate('announce') does not return {announce} is the placeholder in lang.php, not the existence of announce.html.php.

That makes the current comment in templates/announce.php slightly misleading in the current implementation.

### Tested & working
I applied the patch described above and then carried out the tests as per your instructions:
- cp language/en_AU/announce.html.php config/language/fr_FR/announce.html.php
- inserted the HTML block below in config/language/fr_FR/announce.html.php
```
<div class="site-announcement site-announcement--danger">
     <h2>Service disruption</h2>
     <p>We are currently experiencing a service disruption.<br />(for the demo of the patch i kept an english text even if using fr_FR locale)</p>
</div>
```
- No translation override for “announce” in config/language/fr_FR/Lang.php

Result:
<img width="1873" height="573" alt="image" src="https://github.com/user-attachments/assets/b4d618cb-c26e-432a-a90e-31302f71ceac" />

- Next, remove or rename the file config/language/fr_FR/announce.html.php
```
mv config/language/fr_FR/announce.html.php config/language/fr_FR/announce.html.php.bak
```
<img width="1869" height="433" alt="image" src="https://github.com/user-attachments/assets/7091f3dc-5aaf-4d51-9c55-b8d16326a79a" />
