### PR TITLE
set email from auth provided email if available.

### DIFF
--- a/www/download.php
+++ b/www/download.php
@@ -84,7 +84,11 @@ try {
         if( Config::get('log_authenticated_user_download_by_ensure_user_as_recipient')) {
             if( Auth::isRegularUser()) {
                 $user = Auth::user();
-                $email = $user->saml_user_identification_uid;
+                $email = $user->email;
+                if( !$email ) {
+                    $email = $user->saml_user_identification_uid;
+                }
+                
                 $found = false;
                 foreach($transfer->recipients as $r) {
                     if( $r->email == $email ) {


### PR DESCRIPTION
Use the email address provided for the user form the auth system if available.

This was raised here https://github.com/filesender/filesender/issues/2806