### PR TITLE
fix: File size as bi (and not SI)

### DIFF
--- a/classes/utils/Utilities.class.php
+++ b/classes/utils/Utilities.class.php
@@ -364,16 +364,16 @@ class Utilities
         
         if (count($parts) > 2) {
             switch (strtoupper($parts[2])) {
-            case 'P': $size *= 1024;
-            // no break
-            case 'T': $size *= 1024;
-            // no break
-            case 'G': $size *= 1024;
-            // no break
-            case 'M': $size *= 1024;
-            // no break
-            case 'K': $size *= 1024;
-        }
+                case 'P': $size *= 1024;
+                // no break
+                case 'T': $size *= 1024;
+                // no break
+                case 'G': $size *= 1024;
+                // no break
+                case 'M': $size *= 1024;
+                // no break
+                case 'K': $size *= 1024;
+            }
         }
         return $size;
     }
@@ -405,7 +405,7 @@ class Utilities
             self::$formatBytes_unit = $unit;
         }
         $unit = self::$formatBytes_unit;
-        $multipliers = array('', 'k', 'M', 'G', 'T');
+        $multipliers = array('', 'ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi');
         
         // Compute multiplier
         $bytes = max($bytes, 0);

--- a/www/js/client.js
+++ b/www/js/client.js
@@ -1439,7 +1439,7 @@ window.filesender.client = {
 
         const k = 1024
         const dm = decimals < 0 ? 0 : decimals
-        const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+        const sizes = ['Bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
 
         const i = Math.floor(Math.log(bytes) / Math.log(k))
 

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -762,7 +762,7 @@ window.filesender.ui = {
         if(!precision || isNaN(precision))
             precision = 1;
 
-        var multipliers = ['', 'k', 'M', 'G', 'T'];
+        var multipliers = ['', 'ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi'];
 
         var bytes = Math.max(bytes, 0);
         var pow = Math.floor((bytes ? Math.log(bytes) : 0) / Math.log(1024));


### PR DESCRIPTION
File size units on FileSender link download and upload pages are reported as SI units, e.g. GB (gigabytes, 1000^3 bytes), but the numbers appear to actually be the bi prefixes, e.g. GiB (gibibytes, 1024^3 bytes).