### PR TITLE
Fix file selection for downloads from transfer details

### DIFF
--- a/www/js/client.js
+++ b/www/js/client.js
@@ -1140,7 +1140,7 @@ window.filesender.client = {
                     //
                     var onFileOpen = function( blobSink, fileid )
                     {
-                        var progress = page.find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        var progress = page.find(".file[data-id='" + fileid + "']").find('.downloadprogress');
                         progress.html("");
                         blobSink.progress = progress;
 
@@ -1157,7 +1157,7 @@ window.filesender.client = {
                     };
                     var onFileClose = function( blobSink, fileid )
                     {
-                        var progress = page.find("[data-id='" + fileid + "']").find('.downloadprogress');
+                        var progress = page.find(".file[data-id='" + fileid + "']").find('.downloadprogress');
                         progress.html(window.filesender.config.language.download_complete);
 
                     };
@@ -1172,8 +1172,8 @@ window.filesender.client = {
                     var i = 0;
                     for(; i < ids.length; i++ ) {
 
-                        var dataid  = "[data-id='" + ids[i] + "']";
-                        var dataid0 = "[data-id='" + ids[0] + "']";
+                        var dataid  = ".file[data-id='" + ids[i] + "']";
+                        var dataid0 = ".file[data-id='" + ids[0] + "']";
                         
                         var el                 = page.find(dataid);
                         var fileaead           = el.attr('data-fileaead');
@@ -1221,7 +1221,7 @@ window.filesender.client = {
                 else
                 {
                     // single file download
-                    var dataid = "[data-id='" + ids[0] + "']";
+                    var dataid = ".file[data-id='" + ids[0] + "']";
                     var el = page.find(dataid);
                     var transferid               = $('.transfer').attr('data-id');
                     var chunk_size               = el.attr('data-chunk-size');


### PR DESCRIPTION
## Summary

Fix file selection in the download code used by transfer and guest-invitation detail pages.

When a transfer ID and a file ID have the same numeric value, the generic `[data-id]` selector may select the transfer container instead of the file row. This causes encrypted downloads to fail before any request is made to `download.php`.

Fixes #2598

## Root cause

The transfer detail page can contain both:

```html
<div class="fs-transfer-detail" data-id="8">
```

and:

```html
<tr class="file" data-id="8" data-fileaead="...">
```

The download code used selectors such as:

```javascript
"[data-id='" + fileId + "']"
```

When both IDs are equal, the selected element may not contain the file encryption attributes. Reading `data-fileaead` then returns `undefined`, causing the download flow to stop with:

```text
Cannot read properties of undefined (reading 'length')
```

## Change

Scope the download-related selectors to file rows:

```diff
- "[data-id='" + fileId + "']"
+ ".file[data-id='" + fileId + "']"
```

This ensures that the encryption metadata is read from the intended file element.

## Validation

The correction has been validated with mandatory browser-side encryption enabled.

Tested successfully:

- individual encrypted download from transfer details;
- archive download from transfer details;
- download of a file submitted through a guest invitation;
- download using the public transfer link;
- transfer and file sharing the same numeric ID.

## Disclosure

The initial diagnosis and this pull request description were drafted with assistance from ChatGPT.

The proposed selector change has been deployed and validated in our production FileSender 3.11 instance.
