### PR TITLE
fix: correct TAR archive Content-Length calculation

### DIFF
--- a/classes/utils/Archiver.class.php
+++ b/classes/utils/Archiver.class.php
@@ -156,9 +156,7 @@ class Archiver
             $file = $data['data'];
             $fileopts = array();
             $transfer = $file->transfer;
-            if( (!isset($archivedName)) ) {
                 $archivedName = $this->getArchivedFileName( $file );
-            }
 
             $contentsz += $file->size;
 	    $archive->init_file_stream_transfer($archivedName, $file->size, $fileopts);


### PR DESCRIPTION
getTarSize() reused the first file's archived name for all subsequent files due to a missing reset of $archivedName inside the foreach loop. When the first file has a basename longer than 99 characters (triggering a PAX extension header) and any other file does not, getTarSize() over-counts PAX overhead by 1024 bytes per mismatched file, causing Content-Length to be reported larger than the actual TAR stream. This produces NS_ERROR_NET_PARTIAL_TRANSFER in browsers that enforce Content-Length.