### PR TITLE
ui3: use a class here to select the element.

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -594,7 +594,7 @@ EOF;
                                             <div class="fs-radio-group"
                                                  <?php echo "$get_a_link_hidden_stanza" ?>
                                             >
-                                                <input type="radio" id="get_a_link" name="transfer-type" value="transfer-link" class="get_a_link_top_selector">
+                                                <input type="radio" id="get_a_link" name="transfer-type" value="transfer-link" class="get_a_link_top_selector get_a_link transfer-link">
 
                                                 <label for="get_a_link" class="fs-radio">
                                                     <div class="fs-radio__option">
@@ -612,7 +612,7 @@ EOF;
 
                                         <?php if($show_email_choice) { ?>
                                         <div class="fs-radio-group">
-                                            <input type="radio" id="transfer-email" name="transfer-type" value="transfer-email">
+                                            <input type="radio" id="transfer-email" name="transfer-type" value="transfer-email" class="transfer-email">
 
                                             <label for="transfer-email" class="fs-radio">
                                                 <div class="fs-radio__option">

--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -2311,11 +2311,11 @@ $(function() {
         filesender.ui.setFileList(2, 3);
 
         if( form.attr('data-user-has-gal-preference') == '1' ) {
-            $('#transfer-link').prop("checked", true);
+            $('.transfer-link').prop("checked", true);
             filesender.ui.onChangeTransferType("transfer-link");
         }
         if( form.attr('data-user-has-email-preference') == '1' ) {
-            $('#transfer-email').prop("checked", true);
+            $('.transfer-email').prop("checked", true);
             filesender.ui.onChangeTransferType("transfer-email");
         }
 


### PR DESCRIPTION
The naming inconsistency was mentioned in
https://github.com/filesender/filesender/pull/2780

Using a class will allow both to use similar identifiers.