### PR TITLE
ui3: show explicit header if gal is forced.

### DIFF
--- a/language/en_AU/lang.php
+++ b/language/en_AU/lang.php
@@ -915,3 +915,6 @@ $lang['your_transfer_was_sent'] = 'Your transfer was sent to the following email
 $lang['encrypted_metadata_file_size_hidden'] = 'Hidden';
 $lang['use_terareceiver_for_download'] = 'Use TeraReceiver code for this download. This new code allows better retry on network timeout and will in the future allow multiple active download streams for performance';
 
+
+$lang['choose_files_forced_get_a_link'] = 'You will get a link to the uploaded files.';
+$lang['choose_files_forced_email'] = 'Files will be emailed to your nominated destination.';

--- a/templates/upload_page.php
+++ b/templates/upload_page.php
@@ -587,11 +587,18 @@ EOF;
                             <div class="fs-transfer__send-options">
                                 <div class="row">
                                     <div class="col-12">
-                                        <?php if($show_get_a_link_or_email_choice_section_header) { ?>
                                         <h5>
-                                            {tr:choose_files}
+                                            <?php if($show_get_a_link_or_email_choice_section_header) { ?>
+                                                {tr:choose_files}
+                                            <?php
+                                            } else { 
+                                                if($show_email_choice) {
+                                                    echo "{tr:choose_files_forced_email}";
+                                                } else {
+                                                    echo "{tr:choose_files_forced_get_a_link}";
+                                                }
+                                            } ?>
                                         </h5>
-                                        <?php } ?>
                                         <?php if($show_get_a_link_or_email_choice) { ?>
 
                                             <div class="fs-radio-group"


### PR DESCRIPTION
This was raised in https://github.com/filesender/filesender/issues/2794

This PR allows an explicit text to be shown in place of the email/gal selector if the site is configured to only allow get_a_link options.