### PR TITLE
Expose SAML IdP for per-IdP configuration profiles

### DIFF
--- a/classes/auth/AuthSPSaml.class.php
+++ b/classes/auth/AuthSPSaml.class.php
@@ -98,6 +98,8 @@ class AuthSPSaml
             
             $attributes = array();
 
+            // Expose the authenticating IdP as a standard authentication attribute.
+            $attributes['idp'] = $ssp->getAuthData('saml:sp:IdP');
             
             // Wanted attributes
             foreach (array('uid', 'name', 'email') as $attr) {

--- a/unittests/config_tests_filesender.xml
+++ b/unittests/config_tests_filesender.xml
@@ -44,6 +44,7 @@
         <testsuite name="core" >
             <file>tests/dbs/DBsTest.php</file>              <!-- Success -->
             <file>tests/utilities/UtilitiesTest.php</file>  <!-- Success -->
+            <file>tests/auth/AuthSPSamlTest.php</file>
 <!--         <file>tests/auditlog/AuditlogTest.php</file>  -->  <!-- Failed -->
 <!--            <file>tests/dbobject/DBObjectTest.php</file>    <! - Failed -->
             <file>tests/file/FileTest.php</file>            <!-- Failed -->

--- a/unittests/tests/auth/AuthSPSamlTest.php
+++ b/unittests/tests/auth/AuthSPSamlTest.php
@@ -1,0 +1,160 @@
+<?php
+
+require_once dirname(__DIR__, 3).'/vendor/autoload.php';
+
+if (!defined('FILESENDER_BASE')) {
+    define('FILESENDER_BASE', dirname(__DIR__, 3));
+}
+
+require_once FILESENDER_BASE.'/classes/autoload.php';
+
+use PHPUnit\Framework\TestCase;
+
+class AuthSPSamlTest extends TestCase
+{
+    private $authAttributes;
+    private $authUser;
+    private $configParameters;
+
+    protected function setUp(): void
+    {
+        $this->authAttributes = $this->getStaticProperty('Auth', 'attributes');
+        $this->authUser = $this->getStaticProperty('Auth', 'user');
+        $this->configParameters = $this->getStaticProperty('Config', 'parameters');
+
+        $this->setStaticProperty('config', array(
+            'uid_attribute' => 'uid',
+            'name_attribute' => 'cn',
+            'email_attribute' => 'mail',
+            'simplesamlphp_location' => '',
+            'simplesamlphp_url' => '',
+            'authentication_source' => 'test',
+        ));
+        $this->setStaticProperty('simplesamlphp_auth_simple', new AuthSPSamlTestSimple());
+        $this->setStaticProperty('isAuthenticated', true);
+        $this->setStaticProperty('attributes', null);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setStaticProperty('config', null);
+        $this->setStaticProperty('simplesamlphp_auth_simple', null);
+        $this->setStaticProperty('isAuthenticated', null);
+        $this->setStaticProperty('attributes', null);
+        $this->setStaticPropertyValue('Auth', 'attributes', $this->authAttributes);
+        $this->setStaticPropertyValue('Auth', 'user', $this->authUser);
+        $this->setConfigParameters($this->configParameters);
+    }
+
+    public function testAttributesExposeSamlIdentityProvider(): void
+    {
+        $this->setConfigParameters(array(
+            'auth_sp_additional_attributes' => array(),
+            'auth_warn_session_expired' => false,
+        ));
+
+        $attributes = AuthSPSaml::attributes();
+
+        $this->assertSame('https://idp.example.invalid/entity', $attributes['idp']);
+    }
+
+    public function testIdentityProviderSelectsConfigurationProfile(): void
+    {
+        $this->assertProfileIsSelectedForIdentityProvider(
+            'https://idp.example.invalid/entity',
+            'SAML IdP test'
+        );
+    }
+
+    public function testDifferentIdentityProviderRetainsDefaultConfiguration(): void
+    {
+        $this->assertProfileIsSelectedForIdentityProvider(
+            'https://other-idp.example.invalid/entity',
+            'Default site'
+        );
+    }
+
+    public function testMissingIdentityProviderRetainsDefaultConfiguration(): void
+    {
+        $this->assertProfileIsSelectedForIdentityProvider(null, 'Default site');
+    }
+
+    private function assertProfileIsSelectedForIdentityProvider($idp, $expectedSiteName): void
+    {
+        $profile = FILESENDER_BASE.'/config/config-saml-idp-test.php';
+
+        try {
+            file_put_contents(
+                $profile,
+                "<?php\n\$config['site_name'] = 'SAML IdP test';\n"
+            );
+
+            $authAttributes = new ReflectionProperty('Auth', 'attributes');
+            $authUser = new ReflectionProperty('Auth', 'user');
+
+            $authAttributes->setValue(null, array('idp' => $idp));
+            $authUser->setValue(null, true);
+
+            $this->setConfigParameters(array(
+                'auth_config_regex_files' => array(
+                    'idp' => array(
+                        '^https://idp\\.example\\.invalid/entity$' => 'saml-idp-test'
+                    ),
+                ),
+                'site_name' => 'Default site',
+            ));
+
+            $method = new ReflectionMethod('Config', 'handleConfigRegexFiles');
+            $method->invoke(null, 'auth_config_regex_files', false);
+
+            $this->assertSame($expectedSiteName, Config::get('site_name'));
+        } finally {
+            if (file_exists($profile)) {
+                unlink($profile);
+            }
+        }
+    }
+
+    private function setStaticProperty($name, $value): void
+    {
+        $this->setStaticPropertyValue('AuthSPSaml', $name, $value);
+    }
+
+    private function setConfigParameters($parameters): void
+    {
+        $this->setStaticPropertyValue('Config', 'parameters', $parameters);
+    }
+
+    private function getStaticProperty($class, $name)
+    {
+        $property = new ReflectionProperty($class, $name);
+        return $property->getValue();
+    }
+
+    private function setStaticPropertyValue($class, $name, $value): void
+    {
+        $property = new ReflectionProperty($class, $name);
+        $property->setValue(null, $value);
+    }
+}
+
+class AuthSPSamlTestSimple
+{
+    public function getAttributes()
+    {
+        return array(
+            'uid' => array('test-user'),
+            'cn' => array('Test User'),
+            'mail' => array('test@example.invalid'),
+        );
+    }
+
+    public function getAuthData($name)
+    {
+        if ($name == 'saml:sp:IdP') {
+            return 'https://idp.example.invalid/entity';
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
### Summary

Expose the identity provider that authenticated a SAML user as the standard `idp` authentication attribute.

FileSender already supports selecting configuration overrides through `auth_config_regex_files`, including selection based on the `idp` attribute. The SimpleSAMLphp authentication adapter currently does not expose the authenticating IdP through this attribute.

This change retrieves the IdP entity ID from SimpleSAMLphp's `saml:sp:IdP` authentication data and exposes it as `attributes['idp']`.

This allows existing configuration such as:

```php
$config['auth_config_regex_files'] = [
    'idp' => [
        '^https://idp.example.org/entity$' => 'example-profile',
    ],
];
```

to work for SAML-authenticated users as well.

No deployment-specific behaviour is introduced: the mapping from IdP identifiers to configuration profiles remains entirely in the operator's local FileSender configuration.

### Tests

Added unit tests covering:

* exposure of the SimpleSAMLphp IdP entity ID as the `idp` attribute;
* selection of a matching configuration profile through `auth_config_regex_files`;
* retention of the default configuration for a different or missing IdP.

Standalone test result:

`OK (4 tests, 4 assertions)`
