### PR TITLE
D3-Fix: transfer_options.get_a_link.default has no effect on the pre-selected transfer type

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -249,12 +249,16 @@ if( !Auth::isGuest()) {
             } else {
                 $userHasEmailPreference = true;
             }
-        } else {
-            $userHasEmailPreference = true;
         }
     }
     if( !$userHasEmailPreference && !$userHasGALPreference ) {
-        $userHasGALPreference = true;
+        $transferOptions = Config::get('transfer_options');
+        if( isset($transferOptions['get_a_link']['default'])
+            && $transferOptions['get_a_link']['default'] ) {
+            $userHasGALPreference = true;
+        } else {
+            $userHasEmailPreference = true;
+        }
     }
 }
 foreach(Transfer::allOptions() as $name => $dfn)  {


### PR DESCRIPTION
### Summary
I tested the transfer type selection on the upload page on a FileSender 3.10 installation and found that the `transfer_options.get_a_link.default` configuration directive has no effect on which transfer type is pre-selected at stage 3.

The instance configuration is silently bypassed in two related cases, and the "transfer link" mode ends up hardcoded as the effective default in both:

- when the user has no stored transfer preference at all (`save_transfer_preferences = 0`)
- when the user has `save_transfer_preferences = 1` but no `get_a_link` key stored in `transfer_preferences `(e.g. a fresh account, or a preference that was never set)

This is a regression compared to FileSender 2.x, where `get_a_link.default` controlled the default transfer mode.

I also verified this against #2771 (merged), which addresses a different, unrelated case (`available=false` combined with `default=true`, to force link-only transfers with no choice shown to the user). While testing that exact configuration, I found that the second case described above prevented #2771 from working correctly: `data-user-has-gal-preference` stayed at` 0 `even though `available=false` / `default=true` was configured, causing the transfer to be created in email mode. 
Both cases are fixed by the same patch.

### What I verified
I set the following override in `config/config.php`:
```
$config['transfer_options'] = array(
    'get_a_link' => array(
        'available' => true,
        'advanced'  => false,
        'default'   => false
    )
);
```

The configuration is correctly loaded at runtime:

```
php -r 'require "includes/init.php"; var_dump(Config::get("transfer_options")["get_a_link"]);'
array(3) {
  ["available"]=> bool(true)
  ["advanced"]=>  bool(false)
  ["default"]=>   bool(false)
}
```

Yet the upload page still pre-selects the transfer link mode.
I traced the rendering path. `templates/upload_page.php` computes two variables and exposes them to the Document Object Model:
```
data-user-has-gal-preference="<?php echo $userHasGALPreference ? '1' : '0' ?>"
data-user-has-email-preference="<?php echo $userHasEmailPreference ? '1' : '0' ?>"
```
`www/js/upload_page.js` consumes them to check the corresponding radio. So the display path itself is fine, and the JS simply follows what PHP tells it. `Config::get('transfer_options')['get_a_link']['default']` never appears anywhere in this chain.
I confirmed that a stored user preference does correctly switch the default (e.g. `save_transfer_preferences = 1` with `transfer_preferences = {"get_a_link":false}` correctly pre-selects email). The instance configuration, however, is never consulted as a fallback in either of the two cases described above.

### Root cause
The issue is in `templates/upload_page.php`, in the block that computes `$userHasGALPreference` / `$userHasEmailPreference`:

```
$userHasEmailPreference = false;
$userHasGALPreference = false;
if( !Auth::isGuest()) {
    $user = Auth::User();
    if( $user->save_transfer_preferences ) {
        $ops = (array)$user->transfer_preferences;
        if( array_key_exists( 'get_a_link', $ops )) {
            $gal = $ops["get_a_link"];
            if( $gal ) {
                $userHasGALPreference = true;
            } else {
                $userHasEmailPreference = true;
            }
        } else {
            $userHasEmailPreference = true;   // <-- case 1
        }
    }
    if( !$userHasEmailPreference && !$userHasGALPreference ) {
        $userHasGALPreference = true;         // <-- case 2
    }
}
```
Two separate branches hardcode a mode without ever consulting `Config::get('transfer_options')`:

- Case 1 (line marked above): when `save_transfer_preferences = 1` but the stored `transfer_preferences` has no `get_a_link` key, the code unconditionally forces `$userHasEmailPreference = true`.

- Case 2 (line marked above): when the user has no preference at all (`save_transfer_preferences = 0`, or both flags still `false` after the block above), the code unconditionally forces `$userHasGALPreference = true`.

Both cases short-circuit before the instance configuration can ever be read, which is why `transfer_options.get_a_link.default` has no effect unless a `get_a_link` value happens to already be stored in the user's preferences.
Note also that `get_a_link` is explicitly skipped by the `$displayoption()` closure used to render the regular options list (`return` on `$name == "get_a_link"`), so its `default` never produces a checked attribute through that path either. This block is the only place deciding the default mode.

### Proposed fix
Remove the hardcoded branch in case 1, and replace the hardcoded branch in case 2 with a lookup of the configured default, so both cases fall back to the same rule: **user preference → instance default**.

```
$userHasEmailPreference = false;
$userHasGALPreference = false;
if( !Auth::isGuest()) {
    $user = Auth::User();
    if( $user->save_transfer_preferences ) {
        $ops = (array)$user->transfer_preferences;
        if( array_key_exists( 'get_a_link', $ops )) {
            $gal = $ops["get_a_link"];
            if( $gal ) {
                $userHasGALPreference = true;
            } else {
                $userHasEmailPreference = true;
            }
        }
        // No 'else' here: if the key is absent, both flags remain false
        // and the fallback below applies the instance default instead
        // of hardcoding email.
    }
    if( !$userHasEmailPreference && !$userHasGALPreference ) {
        /*
         * No stored user preference: fall back to the instance default
         * configured through transfer_options.get_a_link.default
         * instead of unconditionally forcing the "get a link" mode.
         */
        $transferOptions = Config::get('transfer_options');
        if( isset($transferOptions['get_a_link']['default'])
            && $transferOptions['get_a_link']['default'] ) {
            $userHasGALPreference = true;
        } else {
            $userHasEmailPreference = true;
        }
    }
}
```
### Why this fix is appropriate

- it keeps `www/js/upload_page.js` unchanged
- it preserves the existing precedence: a stored user preference still wins over the instance default
- it makes `transfer_options.get_a_link.default` behave as documented/intended, in every case where no stored preference overrides it
- it does not affect users who have an explicit `get_a_link` value stored in their preferences
- it unifies two previously inconsistent hardcoded branches into a single, config-aware fallback
- it restores the FileSender 2.x behaviour without reintroducing a hardcoded default
- it makes the `available=false` / `default=true` configuration from [#2771](https://github.com/filesender/filesender/pull/2771) work correctly for users whose stored preferences have no `get_a_link` key (e.g. accounts with `save_transfer_preferences = 1` and no prior transfer)

### Tested & Working
I applied the patch described above and carried out the following tests, on top of #2771 (already merged into branch development3).

- **Case A** — `get_a_link` available, `default = false`, no stored preference (`save_transfer_preferences = 0`): the transfer type is pre-selected on email, consistently across subsequent transfers.
- **Case B** — `get_a_link` not available, `default = true` (the #2771 scenario), `save_transfer_preferences = 1` with no `get_a_link` key stored: before this patch, `data-user-has-gal-preference` stayed at `0` and the transfer was created in email mode despite the configuration. After this patch, `data-user-has-gal-preference` is `1`, the GAL radio is checked, and the transfer is correctly created as a link transfer.
- **Case C** — user with an explicit stored preference (`transfer_preferences = {"get_a_link":true}` or `false`): the stored preference is respected in both cases, unchanged by this patch.

### Additional note 
While investigating, I noticed that `www/js/upload_page.js` targets `$('#transfer-link')` to check the GAL radio, but `templates/upload_page.php` renders that radio with `id="get_a_link"` (only its `value` is `transfer-link`):

```
<input type="radio" id="get_a_link" name="transfer-type" value="transfer-link" class="get_a_link_top_selector">
```
The selector therefore never matches, and the GAL radio is never explicitly checked by the JS. In every test I ran where GAL ended up correctly selected, it was because it happened to be the only radio present, or the first one in DOM order — not because the JS checked it. 

This is not addressed by this PR but may warrant a separate fix.