### PR TITLE
ui3: hide header for selecting how to transfer if gal is forced

### DIFF
--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -43,6 +43,7 @@ if( Config::isTrue('show_splash_after_login')) {
 $upload_options_handled = array();
 
 $guest_can_only_send_to_creator = false;
+$show_get_a_link_or_email_choice_section_header = true;
 $show_get_a_link_or_email_choice = true;
 $openpgp_encrypt_passphrase = false;
 $openpgpkey = '';
@@ -122,6 +123,7 @@ foreach(Transfer::allOptions() as $name => $dfn)  {
 
                 $show_email_choice = false;
                 $show_get_a_link_or_email_choice = true;
+                $show_get_a_link_or_email_choice_section_header = false;
                 continue;
             }
         }
@@ -585,10 +587,11 @@ EOF;
                             <div class="fs-transfer__send-options">
                                 <div class="row">
                                     <div class="col-12">
+                                        <?php if($show_get_a_link_or_email_choice_section_header) { ?>
                                         <h5>
                                             {tr:choose_files}
                                         </h5>
-
+                                        <?php } ?>
                                         <?php if($show_get_a_link_or_email_choice) { ?>
 
                                             <div class="fs-radio-group"


### PR DESCRIPTION
This hides the header for how a transfer is to be made if get_a_link is forced in the configuration using something like the following:

$config['transfer_options'] = array(
...
        'get_a_link' => array(
            'available' => false,
            'advanced' => false,
            'default' => true,
	),

The header was being shown above no options if the user was not able to select gal/email. This was raised in

https://github.com/filesender/filesender/issues/2794