### PR TITLE
fix for negative UTC locations

### DIFF
--- a/www/js/upload_page.js
+++ b/www/js/upload_page.js
@@ -1510,6 +1510,13 @@ filesender.ui.startUpload = function() {
             var expiresSelected = filesender.ui.nodes.expires.datepicker('getDate');
             var now = new Date();
             expiresSelected.setHours(now.getHours(), now.getMinutes(), now.getSeconds(), 0);
+            // setting hours alone will jump this into that hour and may
+            // need to have a day rolled back if we are in a tz offset < UTC
+            // note that this offset method is positive in that case
+            // tested in Australia server tz, Pacific/Honolulu on the client
+            if( expiresSelected.getTimezoneOffset() > 0 ) {
+                expiresSelected.setDate( expiresSelected.getDate()-1);
+            }
             this.transfer.expires = expiresSelected.getTime() / 1000;
         } else {
             const expiresDays = $('#expires-select').find(":selected").val();


### PR DESCRIPTION
The getDate method will return 00:00:00 on the selected day. It will also have the time zone of the browser. So for Pacific/Honolulu UTC-10.

Assuming these times (circa a claw full of seconds) for testing, browser:  Sun Aug 02 2026 16:29:29 GMT-1000 (Hawaii-Aleutian Standard Time)
  server: Mon 03 Aug 2026 12:30:21 AEST

The getDate() call will return
browser:  Sun Aug 02 2026 00:00:00 GMT-1000 (Hawaii-Aleutian Standard Time)

The call to setHours() will advance the hours leaving the rest of the expiresSelected as it was.

browser:  Sun Aug 02 2026 16:29:29 GMT-1000 (Hawaii-Aleutian Standard Time)

Without this day offsetthe above setHours() will jump forward into that hour which is not really what we want. We really want to set the hours but also take a day off so that when the time is converted to UTC we are not in the future.

This was reported here https://github.com/filesender/filesender/issues/2794
