### PR TITLE
fix: add ZIP64 extra field to local file header for macOS compatibility

### DIFF
--- a/www/js/zip64handler.js
+++ b/www/js/zip64handler.js
@@ -255,12 +255,20 @@ window.filesender.zip64handler = function() {
             this.writeu16( 0          );  // no compression
             this.writeu32( dts );
             this.writeu32( 0          );  // no crc-32 yet
-            this.writeu32( 0xFFFFFFFF );  // no size yet
-            this.writeu32( 0xFFFFFFFF );  // ...
+            this.writeu32( 0xFFFFFFFF );  // no size yet (ZIP64: value in extra field)
+            this.writeu32( 0xFFFFFFFF );  // ...         (ZIP64: value in extra field)
             this.writeu16( filename_array.length );
-            this.writeu16( 0          );  // no extra data
+            this.writeu16( 20         );  // extra field length: ZIP64 (4 header + 16 data)
 
             $this.write( filename_array );
+
+            // ZIP64 extended information extra field (required when sizes are 0xFFFFFFFF)
+            // Actual sizes are deferred to the data descriptor (general purpose bit 3 set).
+            // Without this field, strict parsers (e.g. macOS Archive Utility) reject the archive.
+            this.writeu16( 0x0001 );  // ZIP64 extra field header ID
+            this.writeu16( 16     );  // data size: two 8-byte fields
+            this.writeu64( 0      );  // uncompressed size placeholder (see data descriptor)
+            this.writeu64( 0      );  // compressed size placeholder   (see data descriptor)
 
             $this.crc = 0;
             $this.filesize = 0;


### PR DESCRIPTION
This was raised in #1341

Local file headers with size fields set to 0xFFFFFFFF must include a ZIP64 extended information extra field per the ZIP64 spec ([APPNOTE](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT) §4.5.3). Without it, strict parsers such as macOS Archive Utility see the 0xFFFFFFFF marker, look for a ZIP64 extra field, find none, and fail with an error. Lenient tools (The Unarchiver, 7zip, Windows) tolerate the omission and fall back to the data descriptor directly, which is why the bug was platform-specific.

The fix adds a 20-byte ZIP64 extra field (header ID 0x0001, uncompressed and compressed size both 0 as placeholders) to every local file header. Actual sizes remain in the data descriptor as before (general purpose bit 3 is set). This allows strict parsers to recognise the ZIP64 format and correctly read 64-bit sizes from the data descriptor.