### PR TITLE
slight update to the test suite for the idp expose

### DIFF
--- a/ci/config/config-saml-idp-test.php
+++ b/ci/config/config-saml-idp-test.php
@@ -1,0 +1,4 @@
+<?php
+
+$config['site_name'] = 'SAML IdP test';
+

--- a/classes/utils/Config.class.php
+++ b/classes/utils/Config.class.php
@@ -92,7 +92,6 @@ class Config
         if( !isset($matchValue)) {
             return;
         }
-
         if (preg_match('`'.$regex.'`', $matchValue)) {
             $extra_config_file = FILESENDER_BASE.'/config/config-' . $extra_config_name . '.php';
             if (file_exists($extra_config_file)) {
@@ -100,6 +99,19 @@ class Config
                 include_once($extra_config_file);
                 self::merge(self::$parameters, $config);
             }
+        }
+        // try subdir for testsuites
+        if (Utilities::isTrue(Config::get("testsuite_run_locally"))) {
+
+            if (preg_match('`'.$regex.'`', $matchValue)) {
+                $extra_config_file = FILESENDER_BASE.'/ci/config/config-' . $extra_config_name . '.php';
+                if (file_exists($extra_config_file)) {
+                    $config = array();
+                    include_once($extra_config_file);
+                    self::merge(self::$parameters, $config);
+                }
+            }
+            
         }
     }
     

--- a/unittests/tests/auth/AuthSPSamlTest.php
+++ b/unittests/tests/auth/AuthSPSamlTest.php
@@ -1,16 +1,8 @@
 <?php
 
-require_once dirname(__DIR__, 3).'/vendor/autoload.php';
+require_once dirname(__FILE__) . '/../common/CommonUnitTestCase.php';
 
-if (!defined('FILESENDER_BASE')) {
-    define('FILESENDER_BASE', dirname(__DIR__, 3));
-}
-
-require_once FILESENDER_BASE.'/classes/autoload.php';
-
-use PHPUnit\Framework\TestCase;
-
-class AuthSPSamlTest extends TestCase
+class AuthSPSamlTest extends CommonUnitTestCase
 {
     private $authAttributes;
     private $authUser;
@@ -29,6 +21,7 @@ class AuthSPSamlTest extends TestCase
             'simplesamlphp_location' => '',
             'simplesamlphp_url' => '',
             'authentication_source' => 'test',
+            'testsuite_run_locally' => true,
         ));
         $this->setStaticProperty('simplesamlphp_auth_simple', new AuthSPSamlTestSimple());
         $this->setStaticProperty('isAuthenticated', true);
@@ -81,14 +74,7 @@ class AuthSPSamlTest extends TestCase
 
     private function assertProfileIsSelectedForIdentityProvider($idp, $expectedSiteName): void
     {
-        $profile = FILESENDER_BASE.'/config/config-saml-idp-test.php';
-
         try {
-            file_put_contents(
-                $profile,
-                "<?php\n\$config['site_name'] = 'SAML IdP test';\n"
-            );
-
             $authAttributes = new ReflectionProperty('Auth', 'attributes');
             $authUser = new ReflectionProperty('Auth', 'user');
 
@@ -102,6 +88,7 @@ class AuthSPSamlTest extends TestCase
                     ),
                 ),
                 'site_name' => 'Default site',
+                'testsuite_run_locally' => true,
             ));
 
             $method = new ReflectionMethod('Config', 'handleConfigRegexFiles');
@@ -109,33 +96,9 @@ class AuthSPSamlTest extends TestCase
 
             $this->assertSame($expectedSiteName, Config::get('site_name'));
         } finally {
-            if (file_exists($profile)) {
-                unlink($profile);
-            }
         }
     }
 
-    private function setStaticProperty($name, $value): void
-    {
-        $this->setStaticPropertyValue('AuthSPSaml', $name, $value);
-    }
-
-    private function setConfigParameters($parameters): void
-    {
-        $this->setStaticPropertyValue('Config', 'parameters', $parameters);
-    }
-
-    private function getStaticProperty($class, $name)
-    {
-        $property = new ReflectionProperty($class, $name);
-        return $property->getValue();
-    }
-
-    private function setStaticPropertyValue($class, $name, $value): void
-    {
-        $property = new ReflectionProperty($class, $name);
-        $property->setValue(null, $value);
-    }
 }
 
 class AuthSPSamlTestSimple

--- a/unittests/tests/common/CommonUnitTestCase.php
+++ b/unittests/tests/common/CommonUnitTestCase.php
@@ -70,6 +70,28 @@ abstract class CommonUnitTestCase extends TestCase {
       }
       print_r("\n---------------------------------------------------------------------------------------\n");
    }
-  
+
+    protected function setStaticProperty($name, $value): void
+    {
+        $this->setStaticPropertyValue('AuthSPSaml', $name, $value);
+    }
+
+    protected function setConfigParameters($parameters): void
+    {
+        $this->setStaticPropertyValue('Config', 'parameters', $parameters);
+    }
+
+    protected function getStaticProperty($class, $name)
+    {
+        $property = new ReflectionProperty($class, $name);
+        return $property->getValue();
+    }
+
+    protected function setStaticPropertyValue($class, $name, $value): void
+    {
+        $property = new ReflectionProperty($class, $name);
+        $property->setValue(null, $value);
+    }
+    
 }
     


### PR DESCRIPTION
This was offered and merged in
https://github.com/filesender/filesender/pull/2812

It seemed simple to just go ahead and make these touchups rather than comment on the PR. 

Changes

* Header block trimmed and CommonUnitTestCase is super
* Support for finding config-saml-idp-test.php from ci/configs if run in test env setting
* Moved setStaticProperty et al into super.